### PR TITLE
fix(render): preserve orientation for portrait video sources

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -131,6 +131,21 @@ def is_hdr_source(video: Path) -> bool:
         return False
 
 
+def is_portrait_source(video: Path) -> bool:
+    """Return True if the video's height > width (portrait / vertical)."""
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=width,height",
+             "-of", "csv=p=0", str(video)],
+            capture_output=True, text=True, check=True,
+        )
+        w, h = map(int, out.stdout.strip().split(","))
+        return h > w
+    except Exception:
+        return False
+
+
 # -------- Per-segment extraction (Rule 2 + Rule 3) --------------------------
 
 
@@ -146,6 +161,7 @@ def extract_segment(
     """Extract a cut range as its own MP4 with grade + 30ms audio fades baked in.
 
     `-ss` before `-i` for fast accurate seeking. Scale to 1080p from 4K.
+    Portrait sources (height > width) are scaled by height to preserve orientation.
 
     Quality ladder:
       - final (default): 1080p libx264 fast CRF 20
@@ -154,10 +170,11 @@ def extract_segment(
     """
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
+    portrait = is_portrait_source(source)
     if draft:
-        scale = "scale=1280:-2"
+        scale = "scale=-2:1280" if portrait else "scale=1280:-2"
     else:
-        scale = "scale=1920:-2"
+        scale = "scale=-2:1920" if portrait else "scale=1920:-2"
 
     vf_parts: list[str] = []
     if is_hdr_source(source):


### PR DESCRIPTION
Portrait videos (height > width) were being scaled by width, squishing vertical footage. Added is_portrait_source() to detect orientation and switch to scale=-2:H for portrait clips.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes squished portrait videos. We now detect orientation and scale portrait sources by height to keep vertical footage correct in draft and final renders.

- **Bug Fixes**
  - Added is_portrait_source() using `ffprobe` to check width and height.
  - For portrait: draft uses `scale=-2:1280`, final uses `scale=-2:1920`; landscape behavior unchanged.

<sup>Written for commit 3ac4e7b1df0847149834ee50404a5b75d0f1a792. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

