### PR TITLE
fix(render): tone-map HLG/PQ sources to Rec.709 SDR

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -84,6 +84,45 @@ def resolve_path(maybe_path: str, base: Path) -> Path:
     return (base / p).resolve()
 
 
+# -------- HDR → SDR tone mapping (HLG / PQ sources) --------------------------
+#
+# iPhone defaults to HLG HDR in Rec.2020 (and many mirrorless cameras ship PQ).
+# If the source is HDR and we only downconvert bit depth (yuv420p10le → yuv420p)
+# without tone-mapping, the output is 8-bit but still carries HLG/PQ transfer
+# metadata. Players that honor the metadata (screen recorders, most social
+# upload re-encodes) interpret 8-bit values in an HDR container and the result
+# looks oversaturated / blown out. QuickTime on macOS can hide this locally —
+# screen recording and uploaded renders cannot.
+#
+# Fix: detect HDR via color_transfer and prepend a zscale+tonemap chain to the
+# vf graph so the output is clean Rec.709 SDR.
+
+HDR_TRANSFERS = {"smpte2084", "arib-std-b67"}  # PQ (HDR10) and HLG
+
+TONEMAP_CHAIN = (
+    "zscale=t=linear:npl=100,"
+    "format=gbrpf32le,"
+    "zscale=p=bt709,"
+    "tonemap=tonemap=hable:desat=0,"
+    "zscale=t=bt709:m=bt709:r=tv,"
+    "format=yuv420p"
+)
+
+
+def is_hdr_source(video: Path) -> bool:
+    """Return True if the source uses a PQ or HLG transfer function."""
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=color_transfer",
+             "-of", "default=noprint_wrappers=1:nokey=1", str(video)],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip() in HDR_TRANSFERS
+    except subprocess.CalledProcessError:
+        return False
+
+
 # -------- Per-segment extraction (Rule 2 + Rule 3) --------------------------
 
 
@@ -112,7 +151,10 @@ def extract_segment(
     else:
         scale = "scale=1920:-2"
 
-    vf_parts = [scale]
+    vf_parts: list[str] = []
+    if is_hdr_source(source):
+        vf_parts.append(TONEMAP_CHAIN)
+    vf_parts.append(scale)
     if grade_filter:
         vf_parts.append(grade_filter)
     vf = ",".join(vf_parts)


### PR DESCRIPTION
## Problem

iPhone (and many mirrorless cameras) ship HDR by default — HLG for iPhone, PQ elsewhere. `extract_segment` converts bit depth via `-pix_fmt yuv420p`, but leaves the HDR transfer metadata (`arib-std-b67` / `smpte2084`) intact on the output.

Players that honor the metadata — screen recorders, almost every social-upload re-encode path (TikTok, IG, YouTube, X) — interpret the 8-bit values as HDR and display crushed, oversaturated colors.

QuickTime on macOS happens to tone-map on playback, which masks the bug locally. Screen recording and uploaded renders cannot.

### Reproduce

```bash
# iPhone-shot HLG source
ffprobe -show_streams IMG_1325.MOV | grep -E "pix_fmt|color_transfer|color_primaries"
# pix_fmt=yuv420p10le
# color_transfer=arib-std-b67     ← HLG
# color_primaries=bt2020

python helpers/render.py edl.json -o final.mp4 --build-subtitles
ffprobe -show_streams final.mp4 | grep -E "pix_fmt|color_transfer|color_primaries"
# pix_fmt=yuv420p
# color_transfer=arib-std-b67     ← still HLG metadata on 8-bit values
# color_primaries=bt2020
```

## Fix

- Detect HDR via `ffprobe stream=color_transfer` ∈ `{smpte2084, arib-std-b67}`.
- When HDR, prepend a `zscale → tonemap=hable → zscale=bt709 → format=yuv420p` chain to the vf graph so the extract produces clean Rec.709 SDR with correct metadata.
- No-op path for SDR sources (most existing footage is unchanged).

Expose `is_hdr_source()` and `TONEMAP_CHAIN` at module scope so downstream scripts that build custom pipelines (e.g. vertical/portrait wrappers) can reuse the detection.

## After

```
pix_fmt=yuv420p
color_transfer=bt709     ← clean SDR
color_primaries=bt709
```

## Test

Verified end-to-end on iPhone HLG 1080×1920 HEVC footage. Before/after comparison: local playback looks similar on macOS (QuickTime tone-maps either way), but screen recording and simulated-upload re-encode paths no longer oversaturate.

## Notes

Kept atomic from the subtitle-safe-zone fix — independent bugs, easier to review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tone-map HLG/PQ HDR sources to clean Rec.709 SDR during segment extraction to prevent oversaturated uploads and screen recordings. HDR outputs are now 8‑bit `yuv420p` with `bt709` transfer and primaries; SDR sources are unchanged.

- **Bug Fixes**
  - Detect HDR via `ffprobe` `stream=color_transfer` in {`smpte2084`, `arib-std-b67`}.
  - When HDR, prepend `zscale → tonemap=hable → zscale=bt709 → format=yuv420p` to the `vf` chain.
  - Expose `is_hdr_source()` and `TONEMAP_CHAIN` for reuse in custom pipelines.

<sup>Written for commit 4d4bfc5ad7b97ef67b067e410f737e0a401b3457. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

