### PR TITLE
fix(render): preserve source fps/sample-rate + accurate frame seeking to prevent A/V drift

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -178,16 +178,25 @@ def extract_segment(
     else:
         preset, crf = "fast", "20"
 
+    # Hybrid seek (Fase 2 — accurate frame seeking):
+    # Em vez de fast-seek até seg_start direto (que pula pra keyframe próximo
+    # e perde precisão de frame), faz fast-seek até 1s ANTES, e depois
+    # accurate-seek (decode frame-a-frame) o último 1s pra garantir frame exato.
+    # Em 525 segmentos, isso evita drift cumulativo de A/V.
+    seek_pre = max(0.0, seg_start - 1.0)
+    seek_fine = seg_start - seek_pre  # geralmente 1.0 (menor se seg_start < 1)
+
     cmd = [
         "ffmpeg", "-y",
-        "-ss", f"{seg_start:.3f}",
+        "-ss", f"{seek_pre:.3f}",  # fast seek até keyframe próximo
         "-i", str(source),
+        "-ss", f"{seek_fine:.3f}",  # accurate seek (frame-exato)
         "-t", f"{duration:.3f}",
         "-vf", vf,
         "-af", af,
         "-c:v", "libx264", "-preset", preset, "-crf", crf,
-        "-pix_fmt", "yuv420p", "-r", "24",
-        "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
+        "-pix_fmt", "yuv420p",
+        "-c:a", "aac", "-b:a", "192k",
         "-movflags", "+faststart",
         str(out_path),
     ]
@@ -432,7 +441,7 @@ def apply_loudnorm_two_pass(
             "-i", str(input_path),
             "-c:v", "copy",
             "-af", filter_str,
-            "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
+            "-c:a", "aac", "-b:a", "192k",
             "-movflags", "+faststart",
             str(output_path),
         ]
@@ -464,7 +473,7 @@ def apply_loudnorm_two_pass(
         "-i", str(input_path),
         "-c:v", "copy",
         "-af", filter_str,
-        "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
+        "-c:a", "aac", "-b:a", "192k",
         "-movflags", "+faststart",
         str(output_path),
     ]


### PR DESCRIPTION
## Summary

Two related fixes to prevent A/V drift when concatenating many segments. Discovered while editing a 3h37min source with 525 cuts — lip sync went out of sync progressively over the timeline.

### 1. Stop forcing `-r 24` and `-ar 48000` in `extract_segment()`

The hardcoded `-r 24` was downsampling source FPS (e.g. 30fps → 24fps), dropping ~20% of frames per segment. The hardcoded `-ar 48000` was upsampling audio (44.1kHz → 48kHz). Both transformations introduced cumulative timing errors over hundreds of concatenated segments.

By removing the hardcoded values, ffmpeg passes through the source rates intact — no resampling or framerate conversion. Same fix applied to both `apply_loudnorm_two_pass()` calls (`-ar 48000` removed there as well).

### 2. Hybrid seek (-ss before AND after -i) in `extract_segment()`

**Before:**
```
-ss seg_start -i source -t duration
```
Fast seek but inexact (jumps to nearest keyframe before `seg_start`). With many cuts, sub-frame errors accumulate.

**After:**
```
-ss (seg_start - 1.0) -i source -ss 1.0 -t duration
```
Fast seek to 1s before, then accurate (frame-by-frame) seek for the last 1s. Frame-exact start for every segment.

Per-segment overhead: ~1s of decode. For 525 cuts, ~9 min of extra processing — acceptable trade for zero drift.

## Test plan

- [x] Validated on a 3h37min source with 525 cuts (Portuguese language educational content, 30fps, 44.1kHz source). Lip sync stable throughout the 2h output.
- [x] No regressions in normal use cases (smaller cut counts).

## Notes

This was found while building a content production pipeline using `video-use`. The drift was very subtle on small edits but devastating on long-form (>1h) edits with many cuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents A/V drift by preserving source frame rate and sample rate, and by using accurate frame seeking for segment extraction. This keeps lip sync stable on long edits with many cuts, with a small per-segment decode cost.

- **Bug Fixes**
  - Stop forcing `-r 24` and `-ar 48000` in `extract_segment()`; removed `-ar 48000` in `apply_loudnorm_two_pass()`. `ffmpeg` now passes through source FPS/sample-rate unchanged.
  - Use hybrid seek in `extract_segment()`: `-ss` to `max(0, start-1s)` before `-i`, then `-ss` for fine seek. Produces frame-exact starts and avoids cumulative timing errors (~1s extra decode per segment).

<sup>Written for commit 9ed65c880579101a31cbd0343fd2513ce547f77f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

