### PR TITLE
Add WhisperX local transcription + Remotion Studio preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,7 @@
+# Transcription backend (auto-detected):
+#   - Set ELEVENLABS_API_KEY to use ElevenLabs Scribe (cloud, fast, includes audio events)
+#   - Leave empty to use WhisperX (local, no API key needed, requires: pip install -e ".[whisperx]")
 ELEVENLABS_API_KEY=
+
+# Optional: enables speaker diarization in WhisperX via pyannote
+# HF_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ node_modules/
 package-lock.json
 yarn.lock
 .npm/
+remotion/public/*.mp4
+remotion/public/*.mov
+remotion/public/*.mkv
+remotion/public/*.avi
 
 # Manim render artifacts (when running skills/manim-video scripts locally)
 media/

--- a/README.md
+++ b/README.md
@@ -31,10 +31,18 @@ pip install -e .
 brew install ffmpeg           # required
 brew install yt-dlp            # optional, for downloading online sources
 
-# 3. Add your ElevenLabs API key
+# 3. Transcription backend (pick one)
+#    Option A — ElevenLabs Scribe (cloud, fast, includes audio event tags):
 cp .env.example .env
 $EDITOR .env                   # ELEVENLABS_API_KEY=...
+#    Option B — WhisperX (local, no API key needed):
+pip install -e ".[whisperx]"
+
+# 4. (Optional) Remotion Studio for instant preview — no render wait
+cd remotion && npm install && cd ..
 ```
+
+> **Backend auto-detection:** if `ELEVENLABS_API_KEY` is set, ElevenLabs is used. Otherwise WhisperX runs locally. Override with `--backend whisperx` or `--backend elevenlabs`.
 
 Then point Claude Code at a folder of raw takes:
 
@@ -57,7 +65,7 @@ The LLM never watches the video. It **reads** it — through two layers that tog
   <img src="static/timeline-view.svg" alt="timeline_view composite — filmstrip + speaker track + waveform + word labels + silence-gap cut candidates" width="100%">
 </p>
 
-**Layer 1 — Audio transcript (always loaded).** One ElevenLabs Scribe call per source gives word-level timestamps, speaker diarization, and audio events (`(laughter)`, `(applause)`, `(sigh)`). All takes pack into a single ~12KB `takes_packed.md` — the LLM's primary reading view.
+**Layer 1 — Audio transcript (always loaded).** One transcription pass per source (ElevenLabs Scribe cloud or WhisperX local) gives word-level timestamps, speaker diarization, and optionally audio events. All takes pack into a single ~12KB `takes_packed.md` — the LLM's primary reading view.
 
 ```
 ## C0103  (duration: 43.0s, 8 phrases)
@@ -75,12 +83,26 @@ Same idea as browser-use giving an LLM a structured DOM instead of a screenshot 
 ## Pipeline
 
 ```
-Transcribe ──> Pack ──> LLM Reasons ──> EDL ──> Render ──> Self-Eval
-                                                              │
-                                                              └─ issue? fix + re-render (max 3)
+Transcribe ──> Pack ──> LLM Reasons ──> EDL ──┬──> Remotion Studio (instant preview)
+                                               │
+                                               └──> Render ──> Self-Eval
+                                                                  │
+                                                                  └─ issue? fix + re-render (max 3)
 ```
 
 The self-eval loop runs `timeline_view` on the _rendered output_ at every cut boundary — catches visual jumps, audio pops, hidden subtitles. You see the preview only after it passes.
+
+## Remotion Studio preview
+
+Skip the render wait — preview your edit instantly in the browser:
+
+```bash
+cd remotion
+npm run setup       # copies source videos into public/
+npm run studio      # opens http://localhost:3000
+```
+
+Remotion Studio reads `edit/edl.json` and sequences the clips with live subtitles. Scrub anywhere, adjust timing in the EDL, and the studio hot-reloads. Only do the full ffmpeg render once you're happy with the cut.
 
 ## Design principles
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -57,7 +57,9 @@ The skill lives in `video-use/`. User footage lives wherever they put it. All se
 
 ## Setup
 
-- `ELEVENLABS_API_KEY` in `.env` at project root or env. Ask and write `.env` if missing.
+- Transcription backend (auto-detected):
+  - **ElevenLabs Scribe** (cloud): set `ELEVENLABS_API_KEY` in `.env`. Fast, includes audio event tags.
+  - **WhisperX** (local): `pip install -e ".[whisperx]"`. No API key needed. Optional `HF_TOKEN` for speaker diarization.
 - `ffmpeg` + `ffprobe` on PATH.
 - Python deps: `pip install -e .`.
 - `yt-dlp`, `manim`, Remotion installed only on first use.
@@ -65,12 +67,14 @@ The skill lives in `video-use/`. User footage lives wherever they put it. All se
 
 ## Helpers
 
-- **`transcribe.py <video>`** — single-file Scribe call. `--num-speakers N` optional. Cached.
-- **`transcribe_batch.py <videos_dir>`** — 4-worker parallel transcription. Use for multi-take.
+- **`transcribe.py <video>`** — transcription (auto-selects backend). `--backend whisperx|elevenlabs`, `--model base|small|large-v3` (WhisperX), `--num-speakers N`. Cached.
+- **`transcribe_batch.py <videos_dir>`** — batch transcription. ElevenLabs: 4-worker parallel. WhisperX: sequential (model loaded once).
 - **`pack_transcripts.py --edit-dir <dir>`** — `transcripts/*.json` → `takes_packed.md` (phrase-level, break on silence ≥ 0.5s).
 - **`timeline_view.py <video> <start> <end>`** — filmstrip + waveform PNG. On-demand visual drill-down. **Not a scan tool** — use it at decision points, not constantly.
 - **`render.py <edl.json> -o <out>`** — per-segment extract → concat → overlays (PTS-shifted) → subtitles LAST. `--preview` for 720p fast. `--build-subtitles` to generate master.srt inline.
 - **`grade.py <in> -o <out>`** — ffmpeg filter chain grade. Presets + `--filter '<raw>'` for custom.
+
+- **`remotion/`** — Remotion Studio preview. After producing `edl.json`, run `cd remotion && npm run setup && npm run studio` for instant browser-based preview with timeline scrubbing. No render wait.
 
 For animations, create `<edit>/animations/slot_<id>/` with `Bash` and spawn a sub-agent via the `Agent` tool.
 

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -1,9 +1,9 @@
-"""Pack all Scribe transcripts in <edit>/transcripts/ into one readable markdown.
+"""Pack all transcripts in <edit>/transcripts/ into one readable markdown.
 
 Groups word-level entries into phrase-level lines, breaking on any silence
 >= 0.5s OR speaker change. Each phrase gets a [start-end] prefix. This is
 the PRIMARY artifact the editor sub-agent reads to pick cuts — it fits one
-hour of takes in a tenth the tokens of raw Scribe JSON and gives
+hour of takes in a tenth the tokens of raw transcript JSON and gives
 word-boundary precision from text alone.
 
 Output: <edit>/takes_packed.md

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -1,16 +1,23 @@
-"""Transcribe a video with ElevenLabs Scribe.
+"""Transcribe a video — WhisperX (local, default) or ElevenLabs Scribe (cloud).
 
-Extracts mono 16kHz audio via ffmpeg, uploads to Scribe with verbatim +
-diarize + audio events + word-level timestamps, writes the full response
-to <edit_dir>/transcripts/<video_stem>.json.
+Backend selection:
+  - If ELEVENLABS_API_KEY is set → uses ElevenLabs Scribe (cloud, fast, diarization + audio events).
+  - Otherwise → uses WhisperX (local, no API key needed).
 
-Cached: if the output file already exists, the upload is skipped.
+Both backends produce the same JSON format (top-level ``words`` list with
+``word``, ``spacing``, and optionally ``audio_event`` entries), so
+``pack_transcripts.py`` works unchanged regardless of backend.
+
+Cached: if the output file already exists, transcription is skipped.
 
 Usage:
     python helpers/transcribe.py <video_path>
     python helpers/transcribe.py <video_path> --edit-dir /custom/edit
     python helpers/transcribe.py <video_path> --language en
     python helpers/transcribe.py <video_path> --num-speakers 2
+    python helpers/transcribe.py <video_path> --backend whisperx
+    python helpers/transcribe.py <video_path> --backend elevenlabs
+    python helpers/transcribe.py <video_path> --model base  # WhisperX model size
 """
 
 from __future__ import annotations
@@ -24,13 +31,13 @@ import tempfile
 import time
 from pathlib import Path
 
-import requests
 
+# ---------------------------------------------------------------------------
+# Shared
+# ---------------------------------------------------------------------------
 
-SCRIBE_URL = "https://api.elevenlabs.io/v1/speech-to-text"
-
-
-def load_api_key() -> str:
+def _load_env_var(name: str) -> str:
+    """Try .env files then the environment. Returns empty string if missing."""
     for candidate in [Path(__file__).resolve().parent.parent / ".env", Path(".env")]:
         if candidate.exists():
             for line in candidate.read_text().splitlines():
@@ -38,12 +45,16 @@ def load_api_key() -> str:
                 if not line or line.startswith("#") or "=" not in line:
                     continue
                 k, v = line.split("=", 1)
-                if k.strip() == "ELEVENLABS_API_KEY":
+                if k.strip() == name:
                     return v.strip().strip('"').strip("'")
-    v = os.environ.get("ELEVENLABS_API_KEY", "")
-    if not v:
-        sys.exit("ELEVENLABS_API_KEY not found in .env or environment")
-    return v
+    return os.environ.get(name, "")
+
+
+def detect_backend() -> str:
+    """Return 'elevenlabs' if an API key is available, else 'whisperx'."""
+    if _load_env_var("ELEVENLABS_API_KEY"):
+        return "elevenlabs"
+    return "whisperx"
 
 
 def extract_audio(video_path: Path, dest: Path) -> None:
@@ -55,12 +66,21 @@ def extract_audio(video_path: Path, dest: Path) -> None:
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
-def call_scribe(
+# ---------------------------------------------------------------------------
+# ElevenLabs Scribe backend
+# ---------------------------------------------------------------------------
+
+SCRIBE_URL = "https://api.elevenlabs.io/v1/speech-to-text"
+
+
+def _call_scribe(
     audio_path: Path,
     api_key: str,
     language: str | None = None,
     num_speakers: int | None = None,
 ) -> dict:
+    import requests
+
     data: dict[str, str] = {
         "model_id": "scribe_v1",
         "diarize": "true",
@@ -87,10 +107,138 @@ def call_scribe(
     return resp.json()
 
 
+# ---------------------------------------------------------------------------
+# WhisperX backend
+# ---------------------------------------------------------------------------
+
+def _get_device() -> tuple[str, str]:
+    """Return (device, compute_type) for WhisperX."""
+    import torch
+
+    if torch.cuda.is_available():
+        return "cuda", "float16"
+    return "cpu", "int8"
+
+
+def _default_whisperx_model(device: str) -> str:
+    """Pick model size: large-v3 on GPU, small on CPU."""
+    return "large-v3" if device == "cuda" else "small"
+
+
+def load_whisperx_model(
+    model_name: str | None = None,
+    device: str | None = None,
+    compute_type: str | None = None,
+):
+    """Load the WhisperX model. Reuse across files in batch mode."""
+    import whisperx
+
+    if device is None or compute_type is None:
+        device, compute_type = _get_device()
+    if model_name is None:
+        model_name = _default_whisperx_model(device)
+    return whisperx.load_model(model_name, device, compute_type=compute_type)
+
+
+def _convert_whisperx_to_scribe_format(result: dict) -> dict:
+    """Convert WhisperX output to the same JSON format as ElevenLabs Scribe.
+
+    The format has a top-level ``words`` list with entries of type ``word``
+    (with ``text``, ``start``, ``end``, ``speaker_id``) and ``spacing``
+    (gap between words).  ``pack_transcripts.py`` reads this format.
+    """
+    words: list[dict] = []
+    raw_words = result.get("word_segments", [])
+
+    prev_end: float | None = None
+    for w in raw_words:
+        start = w.get("start")
+        end = w.get("end")
+        text = w.get("word", "").strip()
+        if start is None or end is None or not text:
+            continue
+
+        if prev_end is not None and start > prev_end:
+            words.append({"type": "spacing", "start": prev_end, "end": start})
+
+        speaker = w.get("speaker")
+        speaker_id = None
+        if speaker and speaker.startswith("SPEAKER_"):
+            speaker_id = f"speaker_{int(speaker[len('SPEAKER_'):])}"
+
+        entry: dict = {
+            "type": "word",
+            "text": text,
+            "start": round(start, 3),
+            "end": round(end, 3),
+        }
+        if speaker_id is not None:
+            entry["speaker_id"] = speaker_id
+        words.append(entry)
+        prev_end = end
+
+    return {"words": words}
+
+
+def _run_whisperx(
+    audio_path: Path,
+    model=None,
+    language: str | None = None,
+    num_speakers: int | None = None,
+) -> dict:
+    """Run WhisperX transcription + alignment + optional diarization."""
+    import whisperx
+
+    device, compute_type = _get_device()
+
+    if model is None:
+        model = load_whisperx_model(device=device, compute_type=compute_type)
+
+    audio = whisperx.load_audio(str(audio_path))
+
+    # 1. Transcribe
+    transcribe_kwargs: dict = {"batch_size": 16}
+    if language:
+        transcribe_kwargs["language"] = language
+    result = model.transcribe(audio, **transcribe_kwargs)
+
+    detected_lang = result.get("language", language or "en")
+
+    # 2. Align for word-level timestamps
+    align_model, metadata = whisperx.load_align_model(
+        language_code=detected_lang, device=device,
+    )
+    result = whisperx.align(
+        result["segments"], align_model, metadata, audio, device,
+        return_char_alignments=False,
+    )
+
+    # 3. Diarize (optional — needs HF_TOKEN for pyannote)
+    hf_token = os.environ.get("HF_TOKEN", "")
+    if hf_token:
+        diarize_model = whisperx.DiarizationPipeline(
+            use_auth_token=hf_token, device=device,
+        )
+        diarize_kwargs: dict = {}
+        if num_speakers:
+            diarize_kwargs["num_speakers"] = num_speakers
+        diarize_segments = diarize_model(str(audio_path), **diarize_kwargs)
+        result = whisperx.assign_word_speakers(diarize_segments, result)
+
+    return _convert_whisperx_to_scribe_format(result)
+
+
+# ---------------------------------------------------------------------------
+# Unified interface
+# ---------------------------------------------------------------------------
+
 def transcribe_one(
     video: Path,
     edit_dir: Path,
-    api_key: str,
+    *,
+    backend: str | None = None,
+    api_key: str | None = None,
+    whisperx_model=None,
     language: str | None = None,
     num_speakers: int | None = None,
     verbose: bool = True,
@@ -108,8 +256,11 @@ def transcribe_one(
             print(f"cached: {out_path.name}")
         return out_path
 
+    if backend is None:
+        backend = detect_backend()
+
     if verbose:
-        print(f"  extracting audio from {video.name}", flush=True)
+        print(f"  extracting audio from {video.name} (backend: {backend})", flush=True)
 
     t0 = time.time()
     with tempfile.TemporaryDirectory() as tmp:
@@ -117,8 +268,17 @@ def transcribe_one(
         extract_audio(video, audio)
         size_mb = audio.stat().st_size / (1024 * 1024)
         if verbose:
-            print(f"  uploading {video.stem}.wav ({size_mb:.1f} MB)", flush=True)
-        payload = call_scribe(audio, api_key, language, num_speakers)
+            action = "uploading" if backend == "elevenlabs" else "transcribing"
+            print(f"  {action} {video.stem}.wav ({size_mb:.1f} MB)", flush=True)
+
+        if backend == "elevenlabs":
+            if not api_key:
+                api_key = _load_env_var("ELEVENLABS_API_KEY")
+            if not api_key:
+                sys.exit("ELEVENLABS_API_KEY not found in .env or environment")
+            payload = _call_scribe(audio, api_key, language, num_speakers)
+        else:
+            payload = _run_whisperx(audio, whisperx_model, language, num_speakers)
 
     out_path.write_text(json.dumps(payload, indent=2))
     dt = time.time() - t0
@@ -133,25 +293,29 @@ def transcribe_one(
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Transcribe a video with ElevenLabs Scribe")
+    ap = argparse.ArgumentParser(
+        description="Transcribe a video (WhisperX local or ElevenLabs Scribe cloud)",
+    )
     ap.add_argument("video", type=Path, help="Path to video file")
     ap.add_argument(
-        "--edit-dir",
-        type=Path,
-        default=None,
+        "--edit-dir", type=Path, default=None,
         help="Edit output directory (default: <video_parent>/edit)",
     )
     ap.add_argument(
-        "--language",
-        type=str,
-        default=None,
+        "--language", type=str, default=None,
         help="Optional ISO language code (e.g., 'en'). Omit to auto-detect.",
     )
     ap.add_argument(
-        "--num-speakers",
-        type=int,
-        default=None,
+        "--num-speakers", type=int, default=None,
         help="Optional number of speakers when known. Improves diarization accuracy.",
+    )
+    ap.add_argument(
+        "--backend", type=str, default=None, choices=["whisperx", "elevenlabs"],
+        help="Transcription backend (default: elevenlabs if API key set, else whisperx).",
+    )
+    ap.add_argument(
+        "--model", type=str, default=None,
+        help="WhisperX model name (default: large-v3 on GPU, small on CPU). Ignored for elevenlabs.",
     )
     args = ap.parse_args()
 
@@ -160,12 +324,17 @@ def main() -> None:
         sys.exit(f"video not found: {video}")
 
     edit_dir = (args.edit_dir or (video.parent / "edit")).resolve()
-    api_key = load_api_key()
+    backend = args.backend or detect_backend()
+
+    whisperx_model = None
+    if backend == "whisperx" and args.model:
+        whisperx_model = load_whisperx_model(model_name=args.model)
 
     transcribe_one(
         video=video,
         edit_dir=edit_dir,
-        api_key=api_key,
+        backend=backend,
+        whisperx_model=whisperx_model,
         language=args.language,
         num_speakers=args.num_speakers,
     )

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -1,13 +1,16 @@
-"""Batch-transcribe every video in a directory with 4 parallel workers.
+"""Batch-transcribe every video in a directory.
 
-Walks <videos_dir> for common video extensions, runs ElevenLabs Scribe on
-each, writes transcripts to <videos_dir>/edit/transcripts/<name>.json.
+Supports both WhisperX (local) and ElevenLabs Scribe (cloud) backends.
+  - ElevenLabs: 4-worker parallel API calls (default if ELEVENLABS_API_KEY set).
+  - WhisperX: model loaded once, files processed sequentially (GPU memory shared).
 
 Cached per-file: any source that already has a transcript is skipped.
 
 Usage:
     python helpers/transcribe_batch.py <videos_dir>
-    python helpers/transcribe_batch.py <videos_dir> --workers 4
+    python helpers/transcribe_batch.py <videos_dir> --backend whisperx
+    python helpers/transcribe_batch.py <videos_dir> --backend whisperx --model base
+    python helpers/transcribe_batch.py <videos_dir> --backend elevenlabs --workers 4
     python helpers/transcribe_batch.py <videos_dir> --num-speakers 2
     python helpers/transcribe_batch.py <videos_dir> --edit-dir /custom/edit
 """
@@ -20,7 +23,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from transcribe import load_api_key, transcribe_one
+from transcribe import detect_backend, load_whisperx_model, transcribe_one, _load_env_var
 
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
@@ -35,26 +38,31 @@ def find_videos(videos_dir: Path) -> list[Path]:
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Parallel batch transcription of a videos directory")
+    ap = argparse.ArgumentParser(description="Batch transcription of a videos directory")
     ap.add_argument("videos_dir", type=Path, help="Directory containing source videos")
     ap.add_argument(
-        "--edit-dir",
-        type=Path,
-        default=None,
+        "--edit-dir", type=Path, default=None,
         help="Edit output directory (default: <videos_dir>/edit)",
     )
-    ap.add_argument("--workers", type=int, default=4, help="Parallel workers (default: 4)")
     ap.add_argument(
-        "--language",
-        type=str,
-        default=None,
+        "--workers", type=int, default=4,
+        help="Parallel workers for ElevenLabs backend (default: 4). Ignored for whisperx.",
+    )
+    ap.add_argument(
+        "--language", type=str, default=None,
         help="Optional ISO language code. Omit to auto-detect per file.",
     )
     ap.add_argument(
-        "--num-speakers",
-        type=int,
-        default=None,
+        "--num-speakers", type=int, default=None,
         help="Optional number of speakers. Improves diarization when known.",
+    )
+    ap.add_argument(
+        "--backend", type=str, default=None, choices=["whisperx", "elevenlabs"],
+        help="Transcription backend (default: elevenlabs if API key set, else whisperx).",
+    )
+    ap.add_argument(
+        "--model", type=str, default=None,
+        help="WhisperX model name (default: large-v3 on GPU, small on CPU).",
     )
     args = ap.parse_args()
 
@@ -72,34 +80,59 @@ def main() -> None:
     already_cached = [v for v in videos if (edit_dir / "transcripts" / f"{v.stem}.json").exists()]
     pending = [v for v in videos if v not in already_cached]
 
+    backend = args.backend or detect_backend()
     print(f"found {len(videos)} videos ({len(already_cached)} cached, {len(pending)} to transcribe)")
+    print(f"backend: {backend}")
     if not pending:
         print("nothing to do")
         return
 
-    api_key = load_api_key()
-
-    print(f"transcribing {len(pending)} files with {args.workers} parallel workers")
     t0 = time.time()
-
     errors: list[tuple[Path, str]] = []
-    with ThreadPoolExecutor(max_workers=args.workers) as pool:
-        futures = {
-            pool.submit(
-                transcribe_one,
-                video=v,
-                edit_dir=edit_dir,
-                api_key=api_key,
-                language=args.language,
-                num_speakers=args.num_speakers,
-                verbose=False,
-            ): v
-            for v in pending
-        }
-        for fut in as_completed(futures):
-            v = futures[fut]
+
+    if backend == "elevenlabs":
+        api_key = _load_env_var("ELEVENLABS_API_KEY")
+        if not api_key:
+            sys.exit("ELEVENLABS_API_KEY not found in .env or environment")
+
+        print(f"transcribing {len(pending)} files with {args.workers} parallel workers")
+        with ThreadPoolExecutor(max_workers=args.workers) as pool:
+            futures = {
+                pool.submit(
+                    transcribe_one,
+                    video=v,
+                    edit_dir=edit_dir,
+                    backend="elevenlabs",
+                    api_key=api_key,
+                    language=args.language,
+                    num_speakers=args.num_speakers,
+                    verbose=False,
+                ): v
+                for v in pending
+            }
+            for fut in as_completed(futures):
+                v = futures[fut]
+                try:
+                    out = fut.result()
+                    print(f"  + {v.stem}  →  {out.name}")
+                except Exception as e:
+                    errors.append((v, str(e)))
+                    print(f"  x {v.stem}  FAILED: {e}")
+    else:
+        print("loading WhisperX model…")
+        model = load_whisperx_model(model_name=args.model)
+
+        print(f"transcribing {len(pending)} files sequentially")
+        for v in pending:
             try:
-                out = fut.result()
+                out = transcribe_one(
+                    video=v,
+                    edit_dir=edit_dir,
+                    backend="whisperx",
+                    whisperx_model=model,
+                    language=args.language,
+                    num_speakers=args.num_speakers,
+                )
                 print(f"  + {v.stem}  →  {out.name}")
             except Exception as e:
                 errors.append((v, str(e)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+whisperx = ["whisperx"]
 animations = ["manim"]
 
 [build-system]

--- a/remotion/.gitignore
+++ b/remotion/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+public/*.mp4
+public/*.mov
+public/*.mkv
+public/*.avi

--- a/remotion/package.json
+++ b/remotion/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "video-use-preview",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Remotion Studio preview for video-use EDL compositions",
+  "scripts": {
+    "studio": "remotion studio src/index.ts",
+    "setup": "node setup-public.mjs"
+  },
+  "dependencies": {
+    "@remotion/cli": "4.0.293",
+    "@remotion/player": "4.0.293",
+    "react": "^19",
+    "react-dom": "^19",
+    "remotion": "4.0.293"
+  },
+  "devDependencies": {
+    "@types/react": "^19",
+    "typescript": "^5"
+  }
+}

--- a/remotion/setup-public.mjs
+++ b/remotion/setup-public.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Copy source videos listed in edl.json into remotion/public/ so
+ * Remotion Studio can serve them. Run with: npm run setup
+ *
+ * Reads ../edit/edl.json (the standard edit output directory).
+ */
+import { readFileSync, copyFileSync, existsSync, mkdirSync } from "fs";
+import { basename, resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const publicDir = resolve(__dirname, "public");
+const edlPath = resolve(__dirname, "..", "edit", "edl.json");
+
+if (!existsSync(edlPath)) {
+  // Try parent's edit dir (when video-use is a skill and edit/ is next to sources)
+  console.error(`No edl.json found at ${edlPath}`);
+  console.error("Run transcribe + pack + create edl.json first, then re-run this.");
+  process.exit(1);
+}
+
+mkdirSync(publicDir, { recursive: true });
+
+const edl = JSON.parse(readFileSync(edlPath, "utf-8"));
+const copied = new Set();
+
+for (const [name, absPath] of Object.entries(edl.sources)) {
+  const filename = basename(absPath);
+  if (copied.has(filename)) continue;
+
+  const dest = resolve(publicDir, filename);
+  if (existsSync(dest)) {
+    console.log(`  exists: ${filename}`);
+  } else if (existsSync(absPath)) {
+    copyFileSync(absPath, dest);
+    console.log(`  copied: ${filename}`);
+  } else {
+    console.warn(`  MISSING: ${absPath}`);
+  }
+  copied.add(filename);
+}
+
+console.log(`\n${copied.size} source(s) in public/. Run: npm run studio`);

--- a/remotion/src/EdlComposition.tsx
+++ b/remotion/src/EdlComposition.tsx
@@ -1,0 +1,86 @@
+import { AbsoluteFill, OffthreadVideo, Sequence, staticFile, useCurrentFrame } from "remotion";
+import { Subtitles } from "./Subtitles";
+
+const FPS = 24;
+
+interface EdlRange {
+  source: string;
+  start: number;
+  end: number;
+  beat?: string;
+  note?: string;
+}
+
+interface Edl {
+  version: number;
+  sources: Record<string, string>;
+  ranges: EdlRange[];
+  [key: string]: unknown;
+}
+
+function sourceToStaticFile(absPath: string): string {
+  const filename = absPath.split("/").pop() || absPath;
+  return staticFile(filename);
+}
+
+export const EdlComposition: React.FC<{ edl: Edl }> = ({ edl }) => {
+  const segments: Array<{
+    range: EdlRange;
+    startFrame: number;
+    durationFrames: number;
+    srcPath: string;
+  }> = [];
+
+  let frameOffset = 0;
+  for (const range of edl.ranges) {
+    const durationSec = range.end - range.start;
+    const durationFrames = Math.ceil(durationSec * FPS);
+    const srcPath = edl.sources[range.source];
+    segments.push({ range, startFrame: frameOffset, durationFrames, srcPath });
+    frameOffset += durationFrames;
+  }
+
+  return (
+    <AbsoluteFill style={{ backgroundColor: "black" }}>
+      {segments.map((seg, i) => (
+        <Sequence
+          key={i}
+          from={seg.startFrame}
+          durationInFrames={seg.durationFrames}
+          name={`${seg.range.beat || "seg"} — ${seg.range.source.slice(0, 30)}`}
+        >
+          <AbsoluteFill>
+            <OffthreadVideo
+              src={sourceToStaticFile(seg.srcPath)}
+              startFrom={Math.round(seg.range.start * FPS)}
+              style={{ width: "100%", height: "100%", objectFit: "contain" }}
+            />
+          </AbsoluteFill>
+        </Sequence>
+      ))}
+
+      <Subtitles edl={edl} fps={FPS} segments={segments} />
+
+      {/* Beat label (top-left) */}
+      {segments.map((seg, i) => (
+        <Sequence key={`label-${i}`} from={seg.startFrame} durationInFrames={seg.durationFrames}>
+          <div
+            style={{
+              position: "absolute",
+              top: 20,
+              left: 20,
+              padding: "4px 12px",
+              background: "rgba(0,0,0,0.6)",
+              color: seg.range.beat?.includes("MEME") ? "#ff5a00" : "#fff",
+              fontFamily: "monospace",
+              fontSize: 16,
+              borderRadius: 4,
+            }}
+          >
+            {seg.range.beat}
+          </div>
+        </Sequence>
+      ))}
+    </AbsoluteFill>
+  );
+};

--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -1,0 +1,33 @@
+import { Composition } from "remotion";
+import { EdlComposition } from "./EdlComposition";
+
+// Import the EDL from the standard edit output directory.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+let edl: any;
+try {
+  edl = require("../../edit/edl.json");
+} catch {
+  edl = { version: 1, sources: {}, ranges: [] };
+}
+
+const FPS = 24;
+
+const totalDurationSec = (edl.ranges || []).reduce(
+  (sum: number, r: any) => sum + ((r.end || 0) - (r.start || 0)),
+  0,
+);
+const totalFrames = Math.max(1, Math.ceil(totalDurationSec * FPS));
+
+export const Root: React.FC = () => {
+  return (
+    <Composition
+      id="Preview"
+      component={EdlComposition}
+      durationInFrames={totalFrames}
+      fps={FPS}
+      width={1920}
+      height={1080}
+      defaultProps={{ edl }}
+    />
+  );
+};

--- a/remotion/src/Subtitles.tsx
+++ b/remotion/src/Subtitles.tsx
@@ -1,0 +1,140 @@
+import { useCurrentFrame } from "remotion";
+import { useMemo } from "react";
+
+interface Word {
+  type: string;
+  text?: string;
+  start?: number;
+  end?: number;
+  speaker_id?: string;
+}
+
+interface Transcript {
+  words: Word[];
+}
+
+interface EdlRange {
+  source: string;
+  start: number;
+  end: number;
+  beat?: string;
+}
+
+interface Segment {
+  range: EdlRange;
+  startFrame: number;
+  durationFrames: number;
+  srcPath: string;
+}
+
+interface Edl {
+  sources: Record<string, string>;
+  ranges: EdlRange[];
+  [key: string]: unknown;
+}
+
+interface SubCue {
+  frameStart: number;
+  frameEnd: number;
+  text: string;
+}
+
+// Load transcripts at bundle time.  Remotion bundles these via require().
+// We try/catch each because not all sources will have transcripts (e.g. meme clips).
+const transcriptCache: Record<string, Transcript> = {};
+
+function tryLoadTranscript(name: string): void {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    transcriptCache[name] = require(`../../edit/transcripts/${name}.json`);
+  } catch {
+    // no transcript for this source
+  }
+}
+
+function getTranscript(name: string): Transcript | undefined {
+  if (!(name in transcriptCache)) {
+    tryLoadTranscript(name);
+  }
+  return transcriptCache[name];
+}
+
+function wordsInRange(transcript: Transcript, start: number, end: number): Word[] {
+  return transcript.words.filter(
+    (w) => w.type === "word" && w.start != null && w.end != null && w.end! > start && w.start! < end,
+  );
+}
+
+function buildCues(edl: Edl, segments: Segment[], fps: number): SubCue[] {
+  const cues: SubCue[] = [];
+
+  for (const seg of segments) {
+    const transcript = getTranscript(seg.range.source);
+    if (!transcript) continue;
+
+    const words = wordsInRange(transcript, seg.range.start, seg.range.end);
+
+    for (let i = 0; i < words.length; i += 2) {
+      const chunk = words.slice(i, i + 2);
+      if (chunk.length === 0) continue;
+
+      const text = chunk
+        .map((w) => (w.text || "").trim())
+        .join(" ")
+        .toUpperCase();
+      if (!text) continue;
+
+      const srcStart = chunk[0].start! - seg.range.start;
+      const srcEnd = chunk[chunk.length - 1].end! - seg.range.start;
+      cues.push({
+        frameStart: seg.startFrame + Math.round(srcStart * fps),
+        frameEnd: seg.startFrame + Math.round(srcEnd * fps),
+        text,
+      });
+    }
+  }
+
+  return cues;
+}
+
+export const Subtitles: React.FC<{
+  edl: Edl;
+  fps: number;
+  segments: Segment[];
+}> = ({ edl, fps, segments }) => {
+  const frame = useCurrentFrame();
+  const cues = useMemo(() => buildCues(edl, segments, fps), [edl, segments, fps]);
+  const activeCue = cues.find((c) => frame >= c.frameStart && frame < c.frameEnd);
+
+  if (!activeCue) return null;
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        bottom: 60,
+        left: 0,
+        right: 0,
+        display: "flex",
+        justifyContent: "center",
+        pointerEvents: "none",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "Helvetica, Arial, sans-serif",
+          fontSize: 48,
+          fontWeight: 700,
+          color: "white",
+          textShadow:
+            "2px 2px 0 #000, -2px 2px 0 #000, 2px -2px 0 #000, -2px -2px 0 #000, 0 2px 0 #000, 0 -2px 0 #000, 2px 0 0 #000, -2px 0 0 #000",
+          padding: "4px 16px",
+          textAlign: "center",
+          letterSpacing: "0.05em",
+        }}
+      >
+        {activeCue.text}
+      </span>
+    </div>
+  );
+};

--- a/remotion/src/index.ts
+++ b/remotion/src/index.ts
@@ -1,0 +1,4 @@
+import { registerRoot } from "remotion";
+import { Root } from "./Root";
+
+registerRoot(Root);

--- a/remotion/tsconfig.json
+++ b/remotion/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- **WhisperX backend**: transcription now works locally without any API key. If `ELEVENLABS_API_KEY` is set, ElevenLabs Scribe is used (existing behavior). Otherwise WhisperX runs locally with word-level alignment. WhisperX output is converted to the same JSON format so the downstream pipeline (pack_transcripts, render) works unchanged.
- **Remotion Studio preview**: new `remotion/` directory with a Remotion project that reads `edl.json` and sequences clips with live subtitles in the browser. Instant preview with timeline scrubbing — no waiting for ffmpeg renders.
- **`--backend` and `--model` flags**: explicitly choose transcription backend and WhisperX model size (e.g. `--model base` for fast CPU inference).

### Changes

- `helpers/transcribe.py` — dual-backend: `detect_backend()` auto-selects based on env vars, `--backend` flag for manual override
- `helpers/transcribe_batch.py` — ElevenLabs uses 4-worker parallel, WhisperX loads model once and processes sequentially
- `remotion/` — Remotion Studio project with `EdlComposition`, `Subtitles` components, and `setup-public.mjs` to copy source videos
- `pyproject.toml` — added `whisperx` optional dependency group
- `.env.example`, `README.md`, `SKILL.md` — updated for both backends + Remotion preview docs

## Test plan

- [ ] Verify ElevenLabs backend still works when `ELEVENLABS_API_KEY` is set
- [ ] Verify WhisperX backend works with `pip install -e ".[whisperx]"` and no API key
- [ ] Verify `--backend whisperx --model base` runs fast on CPU
- [ ] Verify `pack_transcripts.py` produces identical output format for both backends
- [ ] Verify Remotion Studio launches and previews EDL compositions with subtitles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds local WhisperX transcription (no API key) and a Remotion Studio EDL preview, keeping the transcript JSON format unchanged and speeding up iteration with instant, in-browser playback.

- **New Features**
  - Dual transcription backends with auto-detect. Uses ElevenLabs Scribe when `ELEVENLABS_API_KEY` is set, otherwise WhisperX locally. New flags: `--backend whisperx|elevenlabs`, `--model <size>` for WhisperX.
  - Batch mode: ElevenLabs runs with 4 parallel workers; WhisperX loads the model once and processes sequentially.
  - WhisperX output is converted to Scribe-compatible JSON (`words`, `spacing`), so `pack_transcripts` and render stay unchanged.
  - Remotion Studio under `remotion/` reads `edit/edl.json`, sequences clips, and shows live subtitles with timeline scrubbing. Includes a `setup-public.mjs` to copy source videos.
  - Docs and examples updated (`.env.example`, `README.md`, `SKILL.md`); optional dependency group `whisperx` added to `pyproject.toml`.

- **Migration**
  - To use WhisperX locally: `pip install -e ".[whisperx]"`; optionally set `HF_TOKEN` for diarization.
  - To preview in the browser: `cd remotion && npm install && npm run setup && npm run studio`.
  - No changes needed if you already use ElevenLabs; set `ELEVENLABS_API_KEY` and the cloud path is used automatically.

<sup>Written for commit 2cf88888007a0462189d5ff3ab5d5ad66451a257. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

