### PR TITLE
feat: add --fps option to render.py (default 24)

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -142,6 +142,7 @@ def extract_segment(
     out_path: Path,
     preview: bool = False,
     draft: bool = False,
+    fps: int = 24,
 ) -> None:
     """Extract a cut range as its own MP4 with grade + 30ms audio fades baked in.
 
@@ -151,6 +152,9 @@ def extract_segment(
       - final (default): 1080p libx264 fast CRF 20
       - preview:         1080p libx264 medium CRF 22 (evaluable for QC)
       - draft:           720p libx264 ultrafast CRF 28 (cut-point check only)
+
+    fps: output frame rate (default 24 cinematic). Override for 60fps
+    screen-capture or other source-matched rates.
     """
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -186,7 +190,7 @@ def extract_segment(
         "-vf", vf,
         "-af", af,
         "-c:v", "libx264", "-preset", preset, "-crf", crf,
-        "-pix_fmt", "yuv420p", "-r", "24",
+        "-pix_fmt", "yuv420p", "-r", str(fps),
         "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
         "-movflags", "+faststart",
         str(out_path),
@@ -199,6 +203,7 @@ def extract_all_segments(
     edit_dir: Path,
     preview: bool,
     draft: bool = False,
+    fps: int = 24,
 ) -> list[Path]:
     """Extract every EDL range into edit_dir/clips_graded/seg_NN.mp4.
     Returns the ordered list of segment paths.
@@ -238,7 +243,7 @@ def extract_all_segments(
         print(f"  [{i:02d}] {src_name}  {start:7.2f}-{end:7.2f}  ({duration:5.2f}s)  {note}")
         if is_auto:
             print(f"        grade: {seg_filter or '(none)'}")
-        extract_segment(src_path, start, duration, seg_filter, out_path, preview=preview, draft=draft)
+        extract_segment(src_path, start, duration, seg_filter, out_path, preview=preview, draft=draft, fps=fps)
         seg_paths.append(out_path)
 
     return seg_paths
@@ -584,6 +589,12 @@ def main() -> None:
         action="store_true",
         help="Skip audio loudness normalization. Default is on (-14 LUFS, -1 dBTP, LRA 11).",
     )
+    ap.add_argument(
+        "--fps",
+        type=int,
+        default=24,
+        help="Output frame rate (e.g., 24, 30, 60). Default: 24 (cinematic). Use 60 to preserve screen-capture or 60fps source motion.",
+    )
     args = ap.parse_args()
 
     edl_path = args.edl.resolve()
@@ -596,7 +607,7 @@ def main() -> None:
 
     # 1. Extract per-segment (auto-grade per range if EDL grade is "auto")
     segment_paths = extract_all_segments(
-        edl, edit_dir, preview=args.preview, draft=args.draft
+        edl, edit_dir, preview=args.preview, draft=args.draft, fps=args.fps
     )
 
     # 2. Concat → base


### PR DESCRIPTION
## Summary

The output frame rate is hardcoded to 24fps inside `extract_segment`'s ffmpeg call. This is a great default for cinematic talking-head footage but drops motion fidelity for 60fps screen-capture or 30fps tutorial sources. This PR adds a `--fps` CLI option (default 24) so users can match the source rate without patching the file.

- `extract_segment(..., fps: int = 24)` — new keyword arg, threaded through to `-r`.
- `extract_all_segments(..., fps: int = 24)` — passes through.
- `main()` — exposes `--fps` argparse flag, default 24.

Default stays at 24, so existing behavior is unchanged.

## Motivation

Real-world case: a 60fps screen-capture of a financial simulator with voice-over. With the hardcoded 24fps, mouse cursor / chart animation looked stuttery in the cut. `--fps 60` preserves the original feel; `--fps 30` is a sensible middle ground for tutorial content.

## Test plan

- [x] `python helpers/render.py --help` shows the new `--fps FPS` option
- [x] Default render (no flag) still produces 24fps — verified with `ffprobe` `r_frame_rate=24/1`
- [x] `--fps 60` produces 60fps output — verified with `ffprobe` `r_frame_rate=60/1`
- [x] Audio loudness normalization, fades, scale, preset/CRF ladder all unchanged
- [x] Syntax check passes (`ast.parse`)

## Future direction (not in this PR)

A natural follow-up would be `--fps source` to auto-match the first source clip's frame rate via `ffprobe`. Kept out of this PR to keep the change focused — happy to add in a follow-up if maintainers want it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--fps` option to `helpers/render.py` to set the output frame rate (default 24). This lets you match 30/60fps sources to preserve motion without changing code.

- New Features
  - `extract_segment(..., fps=24)` and `extract_all_segments(..., fps=24)` pass `fps` to ffmpeg via `-r`.
  - `main()` exposes a `--fps` CLI flag; default stays 24.

<sup>Written for commit 78f7a48869199425b4380f782db58b898af2648a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

