### PR TITLE
feat(transcribe): add local Whisper transcription helper

### DIFF
--- a/helpers/transcribe_whisper.py
+++ b/helpers/transcribe_whisper.py
@@ -1,0 +1,124 @@
+"""Transcribe a video with local OpenAI Whisper (word-level timestamps).
+
+Extracts mono 16kHz audio via ffmpeg, runs Whisper locally, writes output
+to <edit_dir>/transcripts/<video_stem>.json in the same format as the
+ElevenLabs Scribe transcribe.py helper so the rest of the pipeline works
+unchanged.
+
+Cached: if the output file already exists, transcription is skipped.
+
+Usage:
+    python helpers/transcribe_whisper.py <video_path>
+    python helpers/transcribe_whisper.py <video_path> --edit-dir /custom/edit
+    python helpers/transcribe_whisper.py <video_path> --model medium
+    python helpers/transcribe_whisper.py <video_path> --language en
+
+Models (speed vs accuracy tradeoff):
+    tiny   — fastest, least accurate
+    base   — good balance for English
+    small  — better accuracy, still fast
+    medium — recommended for production (default)
+    large  — most accurate, slow
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def extract_audio(video_path: Path, wav_path: Path) -> None:
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-i", str(video_path),
+            "-ar", "16000", "-ac", "1", "-f", "wav", str(wav_path),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def transcribe(video_path: Path, edit_dir: Path, model_name: str, language: str | None) -> Path:
+    import whisper
+
+    out_dir = edit_dir / "transcripts"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / f"{video_path.stem}.json"
+
+    if out_file.exists():
+        print(f"Cached transcript found: {out_file}")
+        return out_file
+
+    print(f"Loading Whisper model '{model_name}' (first run downloads ~{_model_size(model_name)})...")
+    model = whisper.load_model(model_name)
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        wav_path = Path(tmp.name)
+
+    print("Extracting audio...")
+    extract_audio(video_path, wav_path)
+
+    print("Transcribing (this may take a minute)...")
+    opts: dict = {"word_timestamps": True, "verbose": False}
+    if language:
+        opts["language"] = language
+
+    result = model.transcribe(str(wav_path), **opts)
+    wav_path.unlink(missing_ok=True)
+
+    # Convert to the same shape as ElevenLabs Scribe output so the
+    # rest of the pipeline (pack_transcripts.py, render.py) works unchanged.
+    words = []
+    for seg in result.get("segments", []):
+        for w in seg.get("words", []):
+            words.append({
+                "text": w["word"].strip(),
+                "start": round(w["start"], 3),
+                "end": round(w["end"], 3),
+                "type": "word",
+                "speaker_id": "S0",
+            })
+
+    payload = {
+        "language_code": result.get("language", language or "en"),
+        "text": result["text"].strip(),
+        "words": words,
+        # Scribe-compatible envelope fields
+        "alignment": {"words": words},
+    }
+
+    out_file.write_text(json.dumps(payload, indent=2))
+    print(f"Transcript saved: {out_file}  ({len(words)} words)")
+    return out_file
+
+
+def _model_size(name: str) -> str:
+    sizes = {"tiny": "75 MB", "base": "140 MB", "small": "460 MB",
+             "medium": "1.5 GB", "large": "3 GB"}
+    return sizes.get(name, "unknown size")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Transcribe video with local Whisper.")
+    parser.add_argument("video", help="Path to video file")
+    parser.add_argument("--edit-dir", help="Output directory (default: <video_dir>/edit)")
+    parser.add_argument("--model", default="medium", help="Whisper model (default: medium)")
+    parser.add_argument("--language", default=None, help="Language code e.g. 'en'")
+    args = parser.parse_args()
+
+    video_path = Path(args.video).resolve()
+    if not video_path.exists():
+        print(f"Error: file not found: {video_path}", file=sys.stderr)
+        sys.exit(1)
+
+    edit_dir = Path(args.edit_dir).resolve() if args.edit_dir else video_path.parent / "edit"
+    transcribe(video_path, edit_dir, args.model, args.language)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds `helpers/transcribe_whisper.py` — a drop-in alternative to the ElevenLabs Scribe `transcribe.py` helper for users who don't have an API key or prefer a free, fully offline option.

## Why

The existing pipeline requires an ElevenLabs API key for transcription. Users on free-tier accounts or those who want a zero-cost setup have no fallback. Local Whisper fills that gap.

## How it works

- Uses `openai-whisper` with `word_timestamps=True` to produce word-level timestamps
- Output JSON matches the Scribe envelope shape (`words`, `text`, `language_code`, `alignment`) so `pack_transcripts.py`, `render.py`, and the rest of the pipeline work **unchanged**
- Caches transcripts per source file — skips re-transcription on repeat runs (same behaviour as Scribe helper)
- Extracts mono 16kHz WAV via ffmpeg before passing to Whisper (same as the Scribe path)
- Supports all Whisper model sizes (`tiny` → `large`); defaults to `medium` (good balance of speed and accuracy for English)

## Usage

```bash
# Basic
python helpers/transcribe_whisper.py my_video.mp4

# Custom model and language
python helpers/transcribe_whisper.py my_video.mp4 --model large --language en

# Custom output directory
python helpers/transcribe_whisper.py my_video.mp4 --edit-dir /path/to/edit
```

## Reviewer notes

- No changes to existing files — purely additive
- Requires `openai-whisper` (`pip install openai-whisper`) and `ffmpeg` on PATH, both already listed as setup dependencies
- Word-level timestamp accuracy is slightly lower than Scribe (Whisper drifts ~50–100ms) but within the cut-padding working window defined in SKILL.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a local Whisper transcription helper that outputs Scribe-compatible JSON, enabling offline, zero-API-key transcription without changing the rest of the pipeline. Adds caching and model selection for better control and speed.

- **New Features**
  - Added `helpers/transcribe_whisper.py` using `openai-whisper` with `word_timestamps=True`.
  - Emits Scribe-compatible JSON (`words`, `text`, `language_code`, `alignment`) so `pack_transcripts.py` and `render.py` work unchanged.
  - Extracts mono 16 kHz WAV via `ffmpeg` before transcription.
  - Caches transcripts per source file to skip repeat runs.
  - Supports all Whisper models (`tiny` → `large`); defaults to `medium`. Optional `--language`.

- **Dependencies**
  - Requires `openai-whisper` and `ffmpeg` available on PATH.

<sup>Written for commit ff6884c63bea0fa278cbeba6cc12bddb3a5b9697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

