### PR TITLE
fix(render): escape apostrophes in concat demuxer list

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -268,7 +268,13 @@ def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -
     """Lossless concat via the concat demuxer. No re-encode."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
     concat_list = edit_dir / "_concat.txt"
-    concat_list.write_text("".join(f"file '{p.resolve()}'\n" for p in segment_paths))
+    # Escape single quotes for the concat demuxer line format. A literal ' inside
+    # a single-quoted path must be written as '\'' (close quote, escaped quote,
+    # reopen quote); otherwise a path containing an apostrophe (e.g. a folder
+    # named "What I couldn't do") truncates the path and ffmpeg fails to concat.
+    def _concat_quote(p: Path) -> str:
+        return str(p.resolve()).replace("'", "'\\''")
+    concat_list.write_text("".join(f"file '{_concat_quote(p)}'\n" for p in segment_paths))
 
     cmd = [
         "ffmpeg", "-y",


### PR DESCRIPTION
## Problem

`concat_segments` in `helpers/render.py` writes the ffmpeg concat-demuxer list as:

```python
concat_list.write_text("".join(f"file '{p.resolve()}'\n" for p in segment_paths))
```

When the resolved path contains a literal apostrophe — which is common for English video-folder names (e.g. `2026-03-12 What else I couldn't yet do with the help of AI/`) — the apostrophe closes the single-quoted string early. ffmpeg then parses a truncated path and the concat step fails:

```
concat → base.mp4
subprocess.CalledProcessError: Command '[...ffmpeg... -f concat ...]' returned non-zero exit status ...
```

This is especially confusing because the **per-segment extracts all succeed** — the failure only surfaces at the join, after the slow part of the pipeline has already run.

## Fix

Escape `'` as `'\''` (close quote, escaped quote, reopen quote), which is the quoting the concat demuxer line format expects:

```python
def _concat_quote(p: Path) -> str:
    return str(p.resolve()).replace("'", "'\\''")
concat_list.write_text("".join(f"file '{_concat_quote(p)}'\n" for p in segment_paths))
```

## Repro

Run any EDL whose source/edit directory path contains an apostrophe. Before the fix, concat fails; after, `base.mp4` is produced normally. Verified end-to-end on a real 1080×1920 vertical render whose folder name contained "couldn't".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape apostrophes in segment paths when generating the ffmpeg concat-demuxer list to prevent truncated paths and failed joins. Adds proper `'\''` quoting via a small helper in `concat_segments` so paths containing `'` concat successfully.

<sup>Written for commit 60f1a5054b91c0b209a54767a09e1c20fc9fe77f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

