### PR TITLE
Add local Whisper fallback + utf-8 encoding fix on Windows

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -73,6 +73,7 @@ Helpers (`helpers/transcribe.py`, `helpers/render.py`, etc.) live alongside this
 
 - **`transcribe.py <video>`** — single-file Scribe call. `--num-speakers N` optional. Cached.
 - **`transcribe_batch.py <videos_dir>`** — 4-worker parallel transcription. Use for multi-take.
+- **`transcribe_whisper.py <video>`** — local Whisper fallback (faster-whisper, CPU `int8`). Emits Scribe-compatible JSON so `pack_transcripts.py` works unchanged. Use only when offline / no Scribe quota / cost-sensitive — Scribe stays the default. Requires `pip install -e '.[whisper]'`. `--model` defaults to `medium`; `--language pt` (etc.) skips auto-detection.
 - **`pack_transcripts.py --edit-dir <dir>`** — `transcripts/*.json` → `takes_packed.md` (phrase-level, break on silence ≥ 0.5s).
 - **`timeline_view.py <video> <start> <end>`** — filmstrip + waveform PNG. On-demand visual drill-down. **Not a scan tool** — use it at decision points, not constantly.
 - **`render.py <edl.json> -o <out>`** — per-segment extract → concat → overlays (PTS-shifted) → subtitles LAST. `--preview` for 720p fast. `--build-subtitles` to generate master.srt inline.

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -192,7 +192,7 @@ def main() -> None:
     markdown = render_markdown(entries, args.silence_threshold)
 
     out_path = args.output or (edit_dir / "takes_packed.md")
-    out_path.write_text(markdown)
+    out_path.write_text(markdown, encoding="utf-8")
 
     total_phrases = sum(len(e[2]) for e in entries)
     total_duration = sum(e[1] for e in entries)

--- a/helpers/transcribe_whisper.py
+++ b/helpers/transcribe_whisper.py
@@ -1,0 +1,102 @@
+"""Local Whisper transcription, emits Scribe-compatible JSON.
+
+Uses faster-whisper with word_timestamps=True. Synthesizes 'spacing'
+entries from gaps so pack_transcripts.py works unchanged.
+
+Output schema: {"words": [{type, text, start, end, speaker_id}]}
+type ∈ {"word", "spacing"}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from faster_whisper import WhisperModel
+
+
+def extract_audio(video: Path, dest: Path) -> None:
+    cmd = [
+        "ffmpeg", "-y", "-i", str(video),
+        "-vn", "-ac", "1", "-ar", "16000", "-c:a", "pcm_s16le",
+        str(dest),
+    ]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def transcribe(video: Path, edit_dir: Path, model_size: str, language: str | None) -> Path:
+    transcripts_dir = edit_dir / "transcripts"
+    transcripts_dir.mkdir(parents=True, exist_ok=True)
+    out_path = transcripts_dir / f"{video.stem}.json"
+    if out_path.exists():
+        print(f"cached: {out_path.name}")
+        return out_path
+
+    print(f"loading whisper model: {model_size}")
+    model = WhisperModel(model_size, device="cpu", compute_type="int8")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        audio = Path(tmp) / f"{video.stem}.wav"
+        print(f"  extracting audio from {video.name}")
+        extract_audio(video, audio)
+        print(f"  transcribing...")
+        segments, info = model.transcribe(
+            str(audio),
+            language=language,
+            word_timestamps=True,
+            vad_filter=True,
+        )
+        words_out: list[dict] = []
+        prev_end: float | None = None
+        for seg in segments:
+            if seg.words is None:
+                continue
+            for w in seg.words:
+                if prev_end is not None and w.start - prev_end > 0.0:
+                    words_out.append({
+                        "type": "spacing",
+                        "text": " ",
+                        "start": prev_end,
+                        "end": w.start,
+                        "speaker_id": "speaker_0",
+                    })
+                words_out.append({
+                    "type": "word",
+                    "text": w.word.strip(),
+                    "start": w.start,
+                    "end": w.end,
+                    "speaker_id": "speaker_0",
+                })
+                prev_end = w.end
+
+        payload = {
+            "language_code": info.language,
+            "language_probability": info.language_probability,
+            "words": words_out,
+        }
+        out_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+        print(f"  saved: {out_path.name}  ({len([w for w in words_out if w['type']=='word'])} words)")
+    return out_path
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("video", type=Path)
+    ap.add_argument("--edit-dir", type=Path, default=None)
+    ap.add_argument("--model", default="medium", help="tiny|base|small|medium|large-v3")
+    ap.add_argument("--language", default=None, help="ISO code, e.g. 'pt'. Omit to auto-detect.")
+    args = ap.parse_args()
+
+    video = args.video.resolve()
+    if not video.exists():
+        sys.exit(f"video not found: {video}")
+    edit_dir = (args.edit_dir or (video.parent / "edit")).resolve()
+    transcribe(video, edit_dir, args.model, args.language)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 
 [project.optional-dependencies]
 animations = ["manim"]
+whisper = ["faster-whisper"]
 
 [build-system]
 requires = ["setuptools>=61.0"]


### PR DESCRIPTION
## Summary

Two small, independent improvements bundled together:

1. **New helper `helpers/transcribe_whisper.py`** — local CPU transcription via [`faster-whisper`](https://github.com/SYSTRAN/faster-whisper) (`int8`) that emits Scribe-compatible JSON.
2. **`helpers/pack_transcripts.py`** — pass `encoding=\"utf-8\"` when writing `takes_packed.md` so the helper does not crash on Windows when transcripts contain non-ASCII characters.

Scribe stays the default. Local Whisper is an opt-in fallback for offline / quota-sensitive use.

## Why

- Some users (CI, sandboxed boxes, longer docs work, cost-sensitive batch jobs) want to transcribe without ElevenLabs quota. A local fallback that produces the **same schema** means the rest of the pipeline (`pack_transcripts.py`, `render.py`, EDL building) does not need to know which engine ran.
- On Windows, `Path.write_text(...)` without `encoding=` defaults to the system codepage (often cp1252) and raises `UnicodeEncodeError` on accented Portuguese transcripts. Other helpers already pass `encoding=\"utf-8\"` explicitly — this brings `pack_transcripts.py` in line.

## What changed

- `helpers/transcribe_whisper.py` (new, 102 lines)
  - `extract_audio` → mono 16 kHz `pcm_s16le` WAV via `ffmpeg`.
  - `transcribe(video, edit_dir, model_size, language)` runs `faster-whisper` with `word_timestamps=True` and `vad_filter=True`, then walks segments → words and emits `{type, text, start, end, speaker_id}` entries.
  - Gaps between consecutive words are synthesised as `type: \"spacing\"` entries so `pack_transcripts.py` can pause-detect with no code changes.
  - Output is cached to `<edit-dir>/transcripts/<video.stem>.json`, mirroring the Scribe path layout.
  - CLI: `python helpers/transcribe_whisper.py <video> [--edit-dir DIR] [--model tiny|base|small|medium|large-v3] [--language pt]`. Defaults: model `medium`, auto-detected language, `<video>/edit/` next to the source.
- `helpers/pack_transcripts.py`
  - Single line: `out_path.write_text(markdown)` → `out_path.write_text(markdown, encoding=\"utf-8\")`.
- `pyproject.toml`
  - Added `whisper = [\"faster-whisper\"]` under `[project.optional-dependencies]`. Install with `pip install -e '.[whisper]'`. Default install is unchanged.
- `SKILL.md`
  - Adds a `transcribe_whisper.py` bullet under \"Helpers\", explicitly noting Scribe remains the default and this is opt-in (offline / no-quota / cost-sensitive).

## Reviewer notes

- I left the existing \"Running Whisper locally on CPU\" bullet under \"Things to avoid\" untouched on purpose — for general editing work, hosted Scribe is still the right call (filler tagging, diarisation, accuracy). The new helper is for niche cases, and the SKILL.md bullet is honest about that.
- Tested on Windows 11 with a Portuguese (pt-BR) take. With `--model medium`, word timestamps line up cleanly with `pack_transcripts.py` phrase-break logic. Larger models (`large-v3`) work too but are slower on CPU.
- No GPU code paths. `device=\"cpu\", compute_type=\"int8\"` runs everywhere, including CI.
- No changes to default `dependencies` — purely additive optional extra.

## Test plan

- [ ] `pip install -e '.[whisper]'` succeeds and pulls `faster-whisper`.
- [ ] `python helpers/transcribe_whisper.py sample.mp4 --model small --language pt` writes `edit/transcripts/sample.json` with `words: [{type: \"word\"|\"spacing\", ...}]`.
- [ ] `python helpers/pack_transcripts.py --edit-dir edit/` consumes that JSON and produces `takes_packed.md` (phrase-level, breaks ≥ 0.5s).
- [ ] On Windows with non-ASCII transcripts, `pack_transcripts.py` no longer raises `UnicodeEncodeError`.
- [ ] Default install (`pip install -e .`) does not pull `faster-whisper`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional local Whisper transcription helper using `faster-whisper` on CPU and fixes UTF-8 writing on Windows. Keeps the Scribe schema so the existing packing/render pipeline works unchanged.

- New Features
  - New `helpers/transcribe_whisper.py`: local transcription via `faster-whisper` (`int8`, CPU). Outputs Scribe-compatible `{words: [...]}` with `word`/`spacing`, cached to `edit/transcripts/<video>.json`.
  - Optional dependency `whisper = ["faster-whisper"]`; install with `pip install -e '.[whisper]'`. Scribe remains the default.

- Bug Fixes
  - `helpers/pack_transcripts.py`: write `takes_packed.md` with `encoding="utf-8"` to prevent Windows `UnicodeEncodeError`.

<sup>Written for commit d13154cfa43dd47e853b9846959aab43bca087ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

