### PR TITLE
Add Browser Use Box editing note

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ cd /path/to/your/videos
 claude    # or codex, hermes, etc.
 ```
 
+For always-on editing from your own VPS or Telegram, run the agent through [Browser Use Box](https://browser-use.com/bux). [Watch the 15-second demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
 And in the session:
 
 > edit these into a launch video


### PR DESCRIPTION
## Summary
- add Browser Use Box as an always-on way to run video-use agents from a VPS or Telegram
- include the 15-second Browser Use Box TikTok demo link

## Validation
- README-only change; verified Browser Use Box and TikTok demo links are present locally

Browser Use Box: https://browser-use.com/bux
TikTok demo: https://www.tiktok.com/@browser_use/video/7639824093721758989

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a README note showing how to run the agent through Browser Use Box for always-on editing from a VPS or Telegram. Also links a 15-second TikTok demo of the flow.

<sup>Written for commit a2a38a75bcc5e6b97611283c2a9a630ded267c30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

