### PR TITLE
add install.md and one-paste setup prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,29 +18,23 @@ Drop raw footage in a folder, chat with Claude Code, get `final.mp4` back. Works
 - **Self-evaluates the rendered output** at every cut boundary before showing you anything
 - **Persists session memory** in `project.md` so next week's session picks up where you left off
 
-## Get started
+## Setup prompt
 
-```bash
-# 1. Clone and symlink into Claude Code's skills directory
-git clone https://github.com/browser-use/video-use
-cd video-use
-ln -s "$(pwd)" ~/.claude/skills/video-use
+Paste into Claude Code, Codex, Hermes, Openclaw, or any agent with shell access:
 
-# 2. Install deps
-pip install -e .
-brew install ffmpeg           # required
-brew install yt-dlp            # optional, for downloading online sources
+```text
+Set up https://github.com/browser-use/video-use for me.
 
-# 3. Add your ElevenLabs API key
-cp .env.example .env
-$EDITOR .env                   # ELEVENLABS_API_KEY=...
+Read install.md first to install this repo, wire up ffmpeg, register the skill with whichever agent you're running under, and set up the ElevenLabs API key — ask me to paste it when you need it. Then read SKILL.md for daily usage, and always read helpers/ because that's where the editing scripts live. After install, don't transcribe anything on your own — just tell me it's ready and wait for me to drop footage into a folder.
 ```
 
-Then point Claude Code at a folder of raw takes:
+The agent handles the clone, dependencies, skill registration, and prompts you once for your ElevenLabs API key (grab one at [elevenlabs.io/app/settings/api-keys](https://elevenlabs.io/app/settings/api-keys)).
+
+Then point your agent at a folder of raw takes:
 
 ```bash
 cd /path/to/your/videos
-claude
+claude    # or codex, hermes, etc.
 ```
 
 And in the session:
@@ -48,6 +42,27 @@ And in the session:
 > edit these into a launch video
 
 It inventories the sources, proposes a strategy, waits for your OK, then produces `edit/final.mp4` next to your sources. All outputs live in `<videos_dir>/edit/` — the skill directory stays clean.
+
+## Manual install
+
+If you'd rather do it by hand:
+
+```bash
+# 1. Clone and symlink into your agent's skills directory
+git clone https://github.com/browser-use/video-use ~/Developer/video-use
+ln -sfn ~/Developer/video-use ~/.claude/skills/video-use        # Claude Code
+# ln -sfn ~/Developer/video-use ~/.codex/skills/video-use       # Codex
+
+# 2. Install deps
+cd ~/Developer/video-use
+uv sync                         # or: pip install -e .
+brew install ffmpeg             # required
+brew install yt-dlp             # optional, for downloading online sources
+
+# 3. Add your ElevenLabs API key
+cp .env.example .env
+$EDITOR .env                    # ELEVENLABS_API_KEY=...
+```
 
 ## How it works
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -57,11 +57,15 @@ The skill lives in `video-use/`. User footage lives wherever they put it. All se
 
 ## Setup
 
-- `ELEVENLABS_API_KEY` in `.env` at project root or env. Ask and write `.env` if missing.
+First-time install lives in `install.md` (clone, deps, ffmpeg, skill registration, API key). Don't re-run it every session; on cold start just verify:
+
+- `ELEVENLABS_API_KEY` resolves — either in the environment or in `.env` at the video-use repo root. If missing, ask the user to paste one and write it to `.env` (never to the user's `<videos_dir>`).
 - `ffmpeg` + `ffprobe` on PATH.
-- Python deps: `pip install -e .`.
+- Python deps installed (`uv sync` or `pip install -e .` inside the repo).
 - `yt-dlp`, `manim`, Remotion installed only on first use.
 - This skill vendors `skills/manim-video/`. Read its SKILL.md when building a Manim slot.
+
+Helpers (`helpers/transcribe.py`, `helpers/render.py`, etc.) live alongside this SKILL.md. Resolve their paths relative to the directory containing this file — the skill is typically symlinked at `~/.claude/skills/video-use/` or `~/.codex/skills/video-use/`.
 
 ## Helpers
 

--- a/install.md
+++ b/install.md
@@ -1,0 +1,160 @@
+---
+name: video-use-install
+description: Install video-use into the current agent (Claude Code, Codex, Hermes, Openclaw, etc.) and wire up ffmpeg + the ElevenLabs API key so the user can start editing immediately.
+---
+
+# video-use install
+
+Use this file only for first-time install or reconnect. For daily editing, read `SKILL.md`. Always read `helpers/` — that's where the scripts live.
+
+## What you're doing
+
+You're setting up a conversation-driven video editor for the user. After install, the user drops raw footage into any folder, runs their agent (`claude`, `codex`, etc.) there, and says "edit these into a launch video." You do the rest by reading `SKILL.md`.
+
+Three things must exist on this machine:
+
+1. The `video-use` repo cloned somewhere stable.
+2. `ffmpeg` on `$PATH` (plus optional `yt-dlp` for online sources).
+3. An ElevenLabs API key in `.env` at the repo root (for Scribe transcription).
+
+And one thing must be true about the current agent:
+
+4. It can discover `SKILL.md` — either via a global skills directory (`~/.claude/skills/`, `~/.codex/skills/`) or via a `CLAUDE.md` / system-prompt import.
+
+## Install prompt contract
+
+- Do everything yourself. Only ask the user for things you cannot generate — the ElevenLabs API key, and confirmation before `brew install`.
+- Prefer a stable clone path like `~/Developer/video-use` (not `/tmp`, not `~/Downloads`).
+- The skill references helpers by bare name (`transcribe.py`, `render.py`). That works because SKILL.md and `helpers/` ship together — keep them as siblings when you register the skill.
+- After install, verify by running one real command against one real file. Don't declare success on file-existence checks alone.
+
+## Steps
+
+### 1. Clone to a stable path
+
+```bash
+test -d ~/Developer/video-use || git clone https://github.com/browser-use/video-use ~/Developer/video-use
+cd ~/Developer/video-use
+```
+
+If the repo is already there, `git pull --ff-only` and continue.
+
+### 2. Install Python deps
+
+```bash
+# Prefer uv if available; fall back to pip.
+command -v uv >/dev/null && uv sync || pip install -e .
+```
+
+`pyproject.toml` lists `requests`, `librosa`, `matplotlib`, `pillow`, `numpy`. No console scripts — helpers are invoked directly as `python helpers/<name>.py`.
+
+### 3. Install ffmpeg (+ optional yt-dlp)
+
+`ffmpeg` and `ffprobe` are hard requirements. `yt-dlp` is only needed if the user wants to pull sources from URLs.
+
+```bash
+# macOS
+command -v ffmpeg >/dev/null || brew install ffmpeg
+command -v yt-dlp >/dev/null || brew install yt-dlp     # optional
+
+# Debian / Ubuntu
+# sudo apt-get update && sudo apt-get install -y ffmpeg
+# pip install yt-dlp
+
+# Arch
+# sudo pacman -S ffmpeg yt-dlp
+```
+
+If `brew` / `apt` / `pacman` requires a sudo prompt, tell the user the exact command and wait. Do not invent a password.
+
+### 4. Register the skill with the current agent
+
+Figure out which agent you are running under, and register once. A symlink of the whole repo directory is the right shape — helpers/ needs to sit next to SKILL.md.
+
+- **Claude Code** (`~/.claude/` present):
+
+    ```bash
+    mkdir -p ~/.claude/skills
+    ln -sfn ~/Developer/video-use ~/.claude/skills/video-use
+    ```
+
+- **Codex** (`$CODEX_HOME` set, or `~/.codex/` present):
+
+    ```bash
+    mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+    ln -sfn ~/Developer/video-use "${CODEX_HOME:-$HOME/.codex}/skills/video-use"
+    ```
+
+- **Hermes / Openclaw / another agent with a skills directory**: symlink `~/Developer/video-use` into that agent's skills directory under the name `video-use`. If the agent has no skills directory, add a line to its system prompt / config pointing at `~/Developer/video-use/SKILL.md` (e.g. an `@~/Developer/video-use/SKILL.md` import in a `CLAUDE.md`-equivalent).
+
+If you can't tell which agent you're in, ask the user once: "which agent am I running under — Claude Code, Codex, or something else?" Then pick the right target.
+
+### 5. ElevenLabs API key
+
+Scribe (ElevenLabs) does all transcription. Without a key, nothing transcribes.
+
+1. Check existing state in this order and stop at the first hit:
+
+    ```bash
+    # a) env var already exported
+    [ -n "$ELEVENLABS_API_KEY" ] && echo "env"
+    # b) .env at repo root already has it
+    grep -q '^ELEVENLABS_API_KEY=..' ~/Developer/video-use/.env 2>/dev/null && echo "dotenv"
+    ```
+
+2. If neither is set, ask the user exactly once:
+
+    > I need an ElevenLabs API key for transcription (word-level timestamps, speaker diarization, filler tagging). Grab one at https://elevenlabs.io/app/settings/api-keys and paste it here — I'll write it to `~/Developer/video-use/.env`. Or if you already have it exported as `ELEVENLABS_API_KEY`, say "use env" and I'll skip.
+
+    When the user pastes a key, write it to `~/Developer/video-use/.env`:
+
+    ```bash
+    printf 'ELEVENLABS_API_KEY=%s\n' "$KEY" > ~/Developer/video-use/.env
+    chmod 600 ~/Developer/video-use/.env
+    ```
+
+    Never echo the key back in tool output. Never commit `.env`.
+
+3. Sanity check with a cheap, quota-free call:
+
+    ```bash
+    curl -s -o /dev/null -w '%{http_code}\n' \
+      -H "xi-api-key: $(sed -n 's/^ELEVENLABS_API_KEY=//p' ~/Developer/video-use/.env)" \
+      https://api.elevenlabs.io/v1/user
+    ```
+
+    `200` means the key works. `401` means the user pasted a wrong/expired key — ask once more and stop. Anything else (network, 5xx), move on and verify during first real transcription.
+
+### 6. Verify end-to-end
+
+Run one real thing. Prefer the lightest verification that still proves the pipeline is wired up:
+
+```bash
+python ~/Developer/video-use/helpers/timeline_view.py --help >/dev/null && echo "helpers OK"
+ffprobe -version | head -1
+```
+
+Full transcription test is optional at install time — it burns Scribe credits. Better to wait until the user hands you their first clip.
+
+### 7. Hand off
+
+Tell the user, in one short message:
+
+- Where the skill is installed (`~/Developer/video-use`).
+- That they should `cd` into their footage folder and start their agent there (e.g. `claude`).
+- That a good first message is: *"edit these into a launch video"* or *"inventory these takes and propose a strategy."*
+- That all outputs land in `<videos_dir>/edit/` — the repo stays clean.
+
+## Keeping the skill current
+
+- `cd ~/Developer/video-use && git pull --ff-only` pulls the latest code. The symlink auto-picks it up on the next run.
+- If `pyproject.toml` changed deps, re-run `uv sync` / `pip install -e .` after pulling.
+
+## Cold-start reminders
+
+- Symlink the **whole directory**, not just `SKILL.md`. The helpers need to sit next to it.
+- If `.env` exists but the key is empty, treat it the same as missing — don't assume existence means validity.
+- `ffmpeg` from static builds works fine. Any modern (≥ 4.x) build is enough.
+- `yt-dlp` is optional. Don't block install on it; install lazily the first time a user asks to pull from a URL.
+- Never run transcription as part of install verification unless the user explicitly asks — Scribe costs real money.
+- If the user is on Linux without a package manager Claude recognizes, print the manual `ffmpeg` install URL and wait rather than guessing.


### PR DESCRIPTION
## Summary
- Add `install.md` so a single pasted prompt installs video-use into Claude Code, Codex, Hermes, Openclaw, etc. (mirrors the harnesless onboarding model).
- Add a `## Setup prompt` section at the top of the README with the paste block; keep the old shell steps under `## Manual install`.
- Point `SKILL.md` at `install.md` for cold-install, and note that helpers paths resolve relative to `SKILL.md`.

The ElevenLabs API key is the one piece that can't be auto-generated — the install flow asks the user to paste it once (with the `elevenlabs.io/app/settings/api-keys` link), writes it to `.env` at `chmod 600`, and sanity-checks with a free `GET /v1/user` call before burning Scribe credits.

## Test plan
- [ ] Paste the README setup prompt into a fresh Claude Code session in an empty directory and confirm the agent clones, installs deps, symlinks into `~/.claude/skills/video-use`, and prompts for the ElevenLabs key.
- [ ] Same flow in Codex — symlink should land in `${CODEX_HOME:-~/.codex}/skills/video-use`.
- [ ] `ffprobe -version` works post-install and `python helpers/timeline_view.py --help` runs.
- [ ] Start a session in a folder with raw takes and confirm the existing end-to-end edit flow still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-paste setup flow and a new `install.md` to automate installing `video-use` across Claude Code, Codex, Hermes, and Openclaw. README now starts with a "Setup prompt"; `SKILL.md` points to `install.md` and clarifies helper paths.

- **New Features**
  - Added `install.md` that handles clone, Python deps (`uv` or `pip`), `ffmpeg` (+ optional `yt-dlp`), agent skill registration, and the ElevenLabs key. Writes the key to `.env` with `chmod 600` and verifies via a free `GET /v1/user`.
  - Updated `README` with a single pasteable "Setup prompt" and moved shell steps under `Manual install`.
  - Updated `SKILL.md` to direct cold installs to `install.md`, confirm `ELEVENLABS_API_KEY` and `ffmpeg/ffprobe`, and note that helpers resolve relative to `SKILL.md` (e.g., `helpers/timeline_view.py`).

<sup>Written for commit 7961e084531f072dced4eeff2e6a9461784e77e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

