### PR TITLE
fix(render): preserve source frame rate by default; add --fps override

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -177,7 +177,7 @@ def extract_segment(
     out_path: Path,
     preview: bool = False,
     draft: bool = False,
-    fps: int | None = None,
+    rate: str | None = None,
 ) -> None:
     """Extract a cut range as its own MP4 with grade + 30ms audio fades baked in.
 
@@ -216,10 +216,11 @@ def extract_segment(
     else:
         preset, crf = "fast", "20"
 
-    # Frame rate: an explicit fps wins; otherwise preserve the source's rate
-    # (the skill's "match the source" default). Fall back to 24 only if the
-    # source rate can't be probed.
-    rate = str(fps) if fps is not None else (probe_source_fps(source) or "24")
+    # Frame rate: use the rate the caller resolved once for the whole render
+    # (every segment must share it — concat -c copy in Rule 2 requires a uniform
+    # frame rate). When called standalone with no rate, preserve this source's
+    # own rate; fall back to 24 only if it can't be probed.
+    out_rate = rate if rate is not None else (probe_source_fps(source) or "24")
 
     cmd = [
         "ffmpeg", "-y",
@@ -229,7 +230,7 @@ def extract_segment(
         "-vf", vf,
         "-af", af,
         "-c:v", "libx264", "-preset", preset, "-crf", crf,
-        "-pix_fmt", "yuv420p", "-r", rate,
+        "-pix_fmt", "yuv420p", "-r", out_rate,
         "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
         "-movflags", "+faststart",
         str(out_path),
@@ -261,8 +262,22 @@ def extract_all_segments(
     ranges = edl["ranges"]
     sources = edl["sources"]
 
+    # Resolve ONE output frame rate for the entire render and apply it to every
+    # segment. The lossless concat (Rule 2, `-c copy`) requires all segments to
+    # share a frame rate; probing per-segment would diverge for multi-source
+    # EDLs that mix rates (e.g. a 30fps and a 60fps source) and break the concat.
+    # Explicit --fps wins; otherwise preserve the first source's rate.
+    if fps is not None:
+        out_rate = str(fps)
+    elif ranges:
+        first_src = resolve_path(sources[ranges[0]["source"]], edit_dir)
+        out_rate = probe_source_fps(first_src) or "24"
+    else:
+        out_rate = "24"
+
     seg_paths: list[Path] = []
-    print(f"extracting {len(ranges)} segment(s) → {clips_dir.name}/")
+    print(f"extracting {len(ranges)} segment(s) → {clips_dir.name}/  @ {out_rate} fps"
+          f"{' (forced)' if fps is not None else ' (from source)'}")
     if is_auto:
         print("  (auto-grade per segment: analyzing each range)")
     for i, r in enumerate(ranges):
@@ -282,7 +297,7 @@ def extract_all_segments(
         print(f"  [{i:02d}] {src_name}  {start:7.2f}-{end:7.2f}  ({duration:5.2f}s)  {note}")
         if is_auto:
             print(f"        grade: {seg_filter or '(none)'}")
-        extract_segment(src_path, start, duration, seg_filter, out_path, preview=preview, draft=draft, fps=fps)
+        extract_segment(src_path, start, duration, seg_filter, out_path, preview=preview, draft=draft, rate=out_rate)
         seg_paths.append(out_path)
 
     return seg_paths

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -146,6 +146,26 @@ def is_portrait_source(video: Path) -> bool:
         return False
 
 
+def probe_source_fps(video: Path) -> str | None:
+    """Return the source's frame rate as an ffmpeg-ready string (e.g. '60/1',
+    '30000/1001'), or None if it can't be determined.
+
+    Returned verbatim so fractional rates (29.97, 23.976) survive without
+    rounding when passed straight to ffmpeg's `-r`.
+    """
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=r_frame_rate",
+             "-of", "default=noprint_wrappers=1:nokey=1", str(video)],
+            capture_output=True, text=True, check=True,
+        )
+        val = out.stdout.strip()
+        return val if val and val != "0/0" else None
+    except Exception:
+        return None
+
+
 # -------- Per-segment extraction (Rule 2 + Rule 3) --------------------------
 
 
@@ -157,6 +177,7 @@ def extract_segment(
     out_path: Path,
     preview: bool = False,
     draft: bool = False,
+    fps: int | None = None,
 ) -> None:
     """Extract a cut range as its own MP4 with grade + 30ms audio fades baked in.
 
@@ -195,6 +216,11 @@ def extract_segment(
     else:
         preset, crf = "fast", "20"
 
+    # Frame rate: an explicit fps wins; otherwise preserve the source's rate
+    # (the skill's "match the source" default). Fall back to 24 only if the
+    # source rate can't be probed.
+    rate = str(fps) if fps is not None else (probe_source_fps(source) or "24")
+
     cmd = [
         "ffmpeg", "-y",
         "-ss", f"{seg_start:.3f}",
@@ -203,7 +229,7 @@ def extract_segment(
         "-vf", vf,
         "-af", af,
         "-c:v", "libx264", "-preset", preset, "-crf", crf,
-        "-pix_fmt", "yuv420p", "-r", "24",
+        "-pix_fmt", "yuv420p", "-r", rate,
         "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
         "-movflags", "+faststart",
         str(out_path),
@@ -216,6 +242,7 @@ def extract_all_segments(
     edit_dir: Path,
     preview: bool,
     draft: bool = False,
+    fps: int | None = None,
 ) -> list[Path]:
     """Extract every EDL range into edit_dir/clips_graded/seg_NN.mp4.
     Returns the ordered list of segment paths.
@@ -255,7 +282,7 @@ def extract_all_segments(
         print(f"  [{i:02d}] {src_name}  {start:7.2f}-{end:7.2f}  ({duration:5.2f}s)  {note}")
         if is_auto:
             print(f"        grade: {seg_filter or '(none)'}")
-        extract_segment(src_path, start, duration, seg_filter, out_path, preview=preview, draft=draft)
+        extract_segment(src_path, start, duration, seg_filter, out_path, preview=preview, draft=draft, fps=fps)
         seg_paths.append(out_path)
 
     return seg_paths
@@ -601,6 +628,13 @@ def main() -> None:
         action="store_true",
         help="Skip audio loudness normalization. Default is on (-14 LUFS, -1 dBTP, LRA 11).",
     )
+    ap.add_argument(
+        "--fps",
+        type=int,
+        default=None,
+        help="Output frame rate. Default: preserve the source's frame rate "
+             "(falls back to 24 if it can't be probed). Pass e.g. --fps 30 to force.",
+    )
     args = ap.parse_args()
 
     edl_path = args.edl.resolve()
@@ -613,7 +647,7 @@ def main() -> None:
 
     # 1. Extract per-segment (auto-grade per range if EDL grade is "auto")
     segment_paths = extract_all_segments(
-        edl, edit_dir, preview=args.preview, draft=args.draft
+        edl, edit_dir, preview=args.preview, draft=args.draft, fps=args.fps
     )
 
     # 2. Concat → base

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -164,6 +164,12 @@ def parse_fps(value: str) -> str:
         ) from exc
     if rate <= 0:
         raise argparse.ArgumentTypeError("FPS must be greater than zero")
+    # FFmpeg stores video rates as AVRational (signed 32-bit components).
+    # Bounding the reduced fraction keeps every accepted canonical value safe
+    # for ffmpeg and makes parse_fps(parse_fps(value)) idempotent.
+    max_component = 2_147_483_647
+    if rate.numerator > max_component or rate.denominator > max_component:
+        raise argparse.ArgumentTypeError("FPS precision or magnitude is too large")
     return f"{rate.numerator}/{rate.denominator}"
 
 

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -148,8 +148,14 @@ def is_portrait_source(video: Path) -> bool:
 
 
 def parse_fps(value: str) -> str:
-    """Validate an ffmpeg frame rate while preserving its original spelling."""
+    """Validate and canonicalize an ffmpeg frame rate."""
     text = value.strip()
+    if len(text) > 32 or not re.fullmatch(
+        r"(?:[0-9]+(?:\.[0-9]+)?|[0-9]+/[0-9]+)", text
+    ):
+        raise argparse.ArgumentTypeError(
+            "FPS must be a positive number or rational, e.g. 30 or 30000/1001"
+        )
     try:
         rate = Fraction(text)
     except (ValueError, ZeroDivisionError) as exc:
@@ -158,7 +164,7 @@ def parse_fps(value: str) -> str:
         ) from exc
     if rate <= 0:
         raise argparse.ArgumentTypeError("FPS must be greater than zero")
-    return text
+    return f"{rate.numerator}/{rate.denominator}"
 
 
 def probe_source_fps(video: Path) -> str | None:
@@ -166,8 +172,8 @@ def probe_source_fps(video: Path) -> str | None:
 
     ``avg_frame_rate`` represents the observed average and is the better default
     for variable-frame-rate inputs. ``r_frame_rate`` remains a fallback for
-    streams where the average is unavailable. Values are returned verbatim so
-    rates such as ``30000/1001`` survive without rounding.
+    streams where the average is unavailable. Values are normalized to an exact
+    rational so rates such as ``30000/1001`` survive without rounding.
     """
     try:
         out = subprocess.run(

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -26,6 +26,7 @@ import json
 import re
 import subprocess
 import sys
+from fractions import Fraction
 from pathlib import Path
 
 try:
@@ -146,24 +147,48 @@ def is_portrait_source(video: Path) -> bool:
         return False
 
 
-def probe_source_fps(video: Path) -> str | None:
-    """Return the source's frame rate as an ffmpeg-ready string (e.g. '60/1',
-    '30000/1001'), or None if it can't be determined.
+def parse_fps(value: str) -> str:
+    """Validate an ffmpeg frame rate while preserving its original spelling."""
+    text = value.strip()
+    try:
+        rate = Fraction(text)
+    except (ValueError, ZeroDivisionError) as exc:
+        raise argparse.ArgumentTypeError(
+            "FPS must be a positive number or rational, e.g. 30 or 30000/1001"
+        ) from exc
+    if rate <= 0:
+        raise argparse.ArgumentTypeError("FPS must be greater than zero")
+    return text
 
-    Returned verbatim so fractional rates (29.97, 23.976) survive without
-    rounding when passed straight to ffmpeg's `-r`.
+
+def probe_source_fps(video: Path) -> str | None:
+    """Return an ffmpeg-ready source rate, preferring the average frame rate.
+
+    ``avg_frame_rate`` represents the observed average and is the better default
+    for variable-frame-rate inputs. ``r_frame_rate`` remains a fallback for
+    streams where the average is unavailable. Values are returned verbatim so
+    rates such as ``30000/1001`` survive without rounding.
     """
     try:
         out = subprocess.run(
             ["ffprobe", "-v", "error", "-select_streams", "v:0",
-             "-show_entries", "stream=r_frame_rate",
-             "-of", "default=noprint_wrappers=1:nokey=1", str(video)],
+             "-show_entries", "stream=avg_frame_rate,r_frame_rate",
+             "-of", "json", str(video)],
             capture_output=True, text=True, check=True,
         )
-        val = out.stdout.strip()
-        return val if val and val != "0/0" else None
-    except Exception:
+        streams = json.loads(out.stdout).get("streams") or []
+        if not streams:
+            return None
+        for field in ("avg_frame_rate", "r_frame_rate"):
+            value = streams[0].get(field)
+            if value and value != "0/0":
+                try:
+                    return parse_fps(value)
+                except argparse.ArgumentTypeError:
+                    continue
+    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError):
         return None
+    return None
 
 
 # -------- Per-segment extraction (Rule 2 + Rule 3) --------------------------
@@ -243,7 +268,7 @@ def extract_all_segments(
     edit_dir: Path,
     preview: bool,
     draft: bool = False,
-    fps: int | None = None,
+    fps: str | None = None,
 ) -> list[Path]:
     """Extract every EDL range into edit_dir/clips_graded/seg_NN.mp4.
     Returns the ordered list of segment paths.
@@ -268,7 +293,7 @@ def extract_all_segments(
     # EDLs that mix rates (e.g. a 30fps and a 60fps source) and break the concat.
     # Explicit --fps wins; otherwise preserve the first source's rate.
     if fps is not None:
-        out_rate = str(fps)
+        out_rate = parse_fps(str(fps))
     elif ranges:
         first_src = resolve_path(sources[ranges[0]["source"]], edit_dir)
         out_rate = probe_source_fps(first_src) or "24"
@@ -645,10 +670,11 @@ def main() -> None:
     )
     ap.add_argument(
         "--fps",
-        type=int,
+        type=parse_fps,
         default=None,
         help="Output frame rate. Default: preserve the source's frame rate "
-             "(falls back to 24 if it can't be probed). Pass e.g. --fps 30 to force.",
+             "(falls back to 24 if it can't be probed). Pass e.g. --fps 30 or "
+             "--fps 30000/1001 to force.",
     )
     args = ap.parse_args()
 

--- a/tests/test_render_fps.py
+++ b/tests/test_render_fps.py
@@ -28,6 +28,12 @@ class ParseFpsTests(unittest.TestCase):
             with self.subTest(value=value):
                 self.assertEqual(render.parse_fps(value), canonical)
 
+    def test_canonical_rates_are_idempotent(self):
+        for value in ("60", "29.97", "30000/1001"):
+            with self.subTest(value=value):
+                canonical = render.parse_fps(value)
+                self.assertEqual(render.parse_fps(canonical), canonical)
+
     def test_rejects_invalid_or_non_positive_rates(self):
         for value in (
             "",
@@ -37,6 +43,7 @@ class ParseFpsTests(unittest.TestCase):
             "1/0",
             "1e3",
             "1_000",
+            "0.12345678901234567890",
             "1" * 33,
         ):
             with self.subTest(value=value):

--- a/tests/test_render_fps.py
+++ b/tests/test_render_fps.py
@@ -19,12 +19,26 @@ SPEC.loader.exec_module(render)
 
 class ParseFpsTests(unittest.TestCase):
     def test_accepts_integer_decimal_and_rational_rates(self):
-        for value in ("60", "29.97", "30000/1001"):
+        expected = {
+            "60": "60/1",
+            "29.97": "2997/100",
+            "30000/1001": "30000/1001",
+        }
+        for value, canonical in expected.items():
             with self.subTest(value=value):
-                self.assertEqual(render.parse_fps(value), value)
+                self.assertEqual(render.parse_fps(value), canonical)
 
     def test_rejects_invalid_or_non_positive_rates(self):
-        for value in ("", "nope", "0", "-24", "1/0"):
+        for value in (
+            "",
+            "nope",
+            "0",
+            "-24",
+            "1/0",
+            "1e3",
+            "1_000",
+            "1" * 33,
+        ):
             with self.subTest(value=value):
                 with self.assertRaises(argparse.ArgumentTypeError):
                     render.parse_fps(value)
@@ -53,16 +67,25 @@ class ProbeSourceFpsTests(unittest.TestCase):
         with patch.object(render.subprocess, "run", return_value=result):
             self.assertIsNone(render.probe_source_fps(Path("source.mp4")))
 
+    def test_returns_none_when_ffprobe_fails(self):
+        error = subprocess.CalledProcessError(1, ["ffprobe"])
+        with patch.object(render.subprocess, "run", side_effect=error):
+            self.assertIsNone(render.probe_source_fps(Path("source.mp4")))
+
 
 class RenderRateTests(unittest.TestCase):
-    def test_multi_source_render_resolves_one_rate_from_first_source(self):
-        edl = {
+    @staticmethod
+    def _edl() -> dict:
+        return {
             "sources": {"first": "first.mp4", "second": "second.mp4"},
             "ranges": [
                 {"source": "first", "start": 0, "end": 1},
                 {"source": "second", "start": 0, "end": 1},
             ],
         }
+
+    def test_multi_source_render_resolves_one_rate_from_first_source(self):
+        edl = self._edl()
         with tempfile.TemporaryDirectory() as temp_dir:
             edit_dir = Path(temp_dir)
             with (
@@ -74,6 +97,39 @@ class RenderRateTests(unittest.TestCase):
 
         probe.assert_called_once_with((edit_dir / "first.mp4").resolve())
         self.assertEqual([call.kwargs["rate"] for call in extract.call_args_list], ["60/1", "60/1"])
+
+    def test_explicit_rate_skips_probe_and_applies_to_every_segment(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.object(render, "probe_source_fps") as probe,
+                patch.object(render, "extract_segment") as extract,
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                render.extract_all_segments(
+                    self._edl(), Path(temp_dir), preview=False, fps="30"
+                )
+
+        probe.assert_not_called()
+        self.assertEqual(
+            [call.kwargs["rate"] for call in extract.call_args_list],
+            ["30/1", "30/1"],
+        )
+
+    def test_failed_probe_falls_back_to_24_for_every_segment(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.object(render, "probe_source_fps", return_value=None),
+                patch.object(render, "extract_segment") as extract,
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                render.extract_all_segments(
+                    self._edl(), Path(temp_dir), preview=False
+                )
+
+        self.assertEqual(
+            [call.kwargs["rate"] for call in extract.call_args_list],
+            ["24", "24"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_render_fps.py
+++ b/tests/test_render_fps.py
@@ -1,0 +1,80 @@
+import argparse
+import contextlib
+import importlib.util
+import io
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).parents[1] / "helpers" / "render.py"
+SPEC = importlib.util.spec_from_file_location("video_use_render", MODULE_PATH)
+assert SPEC and SPEC.loader
+render = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(render)
+
+
+class ParseFpsTests(unittest.TestCase):
+    def test_accepts_integer_decimal_and_rational_rates(self):
+        for value in ("60", "29.97", "30000/1001"):
+            with self.subTest(value=value):
+                self.assertEqual(render.parse_fps(value), value)
+
+    def test_rejects_invalid_or_non_positive_rates(self):
+        for value in ("", "nope", "0", "-24", "1/0"):
+            with self.subTest(value=value):
+                with self.assertRaises(argparse.ArgumentTypeError):
+                    render.parse_fps(value)
+
+
+class ProbeSourceFpsTests(unittest.TestCase):
+    @staticmethod
+    def _probe_result(avg: str, nominal: str) -> subprocess.CompletedProcess:
+        stdout = json.dumps({
+            "streams": [{"avg_frame_rate": avg, "r_frame_rate": nominal}]
+        })
+        return subprocess.CompletedProcess([], 0, stdout=stdout, stderr="")
+
+    def test_prefers_average_rate(self):
+        result = self._probe_result("30000/1001", "30/1")
+        with patch.object(render.subprocess, "run", return_value=result):
+            self.assertEqual(render.probe_source_fps(Path("source.mp4")), "30000/1001")
+
+    def test_falls_back_to_nominal_rate(self):
+        result = self._probe_result("0/0", "60/1")
+        with patch.object(render.subprocess, "run", return_value=result):
+            self.assertEqual(render.probe_source_fps(Path("source.mp4")), "60/1")
+
+    def test_returns_none_for_unusable_probe_output(self):
+        result = subprocess.CompletedProcess([], 0, stdout='{"streams": []}', stderr="")
+        with patch.object(render.subprocess, "run", return_value=result):
+            self.assertIsNone(render.probe_source_fps(Path("source.mp4")))
+
+
+class RenderRateTests(unittest.TestCase):
+    def test_multi_source_render_resolves_one_rate_from_first_source(self):
+        edl = {
+            "sources": {"first": "first.mp4", "second": "second.mp4"},
+            "ranges": [
+                {"source": "first", "start": 0, "end": 1},
+                {"source": "second", "start": 0, "end": 1},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            edit_dir = Path(temp_dir)
+            with (
+                patch.object(render, "probe_source_fps", return_value="60/1") as probe,
+                patch.object(render, "extract_segment") as extract,
+            ):
+                with contextlib.redirect_stdout(io.StringIO()):
+                    render.extract_all_segments(edl, edit_dir, preview=False)
+
+        probe.assert_called_once_with((edit_dir / "first.mp4").resolve())
+        self.assertEqual([call.kwargs["rate"] for call in extract.call_args_list], ["60/1", "60/1"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

extract_segment hardcodes every output to 24 fps. This silently downsamples common 30/60 fps phone, webcam, and screen recordings and contradicts SKILL.md's default to match the source unless the user requests a specific delivery rate.

## Fix

- Probe avg_frame_rate first, with r_frame_rate as a fallback.
- Resolve one output rate per render from the first source so every encoded segment remains uniform for lossless concat.
- Fall back to 24 only when probing fails.
- Add --fps overrides accepting integer, decimal, or rational values, for example 30, 29.97, or 30000/1001.
- Restrict input to a bounded ffmpeg-compatible grammar, normalize it to an exact rational, and enforce FFmpeg AVRational component limits.

The initial per-segment implementation could choose different rates in a multi-source EDL; that issue was identified by cubic and fixed in ae0e6af.

## Behavior change

Renders preserve the first source's effective frame rate by default instead of always emitting 24 fps. Pass --fps 24 to retain the old behavior explicitly.

## Verification

- Ten unit tests cover validation, canonicalization and idempotence, avg/r fallback, ffprobe failure, explicit override, 24 fps fallback, and a uniform rate across multi-source segments.
- python -m unittest discover -s tests -v
- python -m py_compile helpers/render.py tests/test_render_fps.py
- FFmpeg accepts the canonicalized decimal-rate output 2997/100.
- Previously verified end-to-end on a 60 fps source.