### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Browser Use
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "video-use"
 version = "0.1.0"
 description = "Conversation-driven video editor skill for Claude Code"
+license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
     "requests",


### PR DESCRIPTION
## Summary
- Add the standard MIT LICENSE file.
- Reference the LICENSE file from pyproject package metadata.

## Issues
Links to all currently open GitHub issues at PR creation time:
- #30
- #25
- #20
- #19
- #8

License-specific issues addressed by this PR:
- #25
- #20
- #19

## Testing
- Not run; license and package metadata only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the standard MIT LICENSE and reference it in `pyproject.toml` package metadata. This makes the license explicit for users and package indexes and enables distribution; closes #25, #20, #19.

<sup>Written for commit 35b12d1e80c4596396cb5f02485c6f5bbd5b9a9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

