### PR TITLE
Revert "Add Browser Use Box editing note"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ cd /path/to/your/videos
 claude    # or codex, hermes, etc.
 ```
 
-For always-on editing from your own VPS or Telegram, run the agent through [Browser Use Box](https://browser-use.com/bux). [Watch the 15-second demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
-
 And in the session:
 
 > edit these into a launch video


### PR DESCRIPTION
Reverts browser-use/video-use#34

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Browser Use Box editing note and TikTok demo link from the README to revert the previous change and keep instructions focused on core usage.

<sup>Written for commit b8b751dabb61b06a45267c37ddcf8b73f6d07cd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

