### PR TITLE
Kent house style

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -5,6 +5,10 @@ description: Edit any video by conversation. Transcribe, cut, color grade, gener
 
 # Video Use
 
+> **User config (Kent):** Before the Converse/Propose step, read `house-style.md`
+> and `house-defaults.json` in this skill's root and apply them. They override the
+> artistic-freedom defaults below, but never the Hard Rules.
+
 ## Principle
 
 1. **LLM reasons from raw transcript + on-demand visuals.** The only derived artifact that earns its keep is a packed phrase-level transcript (`takes_packed.md`). Everything else — filler tagging, retake detection, shot classification, emphasis scoring — you derive at decision time.

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -38,6 +38,30 @@ except Exception:
         return "eq=contrast=1.03:saturation=0.98", {}
 
 
+# -------- House defaults (user config) --------------------------------------
+#
+# Deterministic defaults live in house-defaults.json next to the skill root so
+# they can be edited in one place. Every lookup falls back to the built-in
+# value if the file is missing or a key is absent — the pipeline never depends
+# on the config existing.
+_DEFAULTS_PATH = Path(__file__).resolve().parent.parent / "house-defaults.json"
+try:
+    HOUSE_DEFAULTS = json.loads(_DEFAULTS_PATH.read_text())
+except Exception:
+    HOUSE_DEFAULTS = {}
+
+
+def _hd(dotted_key: str, fallback):
+    """Read a nested key like 'render.crf_final' from house-defaults.json."""
+    node = HOUSE_DEFAULTS
+    for part in dotted_key.split("."):
+        if isinstance(node, dict) and part in node:
+            node = node[part]
+        else:
+            return fallback
+    return node
+
+
 # -------- Subtitle style (bold-overlay, proven at 1920×1080 and 1080×1920) --
 #
 # MarginV is NOT taste — it is a platform safe-zone rule.
@@ -132,7 +156,13 @@ def is_hdr_source(video: Path) -> bool:
 
 
 def is_portrait_source(video: Path) -> bool:
-    """Return True if the video's height > width (portrait / vertical)."""
+    """Return True if the video DISPLAYS taller than wide (portrait / vertical).
+
+    Honors rotation metadata: phone clips are often stored landscape
+    (e.g. 1920x1080) with a 90/270° rotation flag so they display portrait.
+    Reading only stored width/height misjudges these as landscape and the
+    extract upscales the already-rotated frame (e.g. to 1920x3414).
+    """
     try:
         out = subprocess.run(
             ["ffprobe", "-v", "error", "-select_streams", "v:0",
@@ -140,10 +170,28 @@ def is_portrait_source(video: Path) -> bool:
              "-of", "csv=p=0", str(video)],
             capture_output=True, text=True, check=True,
         )
-        w, h = map(int, out.stdout.strip().split(","))
-        return h > w
+        w, h = map(int, out.stdout.strip().split(",")[:2])
     except Exception:
         return False
+
+    rotation = 0
+    for entry in ("stream_side_data=rotation", "stream_tags=rotate"):
+        try:
+            r = subprocess.run(
+                ["ffprobe", "-v", "error", "-select_streams", "v:0",
+                 "-show_entries", entry,
+                 "-of", "default=noprint_wrappers=1:nokey=1", str(video)],
+                capture_output=True, text=True, check=True,
+            ).stdout.strip().splitlines()
+            if r and r[0]:
+                rotation = int(float(r[0]))
+                break
+        except Exception:
+            continue
+
+    if abs(rotation) % 180 == 90:  # 90 or 270 → display dims are swapped
+        w, h = h, w
+    return h > w
 
 
 # -------- Per-segment extraction (Rule 2 + Rule 3) --------------------------
@@ -189,11 +237,11 @@ def extract_segment(
     af = f"afade=t=in:st=0:d=0.03,afade=t=out:st={fade_out_start:.3f}:d=0.03"
 
     if draft:
-        preset, crf = "ultrafast", "28"
+        preset, crf = "ultrafast", str(_hd("render.crf_draft", 28))
     elif preview:
-        preset, crf = "medium", "22"
+        preset, crf = "medium", str(_hd("render.crf_preview", 22))
     else:
-        preset, crf = "fast", "20"
+        preset, crf = "fast", str(_hd("render.crf_final", 20))
 
     cmd = [
         "ffmpeg", "-y",
@@ -203,7 +251,7 @@ def extract_segment(
         "-vf", vf,
         "-af", af,
         "-c:v", "libx264", "-preset", preset, "-crf", crf,
-        "-pix_fmt", "yuv420p", "-r", "24",
+        "-pix_fmt", "yuv420p", "-r", str(_hd("render.fps", 24)),
         "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
         "-movflags", "+faststart",
         str(out_path),
@@ -224,7 +272,7 @@ def extract_all_segments(
     `auto_grade_for_clip` and apply a per-segment subtle correction.
     Otherwise, apply the same preset/raw filter to every segment.
     """
-    resolved = resolve_grade_filter(edl.get("grade"))
+    resolved = resolve_grade_filter(edl.get("grade") or _hd("grade.default_preset", None))
     is_auto = resolved == "__AUTO__"
     clips_dir = edit_dir / (
         "clips_draft" if draft else ("clips_preview" if preview else "clips_graded")
@@ -389,9 +437,9 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
 
 # Social-media standard: -14 LUFS integrated, -1 dBTP peak, LRA 11 LU.
 # Matches YouTube / Instagram / TikTok / X / LinkedIn normalization targets.
-LOUDNORM_I = -14.0
-LOUDNORM_TP = -1.0
-LOUDNORM_LRA = 11.0
+LOUDNORM_I = float(_hd("audio.loudness_i", -14.0))
+LOUDNORM_TP = float(_hd("audio.loudness_tp", -1.0))
+LOUDNORM_LRA = float(_hd("audio.loudness_lra", 11.0))
 
 
 def measure_loudness(video_path: Path) -> dict[str, str] | None:

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -197,6 +197,45 @@ def is_portrait_source(video: Path) -> bool:
 # -------- Per-segment extraction (Rule 2 + Rule 3) --------------------------
 
 
+def display_dims(video: Path) -> tuple[int, int]:
+    """Return the video's DISPLAY (w, h), accounting for rotation metadata."""
+    out = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "stream=width,height", "-of", "csv=p=0", str(video)],
+        capture_output=True, text=True, check=True,
+    )
+    w, h = map(int, out.stdout.strip().split(",")[:2])
+    rotation = 0
+    for entry in ("stream_side_data=rotation", "stream_tags=rotate"):
+        try:
+            r = subprocess.run(
+                ["ffprobe", "-v", "error", "-select_streams", "v:0",
+                 "-show_entries", entry,
+                 "-of", "default=noprint_wrappers=1:nokey=1", str(video)],
+                capture_output=True, text=True, check=True,
+            ).stdout.strip().splitlines()
+            if r and r[0]:
+                rotation = int(float(r[0]))
+                break
+        except Exception:
+            continue
+    if abs(rotation) % 180 == 90:
+        w, h = h, w
+    return w, h
+
+
+def _scaled_target(source: Path, portrait: bool, target_h: int) -> tuple[int, int]:
+    """Output dims after the scale filter, for a zoompan s= value."""
+    dw, dh = display_dims(source)
+    if portrait:
+        th = target_h
+        tw = round(dw * th / dh)
+    else:
+        tw = 1280 if target_h == 1280 else 1920
+        th = round(dh * tw / dw)
+    return (tw + (tw % 2)), (th + (th % 2))
+
+
 def extract_segment(
     source: Path,
     seg_start: float,
@@ -205,6 +244,7 @@ def extract_segment(
     out_path: Path,
     preview: bool = False,
     draft: bool = False,
+    zoom: float | None = None,
 ) -> None:
     """Extract a cut range as its own MP4 with grade + 30ms audio fades baked in.
 
@@ -228,6 +268,47 @@ def extract_segment(
     if is_hdr_source(source):
         vf_parts.append(TONEMAP_CHAIN)
     vf_parts.append(scale)
+    # Animated punch-in/out zoom (emphasis). zoompan keeps a fixed output size,
+    # so it works on video; sin(0→peak→0) over the segment = smooth in-out.
+    # Applied to the base BEFORE overlays/captions composite, so captions stay anchored.
+    # zoom can be a number (whole-segment punch) or {"to": peak, "dur": seconds}
+    # for a SHORT pulse at the segment start (then back to 1.0 for the rest).
+    zcx = zcy = 0.5   # zoom anchor (frame-center default; set per-video for off-center faces)
+    if zoom:
+        if isinstance(zoom, dict):
+            peak = float(zoom["to"])
+            zdur = float(zoom.get("dur", duration))
+            zcx = float(zoom.get("cx", 0.5))
+            zcy = float(zoom.get("cy", 0.5))
+        else:
+            peak = float(zoom)
+            zdur = duration
+    else:
+        peak = 1.0
+    if peak > 1.0:
+        fps = int(_hd("render.fps", 24))
+        n = max(2, round(duration * fps))
+        wn = min(n, max(2, round(zdur * fps)))    # zoom-pulse window in frames
+        amp = peak - 1.0
+        tw, th = _scaled_target(source, portrait, 1280 if draft else 1920)
+        # Immediate punch-in → hold → punch-out within the window, then 1.0.
+        ramp = max(2, round(0.12 * fps))          # ~0.12s snap
+        if 2 * ramp >= wn:
+            ramp = max(1, wn // 3)
+        hold_end = wn - ramp
+        # Per-frame scale + center-crop. Unlike zoompan this is 1 frame in → 1
+        # frame out with no startup hold, so audio can never drift (sync-safe).
+        z = (f"if(gte(n,{wn}),1,"
+             f"if(lt(n,{ramp}),1+{amp:.4f}*(n/{ramp}),"
+             f"if(lt(n,{hold_end}),1+{amp:.4f},"
+             f"1+{amp:.4f}*(({wn}-n)/{ramp}))))")
+        vf_parts.append(f"scale=w='iw*({z})':h='ih*({z})':eval=frame")
+        # center-crop back, anchored on (zcx, zcy) so an off-center face stays centered
+        vf_parts.append(
+            f"crop=w={tw}:h={th}"
+            f":x='max(0,min(in_w-{tw},in_w*{zcx}-{tw}/2))'"
+            f":y='max(0,min(in_h-{th},in_h*{zcy}-{th}/2))'"
+        )
     if grade_filter:
         vf_parts.append(grade_filter)
     vf = ",".join(vf_parts)
@@ -299,11 +380,14 @@ def extract_all_segments(
         else:
             seg_filter = resolved
 
+        zoom = r.get("zoom")
         note = r.get("beat") or r.get("note") or ""
-        print(f"  [{i:02d}] {src_name}  {start:7.2f}-{end:7.2f}  ({duration:5.2f}s)  {note}")
+        zmark = f"  zoom×{zoom}" if zoom else ""
+        print(f"  [{i:02d}] {src_name}  {start:7.2f}-{end:7.2f}  ({duration:5.2f}s)  {note}{zmark}")
         if is_auto:
             print(f"        grade: {seg_filter or '(none)'}")
-        extract_segment(src_path, start, duration, seg_filter, out_path, preview=preview, draft=draft)
+        extract_segment(src_path, start, duration, seg_filter, out_path,
+                        preview=preview, draft=draft, zoom=zoom)
         seg_paths.append(out_path)
 
     return seg_paths

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -273,16 +273,9 @@ def extract_segment(
     # Applied to the base BEFORE overlays/captions composite, so captions stay anchored.
     # zoom can be a number (whole-segment punch) or {"to": peak, "dur": seconds}
     # for a SHORT pulse at the segment start (then back to 1.0 for the rest).
-    zcx = zcy = 0.5   # zoom anchor (frame-center default; set per-video for off-center faces)
     if zoom:
-        if isinstance(zoom, dict):
-            peak = float(zoom["to"])
-            zdur = float(zoom.get("dur", duration))
-            zcx = float(zoom.get("cx", 0.5))
-            zcy = float(zoom.get("cy", 0.5))
-        else:
-            peak = float(zoom)
-            zdur = duration
+        peak = float(zoom["to"]) if isinstance(zoom, dict) else float(zoom)
+        zdur = float(zoom["dur"]) if isinstance(zoom, dict) and "dur" in zoom else duration
     else:
         peak = 1.0
     if peak > 1.0:
@@ -302,12 +295,12 @@ def extract_segment(
              f"if(lt(n,{ramp}),1+{amp:.4f}*(n/{ramp}),"
              f"if(lt(n,{hold_end}),1+{amp:.4f},"
              f"1+{amp:.4f}*(({wn}-n)/{ramp}))))")
+        # scale enlarges from the top-left, so center the crop per-frame using
+        # the same z expression (crop's default init-time centering would stay
+        # locked at z=1 → top-left). Offset = half the growth each axis.
         vf_parts.append(f"scale=w='iw*({z})':h='ih*({z})':eval=frame")
-        # center-crop back, anchored on (zcx, zcy) so an off-center face stays centered
         vf_parts.append(
-            f"crop=w={tw}:h={th}"
-            f":x='max(0,min(in_w-{tw},in_w*{zcx}-{tw}/2))'"
-            f":y='max(0,min(in_h-{th},in_h*{zcy}-{th}/2))'"
+            f"crop={tw}:{th}:x='{tw/2:.1f}*(({z})-1)':y='{th/2:.1f}*(({z})-1)'"
         )
     if grade_filter:
         vf_parts.append(grade_filter)

--- a/house-defaults.json
+++ b/house-defaults.json
@@ -13,6 +13,6 @@
   "pacing":   { "talking_head_speed": 1.2, "open_cold_on_hook": true,
                 "boost_slow_regions": true, "slow_region_speed": 1.4 },
   "broll":    { "start_at_hook": true, "body_max_gap_s": 3, "fallback_to_animation": true },
-  "zoom":     { "emphasis_to": 1.27, "snap_s": 0.12, "center_x": 0.40, "center_y": 0.5,
+  "zoom":     { "emphasis_to": 1.27, "snap_s": 0.12, "center_x": 0.36, "center_y": 0.40,
                 "retention_after_hook": true, "retention_to": 1.27, "retention_dur": 2.5 }
 }

--- a/house-defaults.json
+++ b/house-defaults.json
@@ -12,7 +12,8 @@
                 "primary_color": "#F5F5F5", "secondary_color": "#8AB4F8", "secondary_border": "#4285F4" },
   "pacing":   { "talking_head_speed": 1.2, "open_cold_on_hook": true,
                 "boost_slow_regions": true, "slow_region_speed": 1.4 },
-  "broll":    { "start_at_hook": true, "body_max_gap_s": 3, "fallback_to_animation": true },
-  "zoom":     { "emphasis_to": 1.27, "snap_s": 0.12, "center_x": 0.36, "center_y": 0.40,
-                "retention_after_hook": true, "retention_to": 1.27, "retention_dur": 2.5 }
+  "broll":    { "start_at_hook": true, "body_max_gap_s": 3, "fallback_to_animation": true,
+                "prefer_fewer_longer": true },
+  "zoom":     { "emphasis_peak": 1.27, "snap_seconds": 0.12, "hook_uses_broll": true,
+                "retention_after_hook": true, "retention_pulse_seconds": 2.5 }
 }

--- a/house-defaults.json
+++ b/house-defaults.json
@@ -6,6 +6,13 @@
   "audio":    { "loudness_i": -14.0, "loudness_tp": -1.0, "loudness_lra": 11.0 },
   "grade":    { "default_preset": "neutral_punch" },
   "look":     { "accent_hex": "#4285F4", "card_bg_hex": "#0F1115", "single_accent": true },
-  "captions": { "style": "clean-phrase", "max_words": 4, "case": "sentence", "margin_v": 90 },
-  "pacing":   { "talking_head_speed": 1.2, "open_cold_on_hook": true }
+  "captions": { "style": "clean-phrase", "max_words": 4, "case": "sentence", "margin_v": 90,
+                "dual_language": true, "primary_lang": "id", "secondary_lang": "en",
+                "separate_pills": true, "secondary_scale": 1.0,
+                "primary_color": "#F5F5F5", "secondary_color": "#8AB4F8", "secondary_border": "#4285F4" },
+  "pacing":   { "talking_head_speed": 1.2, "open_cold_on_hook": true,
+                "boost_slow_regions": true, "slow_region_speed": 1.4 },
+  "broll":    { "start_at_hook": true, "body_max_gap_s": 3, "fallback_to_animation": true },
+  "zoom":     { "emphasis_to": 1.27, "snap_s": 0.12, "center_x": 0.40, "center_y": 0.5,
+                "retention_after_hook": true, "retention_to": 1.27, "retention_dur": 2.5 }
 }

--- a/house-defaults.json
+++ b/house-defaults.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Kent's deterministic video-use defaults. render.py auto-reads render.*, audio.*, grade.default_preset (with built-in fallbacks if this file is missing). The remaining keys are read by the editing agent each session — single source of truth, edit values here.",
+
+  "format":   { "aspect": "vertical", "width": 1080, "height": 1920, "fps": 24 },
+  "render":   { "fps": 24, "crf_final": 20, "crf_preview": 22, "crf_draft": 28 },
+  "audio":    { "loudness_i": -14.0, "loudness_tp": -1.0, "loudness_lra": 11.0 },
+  "grade":    { "default_preset": "neutral_punch" },
+  "look":     { "accent_hex": "#4285F4", "card_bg_hex": "#0F1115", "single_accent": true },
+  "captions": { "style": "clean-phrase", "max_words": 4, "case": "sentence", "margin_v": 90 },
+  "pacing":   { "talking_head_speed": 1.2, "open_cold_on_hook": true }
+}

--- a/house-style.md
+++ b/house-style.md
@@ -53,9 +53,9 @@ everywhere. Aim for ~4–5 B-rolls (each covering a whole concept beat) plus a f
   zoom beat.**
 - **Retention zoom:** when `zoom.retention_after_hook`, add a short zoom pulse ~2–3s after the
   hook (right after the first B-roll) via a windowed zoom, then let a B-roll come in after it.
-- **Anchor on the FACE, not the frame.** Set `zoom.center_x` (Kent's face sits ~0.40, left of
-  frame center) so he stays centered when it punches in; `center_y` defaults 0.5. A
-  frame-centered zoom on an off-center face looks "too left."
+- **Anchor on the FACE, not the frame**, on BOTH axes. Kent's face sits low-left in frame, so
+  `zoom.center_x` ≈ 0.36 and `zoom.center_y` ≈ 0.40 keep him center-center on the punch.
+  Frame-centered (`0.5/0.5`) leaves him "top-left" because his face is left of and above center.
 - **MECHANISM (Hard):** use `render.py`'s `zoom` field — a number (whole-segment) or
   `{"to","dur","cx","cy"}` (windowed pulse). It's a per-frame scale + center-crop, which is
   **sync-safe**. Do **NOT** use ffmpeg `zoompan` — its startup stutter holds the video while

--- a/house-style.md
+++ b/house-style.md
@@ -1,0 +1,39 @@
+# Kent's house style
+
+Read this during the **Converse/Propose** step and apply. These are user
+defaults: they override the skill's *artistic-freedom* defaults, **not** the
+Hard Rules. Confirm per-video — don't blind-apply.
+
+> **Numbers live in `house-defaults.json`** (same dir). `render.py` auto-reads
+> `render.*`, `audio.*`, and `grade.default_preset`. Read the rest of that file
+> for exact values (accent, caption params, speed). Edit values *there*, not here.
+
+Only what the skill doesn't already say:
+
+## Defaults that OVERRIDE the skill
+- **Aspect:** default to vertical short-form (skill defaults to "match source").
+- **Grade:** default `neutral_punch` (skill defaults to none). Also enforced via config.
+- **Captions:** clean-phrase style — 3–4 word chunks, **sentence case** (skill ships
+  2-word UPPERCASE as default). Lower-third safe zone.
+- **Accent:** assume a single accent color by default (skill says never assume) —
+  `look.accent_hex` in config; Google topics → Google blue.
+
+## Workflow
+- **Open cold on the hook** — kill leading/trailing dead air; first frame = the hook line.
+- **B-roll:** prefer *authentic UI recreations* (HyperFrames) over abstract mockups.
+  For brand/product topics, replicate the real product UI.
+- **Always ask my niche/business before writing example queries or business names**
+  into graphics. Never invent a niche.
+
+## Mechanisms not in the skill
+- **Talking-head speed-up:** default a global ~`pacing.talking_head_speed`× pitch-preserved
+  speed-up. There is no helper — apply it as a FINAL ffmpeg pass over the composed video:
+  `setpts=PTS/N,fps=<fps>` for video + `atempo=N` for audio. Do it after compositing so
+  overlays/captions stay in sync. Confirm the factor per video.
+
+## This machine — env constraint (causes silent failure)
+- ffmpeg here is built **without libass/freetype** → the `subtitles`, `ass`, and `drawtext`
+  filters DO NOT EXIST. Do **not** use `render.py --build-subtitles` or the EDL `subtitles`
+  field. Render captions as a transparent PIL overlay track and composite it as the LAST
+  overlay (still satisfies Hard Rule 1).
+- (Rotated phone clips are now handled automatically by `render.py` — no manual bake needed.)

--- a/house-style.md
+++ b/house-style.md
@@ -23,10 +23,11 @@ Only what the skill doesn't already say:
 - **Open cold on the hook** — kill leading/trailing dead air; first frame = the hook line.
 - **B-roll:** prefer *authentic UI recreations* (HyperFrames) over abstract mockups.
   For brand/product topics, replicate the real product UI.
-- **B-roll cadence (retention):** start B-roll/visual at the **hook** (frame 0 region), not
-  just later. Through the **body**, never leave more than `broll.body_max_gap_s` (~3s) of bare
-  talking head after the previous B-roll ends — drop in another B-roll, or at minimum a small
-  animation/overlay (`broll.fallback_to_animation`). Something visual almost always on screen.
+- **B-roll rhythm (retention):** start a visual at the **hook**. Prefer **fewer, longer**
+  B-rolls that each carry a whole concept beat (`broll.prefer_fewer_longer`), with
+  **snap-zooms on emphasis** filling between (see *Emphasis zooms*). A zoom counts as
+  "something visual," so a bare-but-zoomed stretch is fine; just avoid long flat
+  talking-head with neither. Never leave more than ~`broll.body_max_gap_s` of nothing.
 - **Always ask my niche/business before writing example queries or business names**
   into graphics. Never invent a niche.
 
@@ -43,28 +44,19 @@ Only what the skill doesn't already say:
   speed), not one global atempo. Keep cuts on word boundaries; re-sync captions/overlays to the
   retimed segment offsets.
 
-## Snap zooms (emphasis + retention) + B-roll balance
-
-Fewer, longer B-rolls + punch-zooms on emphasis reads more confident than dense B-roll
-everywhere. Aim for ~4–5 B-rolls (each covering a whole concept beat) plus a few zooms.
-
-- **Emphasis zoom:** on an emphasized Indonesian phrase, punch IN immediately (`zoom.snap_s`
-  ≈0.12s) to `zoom.emphasis_to` (~127%), hold through the phrase, snap OUT. **No B-roll on a
-  zoom beat.**
-- **Retention zoom:** when `zoom.retention_after_hook`, add a short zoom pulse ~2–3s after the
-  hook (right after the first B-roll) via a windowed zoom, then let a B-roll come in after it.
-- **Anchor on the FACE, not the frame**, on BOTH axes. Kent's face sits low-left in frame, so
-  `zoom.center_x` ≈ 0.36 and `zoom.center_y` ≈ 0.40 keep him center-center on the punch.
-  Frame-centered (`0.5/0.5`) leaves him "top-left" because his face is left of and above center.
-- **MECHANISM (Hard):** use `render.py`'s `zoom` field — a number (whole-segment) or
-  `{"to","dur","cx","cy"}` (windowed pulse). It's a per-frame scale + center-crop, which is
-  **sync-safe**. Do **NOT** use ffmpeg `zoompan` — its startup stutter holds the video while
-  audio runs on, desyncing lip-sync.
-
-## Overlay / caption placement
-- Graphics/B-roll cards live in the **top region** (above the speaker's eyes); captions in the
-  **lower third**. Keeps the face clear and avoids collisions. (Tuned for Kent's centered-ish
-  vertical selfie framing — adjust to the actual subject.)
+## Emphasis zooms (snap-in)
+- On emphasized Indonesian phrases, **snap-zoom** the face: immediate punch-in
+  (~`zoom.snap_seconds` 0.12s) to ~`zoom.emphasis_peak` (1.27×), **hold** through the
+  phrase, snap back out. NOT a slow ramp.
+- **A zoom and a B-roll don't stack** — when a beat gets a zoom, it gets no B-roll, and
+  vice-versa.
+- The **hook uses B-roll, not a zoom** (`zoom.hook_uses_broll`). Add a short **retention
+  zoom** ~2–3s after the hook B-roll (`zoom.retention_after_hook`, pulse length
+  `zoom.retention_pulse_seconds`) to re-grab attention.
+- Implementation: the render.py **`zoom` field** on an EDL range — a number (whole-segment
+  punch) or `{"to": peak, "dur": seconds}` for a short pulse inside a longer beat. It's a
+  per-frame **scale + center-crop** (1 frame in → 1 frame out, re-centered every frame).
+  **Never `zoompan`** — it stutters on startup and drifts A/V sync.
 
 ## Dual-language captions (Indonesian + English)
 

--- a/house-style.md
+++ b/house-style.md
@@ -14,7 +14,8 @@ Only what the skill doesn't already say:
 - **Aspect:** default to vertical short-form (skill defaults to "match source").
 - **Grade:** default `neutral_punch` (skill defaults to none). Also enforced via config.
 - **Captions:** clean-phrase style — 3–4 word chunks, **sentence case** (skill ships
-  2-word UPPERCASE as default). Lower-third safe zone.
+  2-word UPPERCASE as default). Lower-third safe zone. **Dual-language** (Indonesian
+  primary + English below) — see *Dual-language captions* below.
 - **Accent:** assume a single accent color by default (skill says never assume) —
   `look.accent_hex` in config; Google topics → Google blue.
 
@@ -22,6 +23,10 @@ Only what the skill doesn't already say:
 - **Open cold on the hook** — kill leading/trailing dead air; first frame = the hook line.
 - **B-roll:** prefer *authentic UI recreations* (HyperFrames) over abstract mockups.
   For brand/product topics, replicate the real product UI.
+- **B-roll cadence (retention):** start B-roll/visual at the **hook** (frame 0 region), not
+  just later. Through the **body**, never leave more than `broll.body_max_gap_s` (~3s) of bare
+  talking head after the previous B-roll ends — drop in another B-roll, or at minimum a small
+  animation/overlay (`broll.fallback_to_animation`). Something visual almost always on screen.
 - **Always ask my niche/business before writing example queries or business names**
   into graphics. Never invent a niche.
 
@@ -30,6 +35,55 @@ Only what the skill doesn't already say:
   speed-up. There is no helper — apply it as a FINAL ffmpeg pass over the composed video:
   `setpts=PTS/N,fps=<fps>` for video + `atempo=N` for audio. Do it after compositing so
   overlays/captions stay in sync. Confirm the factor per video.
+- **Variable speed-up on slow stretches (retention):** beyond the global factor, when
+  `pacing.boost_slow_regions` is on, find the low-energy spots — long intra-phrase pauses and
+  slow words-per-second runs (read gaps/word timings from the transcript) — and speed *those
+  regions* harder (~`pacing.slow_region_speed`×) while leaving punchy lines at the base factor.
+  Implement as per-segment tempo in the EDL/extract (a region = its own EDL range with its own
+  speed), not one global atempo. Keep cuts on word boundaries; re-sync captions/overlays to the
+  retimed segment offsets.
+
+## Snap zooms (emphasis + retention) + B-roll balance
+
+Fewer, longer B-rolls + punch-zooms on emphasis reads more confident than dense B-roll
+everywhere. Aim for ~4–5 B-rolls (each covering a whole concept beat) plus a few zooms.
+
+- **Emphasis zoom:** on an emphasized Indonesian phrase, punch IN immediately (`zoom.snap_s`
+  ≈0.12s) to `zoom.emphasis_to` (~127%), hold through the phrase, snap OUT. **No B-roll on a
+  zoom beat.**
+- **Retention zoom:** when `zoom.retention_after_hook`, add a short zoom pulse ~2–3s after the
+  hook (right after the first B-roll) via a windowed zoom, then let a B-roll come in after it.
+- **Anchor on the FACE, not the frame.** Set `zoom.center_x` (Kent's face sits ~0.40, left of
+  frame center) so he stays centered when it punches in; `center_y` defaults 0.5. A
+  frame-centered zoom on an off-center face looks "too left."
+- **MECHANISM (Hard):** use `render.py`'s `zoom` field — a number (whole-segment) or
+  `{"to","dur","cx","cy"}` (windowed pulse). It's a per-frame scale + center-crop, which is
+  **sync-safe**. Do **NOT** use ffmpeg `zoompan` — its startup stutter holds the video while
+  audio runs on, desyncing lip-sync.
+
+## Overlay / caption placement
+- Graphics/B-roll cards live in the **top region** (above the speaker's eyes); captions in the
+  **lower third**. Keeps the face clear and avoids collisions. (Tuned for Kent's centered-ish
+  vertical selfie framing — adjust to the actual subject.)
+
+## Dual-language captions (Indonesian + English)
+
+Render **two SEPARATE caption pills**, same font size (`secondary_scale` 1.0): Indonesian
+primary on top (white `primary_color` on a dark pill), English in its own pill a bit below
+(`secondary_color` light Google-blue text + `secondary_border` blue outline — clearly marks
+the translation). A gap between the two pills. Both inside the lower-third safe zone.
+
+Build order matters — **translate whole, then chunk** (never translate cue-by-cue):
+1. Take the full Indonesian transcript and **translate the ENTIRE thing to coherent English
+   first** (whole-text, so meaning/flow is right).
+2. Chunk that English with the **same rules as Indonesian** (`captions.max_words`, sentence
+   case).
+3. The two languages **do NOT need to match word-for-word within a frame** — literal
+   alignment is often impossible. Time the English cues to the Indonesian timeline at the
+   **segment/sentence level** (English progresses alongside Indonesian over the same span),
+   not per-word.
+4. Render English as a second transparent overlay line just under the Indonesian one; same
+   safe-zone, same composite-last rule.
 
 ## This machine — env constraint (causes silent failure)
 - ffmpeg here is built **without libass/freetype** → the `subtitles`, `ass`, and `drawtext`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Kent’s house style with config-driven defaults and a guide. Also adds rotation-aware portrait handling and a sync-safe per-segment snap-zoom, with render/audio/grade settings overridable via `house-defaults.json`.

- **New Features**
  - Config defaults: `render.*`, `audio.*`, and `grade.default_preset` auto-loaded from `house-defaults.json` with safe fallbacks. CRF, FPS, and loudness now come from config.
  - Emphasis zooms: new EDL `zoom` field (number or `{ "to": x, "dur": s }`). Implemented via per-frame scale + center-crop (sync-safe), applied before overlays/captions.
  - Rotation-aware inputs: correct display dims and portrait detection for rotated phone videos.
  - Docs: added `house-style.md`; `SKILL.md` now tells the agent to apply `house-style.md` and `house-defaults.json` before Converse/Propose.

- **Migration**
  - Optional: drop `house-defaults.json` in the skill root to adopt these defaults; without it, built-ins are used.
  - To add zooms, set `zoom` on EDL ranges (e.g., `1.27` or `{ "to": 1.27, "dur": 2.5 }`).
  - On this machine, avoid FFmpeg `subtitles`/`ass`/`drawtext`; render captions as transparent overlays as described in `house-style.md`.

<sup>Written for commit 1755cc7bf243d8bd436dc2c579ba4ac707ca755d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

