### PR TITLE
Migrate GitHub Copilot orchestrator to Copilot SDK and enhance features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,6 @@ ELEVENLABS_API_KEY=
 
 # Required for the GitHub Copilot orchestrator (orchestrator.py).
 # Create a Personal Access Token at https://github.com/settings/tokens
-# with the 'copilot' scope, then paste it here or export it in your shell.
+# with the 'copilot' scope, then paste it here. The orchestrator loads
+# this file automatically (like the transcription helpers do).
 GITHUB_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,6 @@
 ELEVENLABS_API_KEY=
+
+# Required for the GitHub Copilot orchestrator (orchestrator.py).
+# Create a Personal Access Token at https://github.com/settings/tokens
+# with the 'copilot' scope, then paste it here or export it in your shell.
+GITHUB_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
 ELEVENLABS_API_KEY=
 
 # Required for the GitHub Copilot orchestrator (orchestrator.py).
-# Create a Personal Access Token at https://github.com/settings/tokens
-# with the 'copilot' scope, then paste it here. The orchestrator loads
-# this file automatically (like the transcription helpers do).
+#
+# Option A — browser login (recommended, no token needed):
+#   copilot auth login
+#
+# Option B — Personal Access Token:
+#   Create one at https://github.com/settings/tokens with the 'copilot' scope,
+#   then paste it below. The orchestrator loads this file automatically.
 GITHUB_TOKEN=

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Drop raw footage in a folder, chat with Claude Code, get `final.mp4` back. Works
 
 ## Get started
 
+Two ways to run video-use — pick the one that matches your subscription:
+
+### Option A — Claude Code (original)
+
+Requires an Anthropic API subscription or Claude Pro.
+
 ```bash
 # 1. Clone and symlink into Claude Code's skills directory
 git clone https://github.com/browser-use/video-use
@@ -41,6 +47,44 @@ Then point Claude Code at a folder of raw takes:
 ```bash
 cd /path/to/your/videos
 claude
+```
+
+### Option B — GitHub Copilot (no Anthropic key required)
+
+Uses your existing GitHub Copilot subscription as the LLM backend via the
+OpenAI-compatible Copilot API. Same pipeline, same production rules, same helpers.
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/browser-use/video-use
+cd video-use
+
+# 2. Install deps (includes the openai SDK)
+pip install -e ".[copilot]"
+brew install ffmpeg           # required
+brew install yt-dlp            # optional
+
+# 3. Configure API keys
+cp .env.example .env
+$EDITOR .env
+#   ELEVENLABS_API_KEY=...    ← for transcription (same as before)
+#   GITHUB_TOKEN=...          ← PAT with 'copilot' scope
+#                               https://github.com/settings/tokens
+```
+
+Then run the orchestrator against your video folder:
+
+```bash
+python /path/to/video-use/orchestrator.py /path/to/your/videos
+```
+
+Available options:
+
+```
+--model gpt-4o          # default; also: gpt-4o-mini, claude-3.5-sonnet, o3-mini
+--endpoint <url>        # default: https://api.githubcopilot.com
+                        # GitHub Models alternative: https://models.inference.ai.azure.com
+--max-turns 100         # safety cap on LLM turns (default: 100)
 ```
 
 And in the session:

--- a/README.md
+++ b/README.md
@@ -52,23 +52,27 @@ claude
 ### Option B — GitHub Copilot (no Anthropic key required)
 
 Uses your existing GitHub Copilot subscription as the LLM backend via the
-OpenAI-compatible Copilot API. Same pipeline, same production rules, same helpers.
+[GitHub Copilot SDK](https://github.com/github/copilot-sdk). The SDK bundles the
+Copilot CLI automatically — no separate CLI install needed. Same pipeline, same
+production rules, same helpers.
 
 ```bash
 # 1. Clone the repo
 git clone https://github.com/browser-use/video-use
 cd video-use
 
-# 2. Install deps (includes the openai SDK)
+# 2. Install deps (includes the Copilot SDK)
 pip install -e ".[copilot]"
 brew install ffmpeg           # required
 brew install yt-dlp            # optional
 
-# 3. Configure API keys
+# 3. Authenticate — pick one:
+copilot auth login             # Option A: browser login (recommended, no token needed)
+#  — OR —
 cp .env.example .env
 $EDITOR .env
 #   ELEVENLABS_API_KEY=...    ← for transcription (same as before)
-#   GITHUB_TOKEN=...          ← PAT with 'copilot' scope
+#   GITHUB_TOKEN=...          ← PAT with 'copilot' scope (option B)
 #                               https://github.com/settings/tokens
 ```
 
@@ -81,14 +85,18 @@ python /path/to/video-use/orchestrator.py /path/to/your/videos
 Available options:
 
 ```
---model claude-opus-4-7  # default — Anthropic Claude Opus 4.7 (strong reasoning + vision)
---model gpt-4o           # OpenAI GPT-4o alternative
---model claude-sonnet-4-5 # faster Anthropic option
---model gpt-4o-mini      # fastest/lightest option
---endpoint <url>         # default: https://api.githubcopilot.com
-                         # GitHub Models alternative: https://models.inference.ai.azure.com
---max-turns 100          # safety cap on LLM turns (default: 100)
+# Model (omit to let Copilot auto-select — recommended)
+--model claude-opus-4.5   # Anthropic Claude Opus 4.5 — complex tasks, deep reasoning
+--model claude-sonnet-4.5 # Anthropic Claude Sonnet 4.5 — faster, most routine tasks
+--model gpt-5             # OpenAI GPT-5
+--model gpt-4.1           # OpenAI GPT-4.1
+
+# Other flags
+--enable-shell            # enable built-in shell tool (off by default for safety)
+--max-turns 200           # safety cap on interactive turns (default: 200)
 ```
+
+You can also switch models mid-session with `/model` at the prompt.
 
 And in the session:
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,13 @@ python /path/to/video-use/orchestrator.py /path/to/your/videos
 Available options:
 
 ```
---model gpt-4o          # default; also: gpt-4o-mini, claude-3.5-sonnet, o3-mini
---endpoint <url>        # default: https://api.githubcopilot.com
-                        # GitHub Models alternative: https://models.inference.ai.azure.com
---max-turns 100         # safety cap on LLM turns (default: 100)
+--model claude-opus-4-7  # default — Anthropic Claude Opus 4.7 (strong reasoning + vision)
+--model gpt-4o           # OpenAI GPT-4o alternative
+--model claude-sonnet-4-5 # faster Anthropic option
+--model gpt-4o-mini      # fastest/lightest option
+--endpoint <url>         # default: https://api.githubcopilot.com
+                         # GitHub Models alternative: https://models.inference.ai.azure.com
+--max-turns 100          # safety cap on LLM turns (default: 100)
 ```
 
 And in the session:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -37,6 +37,23 @@ REPO_ROOT = Path(__file__).resolve().parent
 HELPERS_DIR = REPO_ROOT / "helpers"
 SKILL_MD = REPO_ROOT / "SKILL.md"
 
+
+def _load_env_file() -> None:
+    """Load key=value pairs from .env into os.environ (does not overwrite existing vars)."""
+    for candidate in [REPO_ROOT / ".env", Path(".env")]:
+        if candidate.exists():
+            for line in candidate.read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                k = k.strip()
+                v = v.strip().strip('"').strip("'")
+                if k and k not in os.environ:
+                    os.environ[k] = v
+            break
+
+
 # ---------------------------------------------------------------------------
 # System prompt
 # ---------------------------------------------------------------------------
@@ -353,11 +370,21 @@ def _format_result(returncode: int, stdout: str, stderr: str) -> str:
     return "\n".join(parts)
 
 
+def _is_under(path: Path, parent: Path) -> bool:
+    """Return True if *path* is the same as or nested under *parent*."""
+    try:
+        path.relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
 def dispatch_tool(
     name: str,
     args: dict,
     videos_dir: Path,
     edit_dir: Path,
+    enable_bash: bool = False,
 ) -> tuple[str, Path | None]:
     """Execute a tool call. Returns (result_text, optional_image_path)."""
 
@@ -376,7 +403,8 @@ def dispatch_tool(
         return _format_result(rc, out, err), None
 
     if name == "transcribe_batch":
-        cmd = [str(HELPERS_DIR / "transcribe_batch.py"), args["videos_dir"]]
+        # Always use the session videos_dir to prevent operating outside it
+        cmd = [str(HELPERS_DIR / "transcribe_batch.py"), str(videos_dir)]
         if args.get("edit_dir"):
             cmd += ["--edit-dir", args["edit_dir"]]
         if args.get("workers"):
@@ -387,7 +415,7 @@ def dispatch_tool(
         return _format_result(rc, out, err), None
 
     if name == "pack_transcripts":
-        cmd = [str(HELPERS_DIR / "pack_transcripts.py"), "--edit-dir", args["edit_dir"]]
+        cmd = [str(HELPERS_DIR / "pack_transcripts.py"), "--edit-dir", args.get("edit_dir") or str(edit_dir)]
         if args.get("silence_threshold") is not None:
             cmd += ["--silence-threshold", str(args["silence_threshold"])]
         rc, out, err = _run_helper(cmd)
@@ -449,6 +477,12 @@ def dispatch_tool(
         return _format_result(rc, out, err), None
 
     if name == "bash":
+        if not enable_bash:
+            return (
+                "[bash tool is disabled by default. Restart the orchestrator with "
+                "--enable-bash to allow shell commands.]",
+                None,
+            )
         command = args["command"]
         proc = subprocess.run(
             command,
@@ -460,7 +494,9 @@ def dispatch_tool(
         return _format_result(proc.returncode, proc.stdout, proc.stderr), None
 
     if name == "read_file":
-        path = Path(args["path"])
+        path = Path(args["path"]).resolve()
+        if not (_is_under(path, videos_dir) or _is_under(path, edit_dir)):
+            return f"Access denied: path must be under {videos_dir} or {edit_dir}", None
         if not path.exists():
             return f"File not found: {path}", None
         try:
@@ -469,7 +505,9 @@ def dispatch_tool(
             return f"Error reading file: {e}", None
 
     if name == "write_file":
-        path = Path(args["path"])
+        path = Path(args["path"]).resolve()
+        if not _is_under(path, edit_dir):
+            return f"Access denied: write path must be under {edit_dir}", None
         path.parent.mkdir(parents=True, exist_ok=True)
         mode = "a" if args.get("append") else "w"
         try:
@@ -487,13 +525,47 @@ def dispatch_tool(
 # ---------------------------------------------------------------------------
 
 
+# Maximum image size (bytes) to embed in chat; larger images are downscaled first.
+MAX_IMAGE_BYTES = 1_500_000  # 1.5 MB
+
+
 def _build_image_message(img_path: Path) -> dict:
-    b64 = base64.b64encode(img_path.read_bytes()).decode()
+    """Embed a timeline image as a base64 data URL, downscaling via ffmpeg if needed."""
+    raw = img_path.read_bytes()
+    mime = "image/png"
+    if len(raw) > MAX_IMAGE_BYTES:
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+        try:
+            subprocess.run(
+                [
+                    "ffmpeg", "-y", "-i", str(img_path),
+                    "-vf", "scale='min(960,iw)':-2",
+                    str(tmp_path),
+                ],
+                capture_output=True,
+                check=False,
+            )
+            raw = tmp_path.read_bytes()
+            mime = "image/jpeg"
+        except Exception:
+            pass
+        finally:
+            tmp_path.unlink(missing_ok=True)
+    if len(raw) > MAX_IMAGE_BYTES:
+        return {
+            "role": "user",
+            "content": (
+                f"[Timeline image too large to embed ({len(raw):,} bytes); "
+                f"saved to: {img_path}]"
+            ),
+        }
+    b64 = base64.b64encode(raw).decode()
     return {
         "role": "user",
         "content": [
             {"type": "text", "text": f"[Timeline view image: {img_path.name}]"},
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}},
+            {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{b64}"}},
         ],
     }
 
@@ -503,6 +575,7 @@ def run_session(
     model: str,
     endpoint: str,
     max_turns: int,
+    enable_bash: bool = False,
 ) -> None:
     try:
         from openai import OpenAI
@@ -513,6 +586,7 @@ def run_session(
             "or:            pip install openai"
         )
 
+    _load_env_file()
     github_token = os.environ.get("GITHUB_TOKEN", "").strip()
     if not github_token:
         sys.exit(
@@ -613,6 +687,10 @@ def run_session(
         messages.append(msg_dict)
 
         if message.tool_calls:
+            # Show any explanation the model included alongside the tool calls
+            if message.content:
+                print(f"\nAssistant: {message.content}\n")
+
             # Execute every requested tool call
             image_paths: list[Path] = []
 
@@ -621,7 +699,15 @@ def run_session(
                 try:
                     tool_args = json.loads(tc.function.arguments)
                 except json.JSONDecodeError:
-                    tool_args = {}
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": (
+                            f"[Invalid JSON in tool arguments — could not parse. "
+                            f"Raw arguments: {tc.function.arguments!r}. Please retry with valid JSON.]"
+                        ),
+                    })
+                    continue
 
                 # Pretty-print what we're doing
                 args_preview = ", ".join(
@@ -630,7 +716,7 @@ def run_session(
                 print(f"  [tool] {tool_name}({args_preview})", flush=True)
 
                 result_text, image_path = dispatch_tool(
-                    tool_name, tool_args, videos_dir, edit_dir
+                    tool_name, tool_args, videos_dir, edit_dir, enable_bash=enable_bash
                 )
 
                 # Truncate very long results so we don't blow the context window
@@ -725,6 +811,15 @@ def main() -> None:
         default=100,
         help="Maximum LLM turns before the session ends (default: 100).",
     )
+    ap.add_argument(
+        "--enable-bash",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable the bash tool (disabled by default). "
+            "Only enable when you trust the model and understand the security implications."
+        ),
+    )
     args = ap.parse_args()
 
     videos_dir = args.videos_dir.resolve()
@@ -736,6 +831,7 @@ def main() -> None:
         model=args.model,
         endpoint=args.endpoint,
         max_turns=args.max_turns,
+        enable_bash=args.enable_bash,
     )
 
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,742 @@
+#!/usr/bin/env python3
+"""GitHub Copilot-backed video editing orchestrator for video-use.
+
+Replaces the `claude` CLI runtime with a standalone Python script that drives
+the same video editing pipeline using the GitHub Copilot API (OpenAI-compatible).
+All 12 hard production rules from SKILL.md are enforced via the same system
+prompt — no logic changes to the skill or helpers are needed.
+
+Requirements:
+  pip install -e ".[copilot]"          # openai>=1.0
+  export GITHUB_TOKEN=<your PAT>       # PAT with `copilot` scope
+  ELEVENLABS_API_KEY=... in .env       # for transcription (same as before)
+  ffmpeg and ffprobe on PATH
+
+Usage:
+  python orchestrator.py /path/to/videos
+  python orchestrator.py /path/to/videos --model gpt-4o
+  python orchestrator.py /path/to/videos --endpoint https://models.inference.ai.azure.com
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Repo-relative paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent
+HELPERS_DIR = REPO_ROOT / "helpers"
+SKILL_MD = REPO_ROOT / "SKILL.md"
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+
+def load_skill_prompt() -> str:
+    """Read SKILL.md and strip the YAML front matter used by Claude Code."""
+    text = SKILL_MD.read_text()
+    if text.startswith("---"):
+        end = text.find("---", 3)
+        if end != -1:
+            text = text[end + 3 :].lstrip("\n")
+    return text
+
+
+# Maximum characters returned from a single tool call before truncation.
+# Keeps large files (packed transcripts, long ffmpeg logs) from consuming
+# the entire context window.
+MAX_TOOL_RESULT_LENGTH = 20_000
+
+# ---------------------------------------------------------------------------
+# Tool schemas (OpenAI function-calling format)
+# ---------------------------------------------------------------------------
+
+TOOLS: list[dict] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "transcribe",
+            "description": (
+                "Transcribe a single video with ElevenLabs Scribe. "
+                "Writes word-level transcript JSON to edit/transcripts/<stem>.json. "
+                "Cached — skips upload if the JSON already exists."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "video_path": {
+                        "type": "string",
+                        "description": "Absolute path to the video file.",
+                    },
+                    "edit_dir": {
+                        "type": "string",
+                        "description": "Edit output directory. Defaults to <video_parent>/edit.",
+                    },
+                    "language": {
+                        "type": "string",
+                        "description": "ISO language code (e.g. 'en'). Omit to auto-detect.",
+                    },
+                    "num_speakers": {
+                        "type": "integer",
+                        "description": "Number of speakers. Improves diarization when known.",
+                    },
+                },
+                "required": ["video_path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "transcribe_batch",
+            "description": (
+                "Batch-transcribe every video in a directory using parallel workers. "
+                "Cached per source — already-transcribed files are skipped."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "videos_dir": {
+                        "type": "string",
+                        "description": "Directory containing source videos.",
+                    },
+                    "workers": {
+                        "type": "integer",
+                        "description": "Parallel workers (default 4).",
+                    },
+                    "edit_dir": {
+                        "type": "string",
+                        "description": "Override edit output directory.",
+                    },
+                    "num_speakers": {
+                        "type": "integer",
+                        "description": "Number of speakers (optional).",
+                    },
+                },
+                "required": ["videos_dir"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "pack_transcripts",
+            "description": (
+                "Pack all per-source transcript JSONs in edit/transcripts/ into "
+                "takes_packed.md — the primary phrase-level reading surface for cut decisions."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "edit_dir": {
+                        "type": "string",
+                        "description": "Edit output directory containing transcripts/ subdirectory.",
+                    },
+                    "silence_threshold": {
+                        "type": "number",
+                        "description": "Silence gap in seconds that triggers a phrase break (default 0.5).",
+                    },
+                },
+                "required": ["edit_dir"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "timeline_view",
+            "description": (
+                "Generate a filmstrip + waveform PNG for a time range of a video. "
+                "Use at decision points (ambiguous pauses, retake comparison, cut-point "
+                "sanity checks). NOT a scan tool — call only when you need a visual check."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "video_path": {
+                        "type": "string",
+                        "description": "Absolute path to the video file.",
+                    },
+                    "start": {
+                        "type": "number",
+                        "description": "Start time in seconds.",
+                    },
+                    "end": {
+                        "type": "number",
+                        "description": "End time in seconds.",
+                    },
+                    "n_frames": {
+                        "type": "integer",
+                        "description": "Number of filmstrip frames to extract (default 8).",
+                    },
+                    "transcript_path": {
+                        "type": "string",
+                        "description": "Optional path to a transcript JSON for word label overlay.",
+                    },
+                },
+                "required": ["video_path", "start", "end"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "render",
+            "description": (
+                "Render a video from an EDL (edit decision list JSON). "
+                "Runs the full pipeline: per-segment extract with grade + 30ms audio fades → "
+                "lossless concat → overlays (PTS-shifted) → subtitles LAST → loudnorm."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "edl_path": {
+                        "type": "string",
+                        "description": "Absolute path to edl.json.",
+                    },
+                    "output_path": {
+                        "type": "string",
+                        "description": "Output video path (e.g. edit/final.mp4).",
+                    },
+                    "preview": {
+                        "type": "boolean",
+                        "description": "Preview mode: 1080p, CRF 22, faster encode.",
+                    },
+                    "build_subtitles": {
+                        "type": "boolean",
+                        "description": "Build master.srt from transcripts + EDL timeline offsets.",
+                    },
+                    "no_subtitles": {
+                        "type": "boolean",
+                        "description": "Skip subtitles even if the EDL references one.",
+                    },
+                    "no_loudnorm": {
+                        "type": "boolean",
+                        "description": "Skip audio loudness normalization (default: on, -14 LUFS).",
+                    },
+                },
+                "required": ["edl_path", "output_path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "grade",
+            "description": (
+                "Apply a color grade to a video via ffmpeg filter chain. "
+                "Presets: subtle, neutral_punch, warm_cinematic, none. "
+                "Omit both preset and filter for auto mode (data-driven per-clip correction)."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "input_path": {
+                        "type": "string",
+                        "description": "Input video path.",
+                    },
+                    "output_path": {
+                        "type": "string",
+                        "description": "Output video path.",
+                    },
+                    "preset": {
+                        "type": "string",
+                        "description": "Grade preset name.",
+                        "enum": ["subtle", "neutral_punch", "warm_cinematic", "none"],
+                    },
+                    "filter": {
+                        "type": "string",
+                        "description": "Raw ffmpeg filter string (overrides preset).",
+                    },
+                },
+                "required": ["input_path", "output_path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "description": (
+                "Run a shell command. Use for ffprobe, yt-dlp, file listing, "
+                "ffmpeg one-offs, and other system tasks the other tools don't cover."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Shell command to execute.",
+                    },
+                },
+                "required": ["command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read the contents of a text file (takes_packed.md, project.md, edl.json, transcripts, etc.).",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Absolute path to the file.",
+                    },
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "write_file",
+            "description": "Write or append content to a file (edl.json, project.md, etc.).",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Absolute path to the file.",
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Content to write.",
+                    },
+                    "append": {
+                        "type": "boolean",
+                        "description": "If true, append to existing file instead of overwriting.",
+                    },
+                },
+                "required": ["path", "content"],
+            },
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatch
+# ---------------------------------------------------------------------------
+
+
+def _run_helper(args: list[str]) -> tuple[int, str, str]:
+    """Run a Python helper from the helpers/ directory."""
+    cmd = [sys.executable] + args
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _format_result(returncode: int, stdout: str, stderr: str) -> str:
+    parts: list[str] = []
+    if stdout.strip():
+        parts.append(stdout.strip())
+    if returncode != 0 and stderr.strip():
+        parts.append(f"[stderr]\n{stderr.strip()}")
+    if not parts:
+        parts.append("(no output)" if returncode == 0 else f"[exit {returncode}] (no output)")
+    if returncode != 0:
+        parts.insert(0, f"[exit code {returncode}]")
+    return "\n".join(parts)
+
+
+def dispatch_tool(
+    name: str,
+    args: dict,
+    videos_dir: Path,
+    edit_dir: Path,
+) -> tuple[str, Path | None]:
+    """Execute a tool call. Returns (result_text, optional_image_path)."""
+
+    if name == "transcribe":
+        video_path = args["video_path"]
+        cmd = [str(HELPERS_DIR / "transcribe.py"), video_path]
+        if args.get("edit_dir"):
+            cmd += ["--edit-dir", args["edit_dir"]]
+        else:
+            cmd += ["--edit-dir", str(edit_dir)]
+        if args.get("language"):
+            cmd += ["--language", args["language"]]
+        if args.get("num_speakers"):
+            cmd += ["--num-speakers", str(args["num_speakers"])]
+        rc, out, err = _run_helper(cmd)
+        return _format_result(rc, out, err), None
+
+    if name == "transcribe_batch":
+        cmd = [str(HELPERS_DIR / "transcribe_batch.py"), args["videos_dir"]]
+        if args.get("edit_dir"):
+            cmd += ["--edit-dir", args["edit_dir"]]
+        if args.get("workers"):
+            cmd += ["--workers", str(args["workers"])]
+        if args.get("num_speakers"):
+            cmd += ["--num-speakers", str(args["num_speakers"])]
+        rc, out, err = _run_helper(cmd)
+        return _format_result(rc, out, err), None
+
+    if name == "pack_transcripts":
+        cmd = [str(HELPERS_DIR / "pack_transcripts.py"), "--edit-dir", args["edit_dir"]]
+        if args.get("silence_threshold") is not None:
+            cmd += ["--silence-threshold", str(args["silence_threshold"])]
+        rc, out, err = _run_helper(cmd)
+        return _format_result(rc, out, err), None
+
+    if name == "timeline_view":
+        video_path = Path(args["video_path"])
+        start = args["start"]
+        end = args["end"]
+        verify_dir = edit_dir / "verify"
+        verify_dir.mkdir(parents=True, exist_ok=True)
+        out_img = verify_dir / f"timeline_{video_path.stem}_{start:.2f}_{end:.2f}.png"
+        cmd = [
+            str(HELPERS_DIR / "timeline_view.py"),
+            str(video_path),
+            str(start),
+            str(end),
+            "-o", str(out_img),
+        ]
+        if args.get("n_frames"):
+            cmd += ["--n-frames", str(args["n_frames"])]
+        if args.get("transcript_path"):
+            cmd += ["--transcript", args["transcript_path"]]
+        rc, out, err = _run_helper(cmd)
+        result = _format_result(rc, out, err)
+        if rc == 0 and out_img.exists():
+            result += f"\nImage saved to: {out_img}"
+            return result, out_img
+        return result, None
+
+    if name == "render":
+        cmd = [
+            str(HELPERS_DIR / "render.py"),
+            args["edl_path"],
+            "-o", args["output_path"],
+        ]
+        if args.get("preview"):
+            cmd.append("--preview")
+        if args.get("build_subtitles"):
+            cmd.append("--build-subtitles")
+        if args.get("no_subtitles"):
+            cmd.append("--no-subtitles")
+        if args.get("no_loudnorm"):
+            cmd.append("--no-loudnorm")
+        rc, out, err = _run_helper(cmd)
+        return _format_result(rc, out, err), None
+
+    if name == "grade":
+        cmd = [
+            str(HELPERS_DIR / "grade.py"),
+            args["input_path"],
+            "-o", args["output_path"],
+        ]
+        if args.get("filter"):
+            cmd += ["--filter", args["filter"]]
+        elif args.get("preset"):
+            cmd += ["--preset", args["preset"]]
+        rc, out, err = _run_helper(cmd)
+        return _format_result(rc, out, err), None
+
+    if name == "bash":
+        command = args["command"]
+        proc = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        return _format_result(proc.returncode, proc.stdout, proc.stderr), None
+
+    if name == "read_file":
+        path = Path(args["path"])
+        if not path.exists():
+            return f"File not found: {path}", None
+        try:
+            return path.read_text(), None
+        except Exception as e:
+            return f"Error reading file: {e}", None
+
+    if name == "write_file":
+        path = Path(args["path"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        mode = "a" if args.get("append") else "w"
+        try:
+            with open(path, mode) as f:
+                f.write(args["content"])
+            return f"Written to {path}", None
+        except Exception as e:
+            return f"Error writing file: {e}", None
+
+    return f"Unknown tool: {name}", None
+
+
+# ---------------------------------------------------------------------------
+# Session loop
+# ---------------------------------------------------------------------------
+
+
+def _build_image_message(img_path: Path) -> dict:
+    b64 = base64.b64encode(img_path.read_bytes()).decode()
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": f"[Timeline view image: {img_path.name}]"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}},
+        ],
+    }
+
+
+def run_session(
+    videos_dir: Path,
+    model: str,
+    endpoint: str,
+    max_turns: int,
+) -> None:
+    try:
+        from openai import OpenAI
+    except ImportError:
+        sys.exit(
+            "openai package not found.\n"
+            "Install with:  pip install -e \".[copilot]\"\n"
+            "or:            pip install openai"
+        )
+
+    github_token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not github_token:
+        sys.exit(
+            "GITHUB_TOKEN is not set.\n"
+            "Export a Personal Access Token with the 'copilot' scope:\n"
+            "  export GITHUB_TOKEN=github_pat_..."
+        )
+
+    client = OpenAI(base_url=endpoint, api_key=github_token)
+
+    edit_dir = videos_dir / "edit"
+    edit_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build system prompt with working-directory context injected at the end
+    system_prompt = load_skill_prompt()
+    system_prompt += (
+        f"\n\n## Session context\n\n"
+        f"- Videos directory: `{videos_dir}`\n"
+        f"- Edit directory: `{edit_dir}`\n"
+        f"- Helpers directory: `{HELPERS_DIR}`\n"
+        f"- All session outputs must go to `{edit_dir}/` (Hard Rule 12).\n"
+    )
+
+    messages: list[dict] = [{"role": "system", "content": system_prompt}]
+
+    # Seed with prior session memory if available
+    project_md = edit_dir / "project.md"
+    if project_md.exists():
+        prior = project_md.read_text().strip()
+        if prior:
+            messages.append({
+                "role": "user",
+                "content": (
+                    f"[Prior session memory — project.md]\n\n{prior}\n\n---\n"
+                    "I'm back. What should we pick up from or start fresh on?"
+                ),
+            })
+            messages.append({
+                "role": "assistant",
+                "content": (
+                    "I've reviewed the session notes above. Ready when you are — "
+                    "just tell me what you'd like to work on."
+                ),
+            })
+
+    print(f"\nvideo-use — GitHub Copilot orchestrator")
+    print(f"  model:    {model}")
+    print(f"  endpoint: {endpoint}")
+    print(f"  videos:   {videos_dir}")
+    print("Type your message. Enter 'exit' or press Ctrl+C to quit.\n")
+
+    # Prompt for the first user message
+    try:
+        first_input = input("You: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print("\nBye.")
+        return
+
+    if not first_input or first_input.lower() in ("exit", "quit", "q"):
+        print("Bye.")
+        return
+
+    messages.append({"role": "user", "content": first_input})
+
+    turn = 0
+    while turn < max_turns:
+        try:
+            response = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                tools=TOOLS,
+                max_tokens=4096,
+            )
+        except KeyboardInterrupt:
+            print("\n[Interrupted]")
+            break
+        except Exception as e:
+            print(f"\n[API error: {e}]")
+            break
+
+        choice = response.choices[0]
+        message = choice.message
+
+        # Serialize the assistant message back into the history
+        msg_dict: dict = {"role": "assistant", "content": message.content}
+        if message.tool_calls:
+            msg_dict["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    },
+                }
+                for tc in message.tool_calls
+            ]
+        messages.append(msg_dict)
+
+        if message.tool_calls:
+            # Execute every requested tool call
+            image_paths: list[Path] = []
+
+            for tc in message.tool_calls:
+                tool_name = tc.function.name
+                try:
+                    tool_args = json.loads(tc.function.arguments)
+                except json.JSONDecodeError:
+                    tool_args = {}
+
+                # Pretty-print what we're doing
+                args_preview = ", ".join(
+                    f"{k}={v!r}" for k, v in list(tool_args.items())[:3]
+                )
+                print(f"  [tool] {tool_name}({args_preview})", flush=True)
+
+                result_text, image_path = dispatch_tool(
+                    tool_name, tool_args, videos_dir, edit_dir
+                )
+
+                # Truncate very long results so we don't blow the context window
+                if len(result_text) > MAX_TOOL_RESULT_LENGTH:
+                    result_text = result_text[:MAX_TOOL_RESULT_LENGTH] + "\n... [truncated]"
+
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "content": result_text,
+                })
+
+                if image_path and image_path.exists():
+                    image_paths.append(image_path)
+
+            # Inject timeline view images as user messages so vision-capable
+            # models (gpt-4o, etc.) can reason about them
+            for img_path in image_paths:
+                messages.append(_build_image_message(img_path))
+
+            turn += 1
+            continue  # Let the model respond to the tool results
+
+        # No tool calls — conversational turn
+        if message.content:
+            print(f"\nAssistant: {message.content}\n")
+
+        if choice.finish_reason == "stop":
+            try:
+                user_input = input("You: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print("\nBye.")
+                break
+
+            if not user_input or user_input.lower() in ("exit", "quit", "q"):
+                print("Bye.")
+                break
+
+            messages.append({"role": "user", "content": user_input})
+
+        turn += 1
+
+    if turn >= max_turns:
+        print(f"\n[Reached max_turns={max_turns}. Session ended.]")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="GitHub Copilot-backed video editing orchestrator for video-use.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Environment variables:\n"
+            "  GITHUB_TOKEN       Personal Access Token with 'copilot' scope (required)\n"
+            "  ELEVENLABS_API_KEY ElevenLabs API key for transcription (required for transcribe tools)\n"
+            "\nModel options (via GitHub Copilot):\n"
+            "  gpt-4o             Default — strong reasoning, vision support\n"
+            "  gpt-4o-mini        Faster and lighter\n"
+            "  claude-3.5-sonnet  Anthropic model via Copilot\n"
+            "  o3-mini            Reasoning model\n"
+            "\nAlternative endpoint (GitHub Models free tier):\n"
+            "  --endpoint https://models.inference.ai.azure.com\n"
+        ),
+    )
+    ap.add_argument(
+        "videos_dir",
+        type=Path,
+        help="Directory containing the source video files.",
+    )
+    ap.add_argument(
+        "--model",
+        default="gpt-4o",
+        help="Model identifier for the Copilot API (default: gpt-4o).",
+    )
+    ap.add_argument(
+        "--endpoint",
+        default="https://api.githubcopilot.com",
+        help=(
+            "GitHub Copilot API base URL "
+            "(default: https://api.githubcopilot.com). "
+            "Use https://models.inference.ai.azure.com for GitHub Models."
+        ),
+    )
+    ap.add_argument(
+        "--max-turns",
+        type=int,
+        default=100,
+        help="Maximum LLM turns before the session ends (default: 100).",
+    )
+    args = ap.parse_args()
+
+    videos_dir = args.videos_dir.resolve()
+    if not videos_dir.is_dir():
+        sys.exit(f"Not a directory: {videos_dir}")
+
+    run_session(
+        videos_dir=videos_dir,
+        model=args.model,
+        endpoint=args.endpoint,
+        max_turns=args.max_turns,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -471,19 +471,11 @@ async def run_session(
     if model:
         session_kwargs["model"] = model
 
-    try:
-        from copilot.generated.session_events import (
-            AssistantMessageData,
-            AssistantMessageDeltaData,
-            SessionIdleData,
-        )
-    except ImportError:
-        # Older SDK versions may use a different import path
-        from copilot.session_events import (  # type: ignore[no-redef]
-            AssistantMessageData,
-            AssistantMessageDeltaData,
-            SessionIdleData,
-        )
+    from copilot.generated.session_events import SessionEventType
+
+    def _event_type(event) -> str:
+        et = getattr(event, "type", "")
+        return str(getattr(et, "value", et))
 
     async with CopilotClient(config) as client:
         async with await client.create_session(**session_kwargs) as session:
@@ -493,11 +485,12 @@ async def run_session(
                 seed_done = asyncio.Event()
 
                 def _on_seed(event):
-                    match event.data:
-                        case AssistantMessageData():
-                            seed_done.set()
-                        case SessionIdleData():
-                            seed_done.set()
+                    et = _event_type(event)
+                    if et in (
+                        SessionEventType.ASSISTANT_MESSAGE.value,
+                        SessionEventType.SESSION_IDLE.value,
+                    ):
+                        seed_done.set()
 
                 unsub_seed = session.on(_on_seed)
                 await session.send(initial_context)
@@ -534,14 +527,19 @@ async def run_session(
                 print("\nAssistant: ", end="", flush=True)
 
                 def on_event(event):
-                    match event.data:
-                        case AssistantMessageDeltaData() as data:
-                            delta = data.delta_content or ""
-                            print(delta, end="", flush=True)
-                        case AssistantMessageData():
-                            print()  # ensure newline after full message
-                        case SessionIdleData():
-                            response_done.set()
+                    et = _event_type(event)
+                    # Support both current "assistant.message_delta" and legacy
+                    # docs/examples that use "assistant.message.delta".
+                    if et in (
+                        SessionEventType.ASSISTANT_MESSAGE_DELTA.value,
+                        "assistant.message.delta",
+                    ):
+                        delta = getattr(event.data, "delta_content", "") or ""
+                        print(delta, end="", flush=True)
+                    elif et == SessionEventType.ASSISTANT_MESSAGE.value:
+                        print()  # ensure newline after full message
+                    elif et == SessionEventType.SESSION_IDLE.value:
+                        response_done.set()
 
                 unsub = session.on(on_event)
                 send_kwargs: dict = {"prompt": user_input}

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -2,32 +2,36 @@
 """GitHub Copilot-backed video editing orchestrator for video-use.
 
 Replaces the `claude` CLI runtime with a standalone Python script that drives
-the same video editing pipeline using the GitHub Copilot API (OpenAI-compatible).
-All 12 hard production rules from SKILL.md are enforced via the same system
-prompt — no logic changes to the skill or helpers are needed.
+the same video editing pipeline using the GitHub Copilot SDK.  The SDK spawns
+the Copilot CLI as a subprocess automatically — no separate CLI install needed.
+
+All 12 hard production rules from SKILL.md are enforced via the system prompt.
+No logic changes to the skill or helpers are required.
 
 Requirements:
-  pip install -e ".[copilot]"          # openai>=1.0
-  export GITHUB_TOKEN=<your PAT>       # PAT with `copilot` scope
-  ELEVENLABS_API_KEY=... in .env       # for transcription (same as before)
+  pip install -e ".[copilot]"          # github-copilot-sdk + pydantic
+  GITHUB_TOKEN=... in .env             # PAT with 'copilot' scope
+    OR  run `copilot auth login` once  # sign in via browser (no token needed)
+  ELEVENLABS_API_KEY=... in .env       # for transcription
   ffmpeg and ffprobe on PATH
 
 Usage:
   python orchestrator.py /path/to/videos
-  python orchestrator.py /path/to/videos --model gpt-4o
-  python orchestrator.py /path/to/videos --endpoint https://models.inference.ai.azure.com
+  python orchestrator.py /path/to/videos --model claude-sonnet-4.5
+  python orchestrator.py /path/to/videos --enable-shell
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import base64
-import json
 import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Optional
 
 # ---------------------------------------------------------------------------
 # Repo-relative paths
@@ -70,283 +74,28 @@ def load_skill_prompt() -> str:
 
 
 # Maximum characters returned from a single tool call before truncation.
-# Keeps large files (packed transcripts, long ffmpeg logs) from consuming
-# the entire context window.
 MAX_TOOL_RESULT_LENGTH = 20_000
 
-# ---------------------------------------------------------------------------
-# Tool schemas (OpenAI function-calling format)
-# ---------------------------------------------------------------------------
-
-TOOLS: list[dict] = [
-    {
-        "type": "function",
-        "function": {
-            "name": "transcribe",
-            "description": (
-                "Transcribe a single video with ElevenLabs Scribe. "
-                "Writes word-level transcript JSON to edit/transcripts/<stem>.json. "
-                "Cached — skips upload if the JSON already exists."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "video_path": {
-                        "type": "string",
-                        "description": "Absolute path to the video file.",
-                    },
-                    "edit_dir": {
-                        "type": "string",
-                        "description": "Edit output directory. Defaults to <video_parent>/edit.",
-                    },
-                    "language": {
-                        "type": "string",
-                        "description": "ISO language code (e.g. 'en'). Omit to auto-detect.",
-                    },
-                    "num_speakers": {
-                        "type": "integer",
-                        "description": "Number of speakers. Improves diarization when known.",
-                    },
-                },
-                "required": ["video_path"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "transcribe_batch",
-            "description": (
-                "Batch-transcribe every video in a directory using parallel workers. "
-                "Cached per source — already-transcribed files are skipped."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "videos_dir": {
-                        "type": "string",
-                        "description": "Directory containing source videos.",
-                    },
-                    "workers": {
-                        "type": "integer",
-                        "description": "Parallel workers (default 4).",
-                    },
-                    "edit_dir": {
-                        "type": "string",
-                        "description": "Override edit output directory.",
-                    },
-                    "num_speakers": {
-                        "type": "integer",
-                        "description": "Number of speakers (optional).",
-                    },
-                },
-                "required": ["videos_dir"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "pack_transcripts",
-            "description": (
-                "Pack all per-source transcript JSONs in edit/transcripts/ into "
-                "takes_packed.md — the primary phrase-level reading surface for cut decisions."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "edit_dir": {
-                        "type": "string",
-                        "description": "Edit output directory containing transcripts/ subdirectory.",
-                    },
-                    "silence_threshold": {
-                        "type": "number",
-                        "description": "Silence gap in seconds that triggers a phrase break (default 0.5).",
-                    },
-                },
-                "required": ["edit_dir"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "timeline_view",
-            "description": (
-                "Generate a filmstrip + waveform PNG for a time range of a video. "
-                "Use at decision points (ambiguous pauses, retake comparison, cut-point "
-                "sanity checks). NOT a scan tool — call only when you need a visual check."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "video_path": {
-                        "type": "string",
-                        "description": "Absolute path to the video file.",
-                    },
-                    "start": {
-                        "type": "number",
-                        "description": "Start time in seconds.",
-                    },
-                    "end": {
-                        "type": "number",
-                        "description": "End time in seconds.",
-                    },
-                    "n_frames": {
-                        "type": "integer",
-                        "description": "Number of filmstrip frames to extract (default 8).",
-                    },
-                    "transcript_path": {
-                        "type": "string",
-                        "description": "Optional path to a transcript JSON for word label overlay.",
-                    },
-                },
-                "required": ["video_path", "start", "end"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "render",
-            "description": (
-                "Render a video from an EDL (edit decision list JSON). "
-                "Runs the full pipeline: per-segment extract with grade + 30ms audio fades → "
-                "lossless concat → overlays (PTS-shifted) → subtitles LAST → loudnorm."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "edl_path": {
-                        "type": "string",
-                        "description": "Absolute path to edl.json.",
-                    },
-                    "output_path": {
-                        "type": "string",
-                        "description": "Output video path (e.g. edit/final.mp4).",
-                    },
-                    "preview": {
-                        "type": "boolean",
-                        "description": "Preview mode: 1080p, CRF 22, faster encode.",
-                    },
-                    "build_subtitles": {
-                        "type": "boolean",
-                        "description": "Build master.srt from transcripts + EDL timeline offsets.",
-                    },
-                    "no_subtitles": {
-                        "type": "boolean",
-                        "description": "Skip subtitles even if the EDL references one.",
-                    },
-                    "no_loudnorm": {
-                        "type": "boolean",
-                        "description": "Skip audio loudness normalization (default: on, -14 LUFS).",
-                    },
-                },
-                "required": ["edl_path", "output_path"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "grade",
-            "description": (
-                "Apply a color grade to a video via ffmpeg filter chain. "
-                "Presets: subtle, neutral_punch, warm_cinematic, none. "
-                "Omit both preset and filter for auto mode (data-driven per-clip correction)."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "input_path": {
-                        "type": "string",
-                        "description": "Input video path.",
-                    },
-                    "output_path": {
-                        "type": "string",
-                        "description": "Output video path.",
-                    },
-                    "preset": {
-                        "type": "string",
-                        "description": "Grade preset name.",
-                        "enum": ["subtle", "neutral_punch", "warm_cinematic", "none"],
-                    },
-                    "filter": {
-                        "type": "string",
-                        "description": "Raw ffmpeg filter string (overrides preset).",
-                    },
-                },
-                "required": ["input_path", "output_path"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "bash",
-            "description": (
-                "Run a shell command. Use for ffprobe, yt-dlp, file listing, "
-                "ffmpeg one-offs, and other system tasks the other tools don't cover."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "description": "Shell command to execute.",
-                    },
-                },
-                "required": ["command"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "read_file",
-            "description": "Read the contents of a text file (takes_packed.md, project.md, edl.json, transcripts, etc.).",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Absolute path to the file.",
-                    },
-                },
-                "required": ["path"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "write_file",
-            "description": "Write or append content to a file (edl.json, project.md, etc.).",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Absolute path to the file.",
-                    },
-                    "content": {
-                        "type": "string",
-                        "description": "Content to write.",
-                    },
-                    "append": {
-                        "type": "boolean",
-                        "description": "If true, append to existing file instead of overwriting.",
-                    },
-                },
-                "required": ["path", "content"],
-            },
-        },
-    },
-]
+# Maximum image size (bytes) to embed; larger images are downscaled first.
+MAX_IMAGE_BYTES = 1_500_000  # 1.5 MB
 
 
 # ---------------------------------------------------------------------------
-# Tool dispatch
+# Path sandbox helper
+# ---------------------------------------------------------------------------
+
+
+def _is_under(path: Path, parent: Path) -> bool:
+    """Return True if *path* is the same as or nested under *parent*."""
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers runner
 # ---------------------------------------------------------------------------
 
 
@@ -367,172 +116,22 @@ def _format_result(returncode: int, stdout: str, stderr: str) -> str:
         parts.append("(no output)" if returncode == 0 else f"[exit {returncode}] (no output)")
     if returncode != 0:
         parts.insert(0, f"[exit code {returncode}]")
-    return "\n".join(parts)
-
-
-def _is_under(path: Path, parent: Path) -> bool:
-    """Return True if *path* is the same as or nested under *parent*."""
-    try:
-        path.relative_to(parent.resolve())
-        return True
-    except ValueError:
-        return False
-
-
-def dispatch_tool(
-    name: str,
-    args: dict,
-    videos_dir: Path,
-    edit_dir: Path,
-    enable_bash: bool = False,
-) -> tuple[str, Path | None]:
-    """Execute a tool call. Returns (result_text, optional_image_path)."""
-
-    if name == "transcribe":
-        video_path = args["video_path"]
-        cmd = [str(HELPERS_DIR / "transcribe.py"), video_path]
-        if args.get("edit_dir"):
-            cmd += ["--edit-dir", args["edit_dir"]]
-        else:
-            cmd += ["--edit-dir", str(edit_dir)]
-        if args.get("language"):
-            cmd += ["--language", args["language"]]
-        if args.get("num_speakers"):
-            cmd += ["--num-speakers", str(args["num_speakers"])]
-        rc, out, err = _run_helper(cmd)
-        return _format_result(rc, out, err), None
-
-    if name == "transcribe_batch":
-        # Always use the session videos_dir to prevent operating outside it
-        cmd = [str(HELPERS_DIR / "transcribe_batch.py"), str(videos_dir)]
-        if args.get("edit_dir"):
-            cmd += ["--edit-dir", args["edit_dir"]]
-        if args.get("workers"):
-            cmd += ["--workers", str(args["workers"])]
-        if args.get("num_speakers"):
-            cmd += ["--num-speakers", str(args["num_speakers"])]
-        rc, out, err = _run_helper(cmd)
-        return _format_result(rc, out, err), None
-
-    if name == "pack_transcripts":
-        cmd = [str(HELPERS_DIR / "pack_transcripts.py"), "--edit-dir", args.get("edit_dir") or str(edit_dir)]
-        if args.get("silence_threshold") is not None:
-            cmd += ["--silence-threshold", str(args["silence_threshold"])]
-        rc, out, err = _run_helper(cmd)
-        return _format_result(rc, out, err), None
-
-    if name == "timeline_view":
-        video_path = Path(args["video_path"])
-        start = args["start"]
-        end = args["end"]
-        verify_dir = edit_dir / "verify"
-        verify_dir.mkdir(parents=True, exist_ok=True)
-        out_img = verify_dir / f"timeline_{video_path.stem}_{start:.2f}_{end:.2f}.png"
-        cmd = [
-            str(HELPERS_DIR / "timeline_view.py"),
-            str(video_path),
-            str(start),
-            str(end),
-            "-o", str(out_img),
-        ]
-        if args.get("n_frames"):
-            cmd += ["--n-frames", str(args["n_frames"])]
-        if args.get("transcript_path"):
-            cmd += ["--transcript", args["transcript_path"]]
-        rc, out, err = _run_helper(cmd)
-        result = _format_result(rc, out, err)
-        if rc == 0 and out_img.exists():
-            result += f"\nImage saved to: {out_img}"
-            return result, out_img
-        return result, None
-
-    if name == "render":
-        cmd = [
-            str(HELPERS_DIR / "render.py"),
-            args["edl_path"],
-            "-o", args["output_path"],
-        ]
-        if args.get("preview"):
-            cmd.append("--preview")
-        if args.get("build_subtitles"):
-            cmd.append("--build-subtitles")
-        if args.get("no_subtitles"):
-            cmd.append("--no-subtitles")
-        if args.get("no_loudnorm"):
-            cmd.append("--no-loudnorm")
-        rc, out, err = _run_helper(cmd)
-        return _format_result(rc, out, err), None
-
-    if name == "grade":
-        cmd = [
-            str(HELPERS_DIR / "grade.py"),
-            args["input_path"],
-            "-o", args["output_path"],
-        ]
-        if args.get("filter"):
-            cmd += ["--filter", args["filter"]]
-        elif args.get("preset"):
-            cmd += ["--preset", args["preset"]]
-        rc, out, err = _run_helper(cmd)
-        return _format_result(rc, out, err), None
-
-    if name == "bash":
-        if not enable_bash:
-            return (
-                "[bash tool is disabled by default. Restart the orchestrator with "
-                "--enable-bash to allow shell commands.]",
-                None,
-            )
-        command = args["command"]
-        proc = subprocess.run(
-            command,
-            shell=True,
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
-        return _format_result(proc.returncode, proc.stdout, proc.stderr), None
-
-    if name == "read_file":
-        path = Path(args["path"]).resolve()
-        if not (_is_under(path, videos_dir) or _is_under(path, edit_dir)):
-            return f"Access denied: path must be under {videos_dir} or {edit_dir}", None
-        if not path.exists():
-            return f"File not found: {path}", None
-        try:
-            return path.read_text(), None
-        except Exception as e:
-            return f"Error reading file: {e}", None
-
-    if name == "write_file":
-        path = Path(args["path"]).resolve()
-        if not _is_under(path, edit_dir):
-            return f"Access denied: write path must be under {edit_dir}", None
-        path.parent.mkdir(parents=True, exist_ok=True)
-        mode = "a" if args.get("append") else "w"
-        try:
-            with open(path, mode) as f:
-                f.write(args["content"])
-            return f"Written to {path}", None
-        except Exception as e:
-            return f"Error writing file: {e}", None
-
-    return f"Unknown tool: {name}", None
+    result = "\n".join(parts)
+    if len(result) > MAX_TOOL_RESULT_LENGTH:
+        result = result[:MAX_TOOL_RESULT_LENGTH] + "\n... [truncated]"
+    return result
 
 
 # ---------------------------------------------------------------------------
-# Session loop
+# Image attachment helper
 # ---------------------------------------------------------------------------
 
 
-# Maximum image size (bytes) to embed in chat; larger images are downscaled first.
-MAX_IMAGE_BYTES = 1_500_000  # 1.5 MB
-
-
-def _build_image_message(img_path: Path) -> dict:
-    """Embed a timeline image as a base64 data URL, downscaling via ffmpeg if needed."""
+def _prepare_image_attachment(img_path: Path) -> dict:
+    """Return a blob attachment dict, downscaling via ffmpeg if > MAX_IMAGE_BYTES."""
     raw = img_path.read_bytes()
     mime = "image/png"
+
     if len(raw) > MAX_IMAGE_BYTES:
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
             tmp_path = Path(tmp.name)
@@ -552,212 +151,397 @@ def _build_image_message(img_path: Path) -> dict:
             pass
         finally:
             tmp_path.unlink(missing_ok=True)
+
     if len(raw) > MAX_IMAGE_BYTES:
-        return {
-            "role": "user",
-            "content": (
-                f"[Timeline image too large to embed ({len(raw):,} bytes); "
-                f"saved to: {img_path}]"
-            ),
-        }
-    b64 = base64.b64encode(raw).decode()
+        return {}  # too large — caller will skip attachment
+
     return {
-        "role": "user",
-        "content": [
-            {"type": "text", "text": f"[Timeline view image: {img_path.name}]"},
-            {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{b64}"}},
-        ],
+        "type": "blob",
+        "data": base64.b64encode(raw).decode(),
+        "mimeType": mime,
     }
 
 
-def run_session(
+# ---------------------------------------------------------------------------
+# Session loop
+# ---------------------------------------------------------------------------
+
+
+async def run_session(
     videos_dir: Path,
     model: str,
-    endpoint: str,
+    enable_shell: bool,
     max_turns: int,
-    enable_bash: bool = False,
 ) -> None:
     try:
-        from openai import OpenAI
+        from copilot import CopilotClient, SubprocessConfig, define_tool
+        from copilot.session import PermissionRequestResult
+        from pydantic import BaseModel, Field
     except ImportError:
         sys.exit(
-            "openai package not found.\n"
+            "Required packages not found.\n"
             "Install with:  pip install -e \".[copilot]\"\n"
-            "or:            pip install openai"
+            "or:            pip install github-copilot-sdk pydantic"
         )
 
     _load_env_file()
-    github_token = os.environ.get("GITHUB_TOKEN", "").strip()
-    if not github_token:
-        sys.exit(
-            "GITHUB_TOKEN is not set.\n"
-            "Export a Personal Access Token with the 'copilot' scope:\n"
-            "  export GITHUB_TOKEN=github_pat_..."
-        )
-
-    client = OpenAI(base_url=endpoint, api_key=github_token)
 
     edit_dir = videos_dir / "edit"
     edit_dir.mkdir(parents=True, exist_ok=True)
 
-    # Build system prompt with working-directory context injected at the end
-    system_prompt = load_skill_prompt()
-    system_prompt += (
-        f"\n\n## Session context\n\n"
+    # ------------------------------------------------------------------
+    # Tool parameter models
+    # ------------------------------------------------------------------
+
+    class TranscribeParams(BaseModel):
+        video_path: str = Field(description="Absolute path to the video file.")
+        language: Optional[str] = Field(default=None, description="ISO language code (e.g. 'en'). Omit to auto-detect.")
+        num_speakers: Optional[int] = Field(default=None, description="Number of speakers for diarization.")
+
+    class TranscribeBatchParams(BaseModel):
+        workers: Optional[int] = Field(default=None, description="Parallel workers (default 4).")
+        num_speakers: Optional[int] = Field(default=None, description="Number of speakers (optional).")
+
+    class PackTranscriptsParams(BaseModel):
+        silence_threshold: Optional[float] = Field(default=None, description="Silence gap in seconds that triggers a phrase break (default 0.5).")
+
+    class TimelineViewParams(BaseModel):
+        video_path: str = Field(description="Absolute path to the video file.")
+        start: float = Field(description="Start time in seconds.")
+        end: float = Field(description="End time in seconds.")
+        n_frames: Optional[int] = Field(default=None, description="Number of filmstrip frames to extract (default 8).")
+        transcript_path: Optional[str] = Field(default=None, description="Optional path to transcript JSON for word label overlay.")
+
+    class RenderParams(BaseModel):
+        edl_path: str = Field(description="Absolute path to edl.json.")
+        output_path: str = Field(description="Output video path (e.g. edit/final.mp4).")
+        preview: Optional[bool] = Field(default=None, description="Preview mode: 1080p, CRF 22, faster encode.")
+        build_subtitles: Optional[bool] = Field(default=None, description="Build master.srt from transcripts + EDL timeline offsets.")
+        no_subtitles: Optional[bool] = Field(default=None, description="Skip subtitles even if the EDL references one.")
+        no_loudnorm: Optional[bool] = Field(default=None, description="Skip audio loudness normalization.")
+
+    class GradeParams(BaseModel):
+        input_path: str = Field(description="Input video path.")
+        output_path: str = Field(description="Output video path.")
+        preset: Optional[str] = Field(default=None, description="Grade preset: subtle, neutral_punch, warm_cinematic, none.")
+        filter: Optional[str] = Field(default=None, description="Raw ffmpeg filter string (overrides preset).")
+
+    # ------------------------------------------------------------------
+    # Tool implementations
+    # ------------------------------------------------------------------
+
+    @define_tool(
+        description=(
+            "Transcribe a single video with ElevenLabs Scribe. "
+            "Writes word-level transcript JSON to edit/transcripts/<stem>.json. "
+            "Cached — skips upload if the JSON already exists."
+        ),
+        skip_permission=True,
+    )
+    async def transcribe(params: TranscribeParams) -> str:
+        cmd = [str(HELPERS_DIR / "transcribe.py"), params.video_path]
+        cmd += ["--edit-dir", str(edit_dir)]
+        if params.language:
+            cmd += ["--language", params.language]
+        if params.num_speakers:
+            cmd += ["--num-speakers", str(params.num_speakers)]
+        rc, out, err = _run_helper(cmd)
+        return _format_result(rc, out, err)
+
+    @define_tool(
+        description=(
+            "Batch-transcribe every video in the session videos directory using parallel workers. "
+            "Cached per source — already-transcribed files are skipped."
+        ),
+        skip_permission=True,
+    )
+    async def transcribe_batch(params: TranscribeBatchParams) -> str:
+        # Always use the session videos_dir — model cannot redirect this elsewhere
+        cmd = [str(HELPERS_DIR / "transcribe_batch.py"), str(videos_dir)]
+        cmd += ["--edit-dir", str(edit_dir)]
+        if params.workers:
+            cmd += ["--workers", str(params.workers)]
+        if params.num_speakers:
+            cmd += ["--num-speakers", str(params.num_speakers)]
+        rc, out, err = _run_helper(cmd)
+        return _format_result(rc, out, err)
+
+    @define_tool(
+        description=(
+            "Pack all per-source transcript JSONs in edit/transcripts/ into "
+            "takes_packed.md — the primary phrase-level reading surface for cut decisions."
+        ),
+        skip_permission=True,
+    )
+    async def pack_transcripts(params: PackTranscriptsParams) -> str:
+        cmd = [str(HELPERS_DIR / "pack_transcripts.py"), "--edit-dir", str(edit_dir)]
+        if params.silence_threshold is not None:
+            cmd += ["--silence-threshold", str(params.silence_threshold)]
+        rc, out, err = _run_helper(cmd)
+        return _format_result(rc, out, err)
+
+    # Side-channel for the last timeline image path so it can be attached in the
+    # next user message (the SDK attachment API goes on session.send, not tool results).
+    _pending_images: list[Path] = []
+
+    @define_tool(
+        description=(
+            "Generate a filmstrip + waveform PNG for a time range of a video. "
+            "Use at decision points (ambiguous pauses, retake comparison, cut-point "
+            "sanity checks). NOT a scan tool — call only when you need a visual check."
+        ),
+        skip_permission=True,
+    )
+    async def timeline_view(params: TimelineViewParams) -> str:
+        video_path = Path(params.video_path)
+        verify_dir = edit_dir / "verify"
+        verify_dir.mkdir(parents=True, exist_ok=True)
+        out_img = verify_dir / f"timeline_{video_path.stem}_{params.start:.2f}_{params.end:.2f}.png"
+        cmd = [
+            str(HELPERS_DIR / "timeline_view.py"),
+            str(video_path),
+            str(params.start),
+            str(params.end),
+            "-o", str(out_img),
+        ]
+        if params.n_frames:
+            cmd += ["--n-frames", str(params.n_frames)]
+        if params.transcript_path:
+            cmd += ["--transcript", params.transcript_path]
+        rc, out, err = _run_helper(cmd)
+        result = _format_result(rc, out, err)
+        if rc == 0 and out_img.exists():
+            _pending_images.append(out_img)
+            result += f"\nImage saved to: {out_img} (will be attached to your next reply)"
+        return result
+
+    @define_tool(
+        description=(
+            "Render a video from an EDL (edit decision list JSON). "
+            "Runs the full pipeline: per-segment extract with grade + 30ms audio fades → "
+            "lossless concat → overlays → subtitles LAST → loudnorm."
+        ),
+        skip_permission=True,
+    )
+    async def render(params: RenderParams) -> str:
+        cmd = [
+            str(HELPERS_DIR / "render.py"),
+            params.edl_path,
+            "-o", params.output_path,
+        ]
+        if params.preview:
+            cmd.append("--preview")
+        if params.build_subtitles:
+            cmd.append("--build-subtitles")
+        if params.no_subtitles:
+            cmd.append("--no-subtitles")
+        if params.no_loudnorm:
+            cmd.append("--no-loudnorm")
+        rc, out, err = _run_helper(cmd)
+        return _format_result(rc, out, err)
+
+    @define_tool(
+        description=(
+            "Apply a color grade to a video via ffmpeg filter chain. "
+            "Presets: subtle, neutral_punch, warm_cinematic, none. "
+            "Omit both preset and filter for auto mode (data-driven per-clip correction)."
+        ),
+        skip_permission=True,
+    )
+    async def grade(params: GradeParams) -> str:
+        cmd = [
+            str(HELPERS_DIR / "grade.py"),
+            params.input_path,
+            "-o", params.output_path,
+        ]
+        if params.filter:
+            cmd += ["--filter", params.filter]
+        elif params.preset:
+            cmd += ["--preset", params.preset]
+        rc, out, err = _run_helper(cmd)
+        return _format_result(rc, out, err)
+
+    # ------------------------------------------------------------------
+    # Permission handler — sandboxes file writes to edit_dir; shell off by default
+    # ------------------------------------------------------------------
+
+    def on_permission_request(request, invocation) -> "PermissionRequestResult":
+        kind = request.kind.value if hasattr(request.kind, "value") else str(request.kind)
+
+        if kind == "shell" and not enable_shell:
+            print(
+                "\n[shell tool blocked — restart with --enable-shell to allow shell commands]",
+                flush=True,
+            )
+            return PermissionRequestResult(kind="denied-interactively-by-user")
+
+        if kind == "write":
+            file_name = getattr(request, "file_name", None) or ""
+            if file_name and not _is_under(Path(file_name), edit_dir):
+                print(f"\n[write blocked — path outside edit_dir: {file_name}]", flush=True)
+                return PermissionRequestResult(kind="denied-by-rules")
+
+        return PermissionRequestResult(kind="approved")
+
+    # ------------------------------------------------------------------
+    # User input handler (enables ask_user tool in the CLI)
+    # ------------------------------------------------------------------
+
+    async def on_user_input_request(request, invocation) -> dict:
+        question = request.get("question", "")
+        choices = request.get("choices")
+        print(f"\nAssistant asks: {question}")
+        if choices:
+            for i, c in enumerate(choices, 1):
+                print(f"  {i}. {c}")
+        try:
+            answer = await asyncio.get_event_loop().run_in_executor(
+                None, lambda: input("Your answer: ").strip()
+            )
+        except (EOFError, KeyboardInterrupt):
+            answer = ""
+        return {"answer": answer, "wasFreeform": True}
+
+    # ------------------------------------------------------------------
+    # Build system prompt
+    # ------------------------------------------------------------------
+
+    system_content = (
+        load_skill_prompt()
+        + f"\n\n## Session context\n\n"
         f"- Videos directory: `{videos_dir}`\n"
         f"- Edit directory: `{edit_dir}`\n"
         f"- Helpers directory: `{HELPERS_DIR}`\n"
         f"- All session outputs must go to `{edit_dir}/` (Hard Rule 12).\n"
     )
 
-    messages: list[dict] = [{"role": "system", "content": system_prompt}]
+    # ------------------------------------------------------------------
+    # Print banner
+    # ------------------------------------------------------------------
 
-    # Seed with prior session memory if available
+    print(f"\nvideo-use — GitHub Copilot SDK orchestrator")
+    print(f"  model:    {model or 'auto (Copilot selects)'}")
+    print(f"  videos:   {videos_dir}")
+    print(f"  shell:    {'enabled' if enable_shell else 'disabled  (--enable-shell to allow)'}")
+    print("Type your message. Enter 'exit' or press Ctrl+C to quit.\n")
+
+    # ------------------------------------------------------------------
+    # Prior session memory
+    # ------------------------------------------------------------------
+
     project_md = edit_dir / "project.md"
+    initial_context: str | None = None
     if project_md.exists():
         prior = project_md.read_text().strip()
         if prior:
-            messages.append({
-                "role": "user",
-                "content": (
-                    f"[Prior session memory — project.md]\n\n{prior}\n\n---\n"
-                    "I'm back. What should we pick up from or start fresh on?"
-                ),
-            })
-            messages.append({
-                "role": "assistant",
-                "content": (
-                    "I've reviewed the session notes above. Ready when you are — "
-                    "just tell me what you'd like to work on."
-                ),
-            })
-
-    print(f"\nvideo-use — GitHub Copilot orchestrator")
-    print(f"  model:    {model}")
-    print(f"  endpoint: {endpoint}")
-    print(f"  videos:   {videos_dir}")
-    print("Type your message. Enter 'exit' or press Ctrl+C to quit.\n")
-
-    # Prompt for the first user message
-    try:
-        first_input = input("You: ").strip()
-    except (EOFError, KeyboardInterrupt):
-        print("\nBye.")
-        return
-
-    if not first_input or first_input.lower() in ("exit", "quit", "q"):
-        print("Bye.")
-        return
-
-    messages.append({"role": "user", "content": first_input})
-
-    turn = 0
-    while turn < max_turns:
-        try:
-            response = client.chat.completions.create(
-                model=model,
-                messages=messages,
-                tools=TOOLS,
-                max_tokens=4096,
+            initial_context = (
+                f"[Prior session memory — project.md]\n\n{prior}\n\n---\n"
+                "I'm back. What should we pick up from or start fresh on?"
             )
-        except KeyboardInterrupt:
-            print("\n[Interrupted]")
-            break
-        except Exception as e:
-            print(f"\n[API error: {e}]")
-            break
 
-        choice = response.choices[0]
-        message = choice.message
+    # ------------------------------------------------------------------
+    # SDK client + session
+    # ------------------------------------------------------------------
 
-        # Serialize the assistant message back into the history
-        msg_dict: dict = {"role": "assistant", "content": message.content}
-        if message.tool_calls:
-            msg_dict["tool_calls"] = [
-                {
-                    "id": tc.id,
-                    "type": "function",
-                    "function": {
-                        "name": tc.function.name,
-                        "arguments": tc.function.arguments,
-                    },
-                }
-                for tc in message.tool_calls
-            ]
-        messages.append(msg_dict)
+    github_token = os.environ.get("GITHUB_TOKEN", "").strip() or None
+    config = SubprocessConfig(
+        cwd=str(videos_dir),
+        github_token=github_token,
+    )
 
-        if message.tool_calls:
-            # Show any explanation the model included alongside the tool calls
-            if message.content:
-                print(f"\nAssistant: {message.content}\n")
+    session_kwargs: dict = dict(
+        on_permission_request=on_permission_request,
+        on_user_input_request=on_user_input_request,
+        tools=[transcribe, transcribe_batch, pack_transcripts, timeline_view, render, grade],
+        system_message={"content": system_content},
+        streaming=True,
+    )
+    if model:
+        session_kwargs["model"] = model
 
-            # Execute every requested tool call
-            image_paths: list[Path] = []
+    try:
+        from copilot.generated.session_events import (
+            AssistantMessageData,
+            AssistantMessageDeltaData,
+            SessionIdleData,
+        )
+    except ImportError:
+        # Older SDK versions may use a different import path
+        from copilot.session_events import (  # type: ignore[no-redef]
+            AssistantMessageData,
+            AssistantMessageDeltaData,
+            SessionIdleData,
+        )
 
-            for tc in message.tool_calls:
-                tool_name = tc.function.name
+    async with CopilotClient(config) as client:
+        async with await client.create_session(**session_kwargs) as session:
+
+            # Seed prior session memory as first user turn
+            if initial_context:
+                seed_done = asyncio.Event()
+
+                def _on_seed(event):
+                    match event.data:
+                        case AssistantMessageData():
+                            seed_done.set()
+                        case SessionIdleData():
+                            seed_done.set()
+
+                unsub_seed = session.on(_on_seed)
+                await session.send(initial_context)
+                await seed_done.wait()
+                unsub_seed()
+                print()
+
+            turn = 0
+            while turn < max_turns:
+                # Collect any pending timeline images
+                attachments: list[dict] = []
+                while _pending_images:
+                    img_path = _pending_images.pop(0)
+                    if img_path.exists():
+                        att = _prepare_image_attachment(img_path)
+                        if att:
+                            attachments.append(att)
+
+                # Prompt user
                 try:
-                    tool_args = json.loads(tc.function.arguments)
-                except json.JSONDecodeError:
-                    messages.append({
-                        "role": "tool",
-                        "tool_call_id": tc.id,
-                        "content": (
-                            f"[Invalid JSON in tool arguments — could not parse. "
-                            f"Raw arguments: {tc.function.arguments!r}. Please retry with valid JSON.]"
-                        ),
-                    })
-                    continue
+                    user_input = await asyncio.get_event_loop().run_in_executor(
+                        None, lambda: input("You: ").strip()
+                    )
+                except (EOFError, KeyboardInterrupt):
+                    print("\nBye.")
+                    break
 
-                # Pretty-print what we're doing
-                args_preview = ", ".join(
-                    f"{k}={v!r}" for k, v in list(tool_args.items())[:3]
-                )
-                print(f"  [tool] {tool_name}({args_preview})", flush=True)
+                if not user_input or user_input.lower() in ("exit", "quit", "q"):
+                    print("Bye.")
+                    break
 
-                result_text, image_path = dispatch_tool(
-                    tool_name, tool_args, videos_dir, edit_dir, enable_bash=enable_bash
-                )
+                # Wait for full response
+                response_done = asyncio.Event()
+                print("\nAssistant: ", end="", flush=True)
 
-                # Truncate very long results so we don't blow the context window
-                if len(result_text) > MAX_TOOL_RESULT_LENGTH:
-                    result_text = result_text[:MAX_TOOL_RESULT_LENGTH] + "\n... [truncated]"
+                def on_event(event):
+                    match event.data:
+                        case AssistantMessageDeltaData() as data:
+                            delta = data.delta_content or ""
+                            print(delta, end="", flush=True)
+                        case AssistantMessageData():
+                            print()  # ensure newline after full message
+                        case SessionIdleData():
+                            response_done.set()
 
-                messages.append({
-                    "role": "tool",
-                    "tool_call_id": tc.id,
-                    "content": result_text,
-                })
+                unsub = session.on(on_event)
+                send_kwargs: dict = {"prompt": user_input}
+                if attachments:
+                    send_kwargs["attachments"] = attachments
 
-                if image_path and image_path.exists():
-                    image_paths.append(image_path)
+                await session.send(**send_kwargs)
+                await response_done.wait()
+                unsub()
+                print()
 
-            # Inject timeline view images as user messages so vision-capable
-            # models (gpt-4o, etc.) can reason about them
-            for img_path in image_paths:
-                messages.append(_build_image_message(img_path))
-
-            turn += 1
-            continue  # Let the model respond to the tool results
-
-        # No tool calls — conversational turn
-        if message.content:
-            print(f"\nAssistant: {message.content}\n")
-
-        if choice.finish_reason == "stop":
-            try:
-                user_input = input("You: ").strip()
-            except (EOFError, KeyboardInterrupt):
-                print("\nBye.")
-                break
-
-            if not user_input or user_input.lower() in ("exit", "quit", "q"):
-                print("Bye.")
-                break
-
-            messages.append({"role": "user", "content": user_input})
-
-        turn += 1
+                turn += 1
 
     if turn >= max_turns:
         print(f"\n[Reached max_turns={max_turns}. Session ended.]")
@@ -770,20 +554,22 @@ def run_session(
 
 def main() -> None:
     ap = argparse.ArgumentParser(
-        description="GitHub Copilot-backed video editing orchestrator for video-use.",
+        description="GitHub Copilot SDK video editing orchestrator for video-use.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
-            "Environment variables:\n"
-            "  GITHUB_TOKEN       Personal Access Token with 'copilot' scope (required)\n"
-            "  ELEVENLABS_API_KEY ElevenLabs API key for transcription (required for transcribe tools)\n"
-            "\nModel options (via GitHub Copilot):\n"
-            "  claude-opus-4-7    Default — Anthropic Claude Opus 4.7, strong reasoning + vision\n"
-            "  claude-sonnet-4-5  Anthropic Claude Sonnet 4.5 — faster, lighter\n"
-            "  gpt-4o             OpenAI GPT-4o — strong reasoning, vision support\n"
-            "  gpt-4o-mini        OpenAI GPT-4o mini — fastest OpenAI option\n"
-            "  o3-mini            OpenAI o3-mini — reasoning model\n"
-            "\nAlternative endpoint (GitHub Models free tier):\n"
-            "  --endpoint https://models.inference.ai.azure.com\n"
+            "Authentication (pick one):\n"
+            "  copilot auth login              Sign in via browser — no token needed\n"
+            "  GITHUB_TOKEN=... in .env        PAT with 'copilot' scope\n"
+            "    https://github.com/settings/tokens\n"
+            "\nModel options (via GitHub Copilot CLI — use /model inside session to switch):\n"
+            "  (omit --model)                  Copilot auto-selects the best model\n"
+            "  claude-opus-4.5                 Anthropic Claude Opus 4.5 — complex tasks\n"
+            "  claude-sonnet-4.5               Anthropic Claude Sonnet 4.5 — faster\n"
+            "  gpt-5                           OpenAI GPT-5\n"
+            "  gpt-4.1                         OpenAI GPT-4.1\n"
+            "\nEnvironment variables:\n"
+            "  GITHUB_TOKEN        PAT with 'copilot' scope (alternative to browser login)\n"
+            "  ELEVENLABS_API_KEY  ElevenLabs API key for transcription\n"
         ),
     )
     ap.add_argument(
@@ -793,32 +579,23 @@ def main() -> None:
     )
     ap.add_argument(
         "--model",
-        default="claude-opus-4-7",
-        help="Model identifier for the Copilot API (default: claude-opus-4-7).",
+        default="",
+        help="Model identifier (default: Copilot auto-selects). Use /model inside session to switch.",
     )
     ap.add_argument(
-        "--endpoint",
-        default="https://api.githubcopilot.com",
+        "--enable-shell",
+        action="store_true",
+        default=False,
         help=(
-            "GitHub Copilot API base URL "
-            "(default: https://api.githubcopilot.com). "
-            "Use https://models.inference.ai.azure.com for GitHub Models."
+            "Enable the built-in shell tool (disabled by default). "
+            "Only enable when you trust the model and understand the security implications."
         ),
     )
     ap.add_argument(
         "--max-turns",
         type=int,
-        default=100,
-        help="Maximum LLM turns before the session ends (default: 100).",
-    )
-    ap.add_argument(
-        "--enable-bash",
-        action="store_true",
-        default=False,
-        help=(
-            "Enable the bash tool (disabled by default). "
-            "Only enable when you trust the model and understand the security implications."
-        ),
+        default=200,
+        help="Maximum interactive turns before the session ends (default: 200).",
     )
     args = ap.parse_args()
 
@@ -826,12 +603,13 @@ def main() -> None:
     if not videos_dir.is_dir():
         sys.exit(f"Not a directory: {videos_dir}")
 
-    run_session(
-        videos_dir=videos_dir,
-        model=args.model,
-        endpoint=args.endpoint,
-        max_turns=args.max_turns,
-        enable_bash=args.enable_bash,
+    asyncio.run(
+        run_session(
+            videos_dir=videos_dir,
+            model=args.model,
+            enable_shell=args.enable_shell,
+            max_turns=args.max_turns,
+        )
     )
 
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -691,10 +691,11 @@ def main() -> None:
             "  GITHUB_TOKEN       Personal Access Token with 'copilot' scope (required)\n"
             "  ELEVENLABS_API_KEY ElevenLabs API key for transcription (required for transcribe tools)\n"
             "\nModel options (via GitHub Copilot):\n"
-            "  gpt-4o             Default — strong reasoning, vision support\n"
-            "  gpt-4o-mini        Faster and lighter\n"
-            "  claude-3.5-sonnet  Anthropic model via Copilot\n"
-            "  o3-mini            Reasoning model\n"
+            "  claude-opus-4-7    Default — Anthropic Claude Opus 4.7, strong reasoning + vision\n"
+            "  claude-sonnet-4-5  Anthropic Claude Sonnet 4.5 — faster, lighter\n"
+            "  gpt-4o             OpenAI GPT-4o — strong reasoning, vision support\n"
+            "  gpt-4o-mini        OpenAI GPT-4o mini — fastest OpenAI option\n"
+            "  o3-mini            OpenAI o3-mini — reasoning model\n"
             "\nAlternative endpoint (GitHub Models free tier):\n"
             "  --endpoint https://models.inference.ai.azure.com\n"
         ),
@@ -706,8 +707,8 @@ def main() -> None:
     )
     ap.add_argument(
         "--model",
-        default="gpt-4o",
-        help="Model identifier for the Copilot API (default: gpt-4o).",
+        default="claude-opus-4-7",
+        help="Model identifier for the Copilot API (default: claude-opus-4-7).",
     )
     ap.add_argument(
         "--endpoint",

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -33,6 +33,15 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
+try:
+    from copilot import CopilotClient, SubprocessConfig, define_tool
+    from copilot.session import PermissionRequestResult
+    from pydantic import BaseModel, Field
+except ImportError:  # deferred error — shown at runtime with a friendly message
+    CopilotClient = SubprocessConfig = define_tool = PermissionRequestResult = None  # type: ignore
+    BaseModel = object  # type: ignore
+    Field = lambda **_: None  # type: ignore
+
 # ---------------------------------------------------------------------------
 # Repo-relative paths
 # ---------------------------------------------------------------------------
@@ -163,6 +172,50 @@ def _prepare_image_attachment(img_path: Path) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Tool parameter models (module-level so get_type_hints() can resolve them)
+# ---------------------------------------------------------------------------
+
+
+class TranscribeParams(BaseModel):
+    video_path: str = Field(description="Absolute path to the video file.")
+    language: Optional[str] = Field(default=None, description="ISO language code (e.g. 'en'). Omit to auto-detect.")
+    num_speakers: Optional[int] = Field(default=None, description="Number of speakers for diarization.")
+
+
+class TranscribeBatchParams(BaseModel):
+    workers: Optional[int] = Field(default=None, description="Parallel workers (default 4).")
+    num_speakers: Optional[int] = Field(default=None, description="Number of speakers (optional).")
+
+
+class PackTranscriptsParams(BaseModel):
+    silence_threshold: Optional[float] = Field(default=None, description="Silence gap in seconds that triggers a phrase break (default 0.5).")
+
+
+class TimelineViewParams(BaseModel):
+    video_path: str = Field(description="Absolute path to the video file.")
+    start: float = Field(description="Start time in seconds.")
+    end: float = Field(description="End time in seconds.")
+    n_frames: Optional[int] = Field(default=None, description="Number of filmstrip frames to extract (default 8).")
+    transcript_path: Optional[str] = Field(default=None, description="Optional path to transcript JSON for word label overlay.")
+
+
+class RenderParams(BaseModel):
+    edl_path: str = Field(description="Absolute path to edl.json.")
+    output_path: str = Field(description="Output video path (e.g. edit/final.mp4).")
+    preview: Optional[bool] = Field(default=None, description="Preview mode: 1080p, CRF 22, faster encode.")
+    build_subtitles: Optional[bool] = Field(default=None, description="Build master.srt from transcripts + EDL timeline offsets.")
+    no_subtitles: Optional[bool] = Field(default=None, description="Skip subtitles even if the EDL references one.")
+    no_loudnorm: Optional[bool] = Field(default=None, description="Skip audio loudness normalization.")
+
+
+class GradeParams(BaseModel):
+    input_path: str = Field(description="Input video path.")
+    output_path: str = Field(description="Output video path.")
+    preset: Optional[str] = Field(default=None, description="Grade preset: subtle, neutral_punch, warm_cinematic, none.")
+    filter: Optional[str] = Field(default=None, description="Raw ffmpeg filter string (overrides preset).")
+
+
+# ---------------------------------------------------------------------------
 # Session loop
 # ---------------------------------------------------------------------------
 
@@ -173,11 +226,7 @@ async def run_session(
     enable_shell: bool,
     max_turns: int,
 ) -> None:
-    try:
-        from copilot import CopilotClient, SubprocessConfig, define_tool
-        from copilot.session import PermissionRequestResult
-        from pydantic import BaseModel, Field
-    except ImportError:
+    if CopilotClient is None:
         sys.exit(
             "Required packages not found.\n"
             "Install with:  pip install -e \".[copilot]\"\n"
@@ -188,43 +237,6 @@ async def run_session(
 
     edit_dir = videos_dir / "edit"
     edit_dir.mkdir(parents=True, exist_ok=True)
-
-    # ------------------------------------------------------------------
-    # Tool parameter models
-    # ------------------------------------------------------------------
-
-    class TranscribeParams(BaseModel):
-        video_path: str = Field(description="Absolute path to the video file.")
-        language: Optional[str] = Field(default=None, description="ISO language code (e.g. 'en'). Omit to auto-detect.")
-        num_speakers: Optional[int] = Field(default=None, description="Number of speakers for diarization.")
-
-    class TranscribeBatchParams(BaseModel):
-        workers: Optional[int] = Field(default=None, description="Parallel workers (default 4).")
-        num_speakers: Optional[int] = Field(default=None, description="Number of speakers (optional).")
-
-    class PackTranscriptsParams(BaseModel):
-        silence_threshold: Optional[float] = Field(default=None, description="Silence gap in seconds that triggers a phrase break (default 0.5).")
-
-    class TimelineViewParams(BaseModel):
-        video_path: str = Field(description="Absolute path to the video file.")
-        start: float = Field(description="Start time in seconds.")
-        end: float = Field(description="End time in seconds.")
-        n_frames: Optional[int] = Field(default=None, description="Number of filmstrip frames to extract (default 8).")
-        transcript_path: Optional[str] = Field(default=None, description="Optional path to transcript JSON for word label overlay.")
-
-    class RenderParams(BaseModel):
-        edl_path: str = Field(description="Absolute path to edl.json.")
-        output_path: str = Field(description="Output video path (e.g. edit/final.mp4).")
-        preview: Optional[bool] = Field(default=None, description="Preview mode: 1080p, CRF 22, faster encode.")
-        build_subtitles: Optional[bool] = Field(default=None, description="Build master.srt from transcripts + EDL timeline offsets.")
-        no_subtitles: Optional[bool] = Field(default=None, description="Skip subtitles even if the EDL references one.")
-        no_loudnorm: Optional[bool] = Field(default=None, description="Skip audio loudness normalization.")
-
-    class GradeParams(BaseModel):
-        input_path: str = Field(description="Input video path.")
-        output_path: str = Field(description="Output video path.")
-        preset: Optional[str] = Field(default=None, description="Grade preset: subtle, neutral_punch, warm_cinematic, none.")
-        filter: Optional[str] = Field(default=None, description="Raw ffmpeg filter string (overrides preset).")
 
     # ------------------------------------------------------------------
     # Tool implementations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 
 [project.optional-dependencies]
 animations = ["manim"]
+copilot = ["openai>=1.0"]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 
 [project.optional-dependencies]
 animations = ["manim"]
-copilot = ["openai>=1.0"]
+copilot = ["github-copilot-sdk", "pydantic>=2.0"]
 
 [build-system]
 requires = ["setuptools>=61.0"]


### PR DESCRIPTION
Because I primarily use Github Copilot subscription, I thought supporting Copilot enhances availability for those who uses copilot on daily basis.

This pull request adds support for using GitHub Copilot as an alternative backend to Anthropic Claude for running the video processing pipeline. It introduces new setup instructions, configuration options, and dependencies to make it easy to use your GitHub Copilot subscription instead of an Anthropic API key.

**Copilot integration and setup:**

* Added instructions to the `README.md` for running the pipeline with GitHub Copilot, including authentication steps, dependency installation, and usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R100)
* Updated `.env.example` to include a `GITHUB_TOKEN` variable with detailed setup notes for Copilot authentication, supporting both browser login and Personal Access Token methods.
* Added a new optional dependency group `copilot` in `pyproject.toml` for installing `github-copilot-sdk` and `pydantic`, required for Copilot integration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Copilot–powered orchestrator that runs the same video-editing pipeline without an Anthropic key. Migrates to the `github-copilot-sdk`, adds safer tooling, and updates docs for Copilot setup.

- New Features
  - New `orchestrator.py` built on `github-copilot-sdk` with streaming sessions and `/model` switching.
  - Tools via `@define_tool`: transcribe, batch transcribe, pack transcripts, timeline view (image attachments), render, grade.
  - Safer runtime: shell disabled by default (`--enable-shell` to opt in), file writes sandboxed to `edit/`, path traversal blocked.
  - QoL: auto-load `.env`, downscale timeline images, seed context from `edit/project.md`, lock batch ops to session directories.
  - Docs/config: README adds Copilot setup; `.env.example` documents `GITHUB_TOKEN`.

- Migration
  - Install: `pip install -e ".[copilot]"` (adds `github-copilot-sdk`, `pydantic`); install `ffmpeg` (and `yt-dlp` if needed).
  - Auth: `copilot auth login` (recommended) or set `GITHUB_TOKEN` (scope: copilot) and `ELEVENLABS_API_KEY` in `.env`.
  - Run: `python orchestrator.py /path/to/videos` (optional: `--model`, `--enable-shell`, `--max-turns`). Copilot auto-selects a model by default.

<sup>Written for commit 8e57814b79d51734f2910cb28aed14aec0cf17b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

