### PR TITLE
fix(pack_transcripts): write output as UTF-8 to fix Windows encoding error

### DIFF
--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -192,7 +192,7 @@ def main() -> None:
     markdown = render_markdown(entries, args.silence_threshold)
 
     out_path = args.output or (edit_dir / "takes_packed.md")
-    out_path.write_text(markdown)
+    out_path.write_text(markdown, encoding="utf-8")
 
     total_phrases = sum(len(e[2]) for e in entries)
     total_duration = sum(e[1] for e in entries)


### PR DESCRIPTION
## Summary

- `Path.write_text()` in `pack_transcripts.py` was called without an explicit encoding, which defaults to the system locale on Windows (cp1252)
- cp1252 cannot encode the Unicode characters used in the output (e.g. `≥` U+2265 in the header comment, `→` U+2192 in the print statement)
- This caused an unhandled `UnicodeEncodeError` crash on every Windows run

## Fix

Pass `encoding="utf-8"` to `Path.write_text()` — one character change, consistent across all platforms.

## Test

Reproduced the crash on Windows 11 with Python 3.13, confirmed fix resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Write packed transcript output as UTF-8 to prevent UnicodeEncodeError on Windows where the default cp1252 can’t encode symbols.
Adds encoding="utf-8" to Path.write_text() for consistent cross‑platform writes.

<sup>Written for commit 32bfbbe485a774e465099727e7cc6e3e1ede5521. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

