### PR TITLE
docs: add HyperFrames animation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Drop raw footage in a folder, chat with Claude Code, get `final.mp4` back. Works
 - **Auto color grades** every segment (warm cinematic, neutral punch, or any custom ffmpeg chain)
 - **30ms audio fades** at every cut so you never hear a pop
 - **Burns subtitles** in your style — 2-word UPPERCASE chunks by default, fully customizable
-- **Generates animation overlays** via [Manim](https://www.manim.community/), [Remotion](https://www.remotion.dev/), or PIL — spawned in parallel sub-agents, one per animation
+- **Generates animation overlays** via [HyperFrames](https://github.com/heygen-com/hyperframes), [Remotion](https://www.remotion.dev/), [Manim](https://www.manim.community/), or PIL — spawned in parallel sub-agents, one per animation
 - **Self-evaluates the rendered output** at every cut boundary before showing you anything
 - **Persists session memory** in `project.md` so next week's session picks up where you left off
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -62,7 +62,9 @@ First-time install lives in `install.md` (clone, deps, ffmpeg, skill registratio
 - `ELEVENLABS_API_KEY` resolves — either in the environment or in `.env` at the video-use repo root. If missing, ask the user to paste one and write it to `.env` (never to the user's `<videos_dir>`).
 - `ffmpeg` + `ffprobe` on PATH.
 - Python deps installed (`uv sync` or `pip install -e .` inside the repo).
-- `yt-dlp`, `manim`, Remotion installed only on first use.
+- Node.js + npm available if the session needs HyperFrames or Remotion slots. HyperFrames currently requires Node.js 22+.
+- `yt-dlp`, HyperFrames, Remotion, Manim installed only on first use.
+- First-use animation setup happens inside the slot directory, never at the video-use repo root. HyperFrames can be invoked with `npx --yes hyperframes ...`; Remotion can be scaffolded with `npx create-video@latest` or installed as a project-local dependency before using its `remotion render` command.
 - This skill vendors `skills/manim-video/`. Read its SKILL.md when building a Manim slot.
 
 Helpers (`helpers/transcribe.py`, `helpers/render.py`, etc.) live alongside this SKILL.md. Resolve their paths relative to the directory containing this file — the skill is typically symlinked at `~/.claude/skills/video-use/` or `~/.codex/skills/video-use/`.
@@ -198,11 +200,18 @@ Animations match the content and the brand. **Get the palette, font, and visual 
 
 **Tool options:**
 
-- **PIL + PNG sequence + ffmpeg** — simple overlay cards: counters, typewriter text, single bar reveals, progressive draws. Fast to iterate, any aesthetic you want. The launch video used this.
-- **Manim** — formal diagrams, state machines, equation derivations, graph morphs. Read `skills/manim-video/SKILL.md` and its references for depth.
-- **Remotion** — typography-heavy, brand-aligned, web-adjacent layouts. React/CSS-based.
+Pick the engine per animation slot. Do not default to Remotion just because the animation is web-adjacent.
 
-None is mandatory. Invent hybrids if useful (e.g., PIL background with a Remotion layer on top).
+- **HyperFrames** — Browser-native HTML/CSS/GSAP video compositions: product UI motion, website-to-video or mockup-to-video captures, kinetic typography, landing-page/storyboard promos, data-driven UI states, transparent WebM overlays, and clips that need deterministic frame capture plus HyperFrames lint/validate/render checks. Best when the animation should be authored and verified like a web composition instead of a React component tree.
+- **Remotion** — React/CSS compositions with component state, reusable React primitives, or an existing Remotion brand system. Best when the user specifically asks for React/Remotion or when React composition is the simpler authoring model.
+- **Manim** — formal diagrams, state machines, equation derivations, graph morphs. Read `skills/manim-video/SKILL.md` and its references for depth.
+- **PIL + PNG sequence + ffmpeg** — simple overlay cards: counters, typewriter text, single bar reveals, progressive draws. Fast to iterate, any aesthetic you want. The launch video used this.
+
+For HyperFrames slots, scaffold the slot inside `edit/animations/slot_<id>/` with `npx --yes hyperframes init . --example blank --non-interactive --skip-skills`, build the HTML composition there, run the HyperFrames checks that fit the slot (`lint`, `validate`, and a draft render when practical), then produce the final overlay video with `npx --yes hyperframes render . -o render.mp4` or `--format webm -o render.webm` when alpha is required. Point the EDL overlay `file` at the actual rendered path.
+
+For Remotion slots, keep the Remotion project isolated inside the same slot directory, scaffold with `npx create-video@latest` or install Remotion locally there, render the composition to `render.mp4` with the project-local `remotion render` command, and verify duration and dimensions with `ffprobe`.
+
+None is mandatory. Invent hybrids if useful (e.g., PIL background with a HyperFrames or Remotion layer on top).
 
 **Duration rules of thumb, context-dependent:**
 

--- a/install.md
+++ b/install.md
@@ -50,7 +50,7 @@ command -v uv >/dev/null && uv sync || pip install -e .
 
 ### 3. Install ffmpeg (+ optional yt-dlp)
 
-`ffmpeg` and `ffprobe` are hard requirements. `yt-dlp` is only needed if the user wants to pull sources from URLs.
+`ffmpeg` and `ffprobe` are hard requirements. `yt-dlp` is only needed if the user wants to pull sources from URLs. Animation engines such as HyperFrames, Remotion, and Manim are installed lazily the first time a project actually needs them.
 
 ```bash
 # macOS
@@ -156,5 +156,7 @@ Tell the user, in one short message:
 - If `.env` exists but the key is empty, treat it the same as missing — don't assume existence means validity.
 - `ffmpeg` from static builds works fine. Any modern (≥ 4.x) build is enough.
 - `yt-dlp` is optional. Don't block install on it; install lazily the first time a user asks to pull from a URL.
+- Node.js/npm are only needed for HyperFrames or Remotion slots. HyperFrames currently requires Node.js 22+.
+- HyperFrames, Remotion, and Manim are optional animation engines. Don't install or prefer one globally during setup; pick the engine per animation slot in `SKILL.md`. HyperFrames can run through `npx --yes hyperframes ...` in the slot directory. Remotion can be scaffolded with `npx create-video@latest` or installed inside the slot before rendering.
 - Never run transcription as part of install verification unless the user explicitly asks — Scribe costs real money.
 - If the user is on Linux without a package manager Claude recognizes, print the manual `ffmpeg` install URL and wait rather than guessing.


### PR DESCRIPTION
## Problem

`video-use` tells agents to build animation overlays, but the skill guidance only named Remotion as the web-style animation option. That makes agents likely to pick Remotion by default for browser-authored overlays even when HyperFrames is the better fit for browser-native HTML/CSS/GSAP video compositions.

## What this fixes

This PR adds HyperFrames as a first-class animation engine alongside Remotion, Manim, and PIL:

- updates the README feature list to name HyperFrames as an overlay option
- changes the skill instructions to pick the animation engine per slot instead of defaulting to Remotion for web-adjacent work
- documents stronger HyperFrames use cases: product UI motion, website-to-video or mockup-to-video captures, kinetic typography, landing-page/storyboard promos, data-driven UI states, transparent WebM overlays, deterministic frame capture, and HyperFrames lint/validate/render workflows
- keeps Remotion available for React/component-state/brand-system compositions with project-local setup guidance
- adds HyperFrames slot workflow guidance for `init`, `lint`, `validate`, MP4 render, and transparent WebM render
- clarifies lazy optional engine setup, including Node/npm and HyperFrames' Node.js 22+ requirement

## Why

HyperFrames and Remotion overlap at the high level, but they are not interchangeable authoring models. HyperFrames should be easy for an agent to choose when the animation should be authored and verified like a web composition: browser timeline, DOM/CSS/GSAP motion, transparent overlay output, and deterministic checks.

Remotion remains the better fit when the composition is naturally React-driven, depends on component state, or already has Remotion primitives. The skill should make that choice explicit without turning either engine into the global default.

## Verification

### Local checks

- `git diff --check`
- `python3 helpers/timeline_view.py --help`
- `python3 helpers/render.py --help`
- `python3 -m compileall helpers`
- `npx --yes hyperframes init --help`
- `npx --yes hyperframes validate --help`
- `npx --yes hyperframes render --help`
- `npm view create-video bin version --json`
- `npm view hyperframes engines --json`

### Browser verification

Verified the user-visible docs/skill flow in a browser:

- opened the updated README and confirmed HyperFrames appears alongside Remotion, Manim, and PIL
- opened `SKILL.md` and confirmed the animation section includes the stronger HyperFrames use cases, Remotion selection criteria, concrete first-use commands, and Node/npm setup notes
- saved local proof artifacts under `/tmp/video-use-hyperframes-option/`

### Independent validation

Used unbiased subagents to review the diff for engine-selection bias:

- first pass confirmed HyperFrames was first-class and Remotion remained fairly described, but flagged missing first-use setup guidance
- after adding concrete first-use commands and Node/npm prerequisites, final pass returned `PASS` with no remaining findings

## Notes

- this intentionally does not add global Node dependencies to `video-use`; animation engines stay lazy and slot-local
- upstream push to `browser-use/video-use` is not available from this account, so this PR is opened from the fork branch
