### PR TITLE
fix(render): preserve vertical aspect when source is portrait

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -154,10 +154,21 @@ def extract_segment(
     """
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
+    probe = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "stream=width,height",
+         "-of", "csv=p=0:s=x", str(source)],
+        capture_output=True, text=True,
+    )
+    try:
+        sw, sh = (int(x) for x in probe.stdout.strip().split("x")[:2])
+        is_vertical = sh > sw
+    except Exception:
+        is_vertical = False
     if draft:
-        scale = "scale=1280:-2"
+        scale = "scale=-2:1280" if is_vertical else "scale=1280:-2"
     else:
-        scale = "scale=1920:-2"
+        scale = "scale=-2:1920" if is_vertical else "scale=1920:-2"
 
     vf_parts: list[str] = []
     if is_hdr_source(source):


### PR DESCRIPTION
## Problem

`extract_segment` in `helpers/render.py` hardcodes the scale filter to width-anchored:

```python
if draft:
    scale = "scale=1280:-2"
else:
    scale = "scale=1920:-2"
```

This assumes a landscape source. When the source is portrait (e.g. a phone capture at 1080x1920), the filter upscales width to 1920 and `-2` derives height to keep the aspect — producing **1920x3414** output instead of the expected 1080x1920.

This conflicts with the documented vertical social target in `SKILL.md`:

> Common targets: ... `1080×1920@30` vertical social

## Reproduction

1. Source: 1080x1920 @ 60fps h264 (any iPhone/Android vertical capture)
2. Build a single-range EDL pointing at it
3. `python helpers/render.py edl.json -o final.mp4`
4. `ffprobe final.mp4` → `width=1920, height=3414`

## Fix

Probe the source's `width,height` once and pick the scale axis from orientation:

- portrait (height > width): `scale=-2:1920` (or `-2:1280` for draft)
- landscape: unchanged (`scale=1920:-2` / `scale=1280:-2`)

13 lines added in `extract_segment`, no behavior change for landscape sources.

Verified on a 1080x1920 70s clip: output is now 1080x1920 @ 24fps as expected, matching the documented spec.

## Notes

Found while running video-use end-to-end on Windows with a vertical phone capture as part of normal usage — not synthesized for the PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scaling for portrait sources so exported video keeps the correct vertical aspect. Portrait clips now render as 1080x1920 in final and 720x1280 in draft, matching the `SKILL.md` vertical social target.

- **Bug Fixes**
  - Detects orientation via `ffprobe` (reads `width,height`).
  - Applies `scale=-2:1920` (or `-2:1280` in draft) for portrait; keeps `1920:-2`/`1280:-2` for landscape.
  - Prevents over-tall outputs like 1920x3414; no change for landscape sources.

<sup>Written for commit d0b698984967190eb02f92ea476c55171d945704. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/video-use/pull/23?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

