### PR TITLE
fix(subtitles): raise MarginV to 90 to clear vertical safe zones

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -38,13 +38,21 @@ except Exception:
         return "eq=contrast=1.03:saturation=0.98", {}
 
 
-# -------- Subtitle style (proven at 1920×1080, from HEURISTICS §5) -----------
-
+# -------- Subtitle style (bold-overlay, proven at 1920×1080 and 1080×1920) --
+#
+# MarginV is NOT taste — it is a platform safe-zone rule.
+# TikTok / IG Reels / Shorts UI (caption, username, music, right-rail actions)
+# covers roughly the bottom ~25–30% of a 1080×1920 frame. Captions placed near
+# the bottom edge get clipped or obscured by the UI. libass auto-scales the
+# render canvas relative to PlayResY=288, so MarginV=90 lands the caption
+# baseline roughly 30% up from the bottom on any aspect — clear of the UI on
+# every major vertical-video platform. Do not drop this below ~75 without a
+# specific reason.
 SUB_FORCE_STYLE = (
     "FontName=Helvetica,FontSize=18,Bold=1,"
     "PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,BackColour=&H00000000,"
     "BorderStyle=1,Outline=2,Shadow=0,"
-    "Alignment=2,MarginV=35"
+    "Alignment=2,MarginV=90"
 )
 
 # -------- Helpers ------------------------------------------------------------


### PR DESCRIPTION
## Problem

The `bold-overlay` caption style in `render.py` ships with `MarginV=35`, which places the caption baseline just above the bottom edge. On `1080×1920` vertical output (TikTok / IG Reels / YouTube Shorts / Snap) this lands squarely inside the platform UI safe zone — caption, username, music ticker, and right-rail actions cover roughly the bottom ~25–30% of the frame. Captions get clipped or obscured by the UI after upload.

Observed on a shipped TikTok export: the 2-word UPPERCASE caption sat ~240 px from the bottom edge at 1920 tall, well inside TikTok's description/music strip.

## Fix

Bump `MarginV` from `35` → `90`. libass auto-scales the render canvas relative to `PlayResY=288`, so `90` lands the caption baseline ~30% up from the bottom on any output aspect — clear of the UI on every major vertical platform. Landscape output is unaffected visually because the caption stays in the lower third either way.

Added an inline comment documenting why this value is a platform safe-zone rule, not a taste call, so future edits don't silently walk it back.

## Test

Re-rendered vertical `1080×1920` outputs with the same EDL before/after. Captions now sit above the TikTok/IG UI zone and are fully visible after platform upload.

## Notes

Pairs well with — but is independent from — a separate PR for HDR tone-mapping of HLG/PQ sources (iPhone footage). Kept atomic on purpose.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised subtitle `MarginV` from 35 to 90 to keep captions above vertical-platform UI safe zones on 1080×1920 exports (TikTok/IG/Shorts). Landscape renders are unchanged; added an inline comment documenting the safe‑zone rule.

<sup>Written for commit 79e33e4b206349dc43e03976fc8e2322cbed8ad6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

