### PR TITLE
render: fix progressive A/V (lip-sync) drift across multi-segment concats

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -3,7 +3,7 @@
 Implements the HEURISTICS render pipeline in the correct order:
 
   1. Per-segment extract with color grade + 30ms audio fades baked in
-  2. Lossless -c copy concat into base.mp4
+  2. Lossless -c copy concat into base.mov (PCM audio, sample-exact)
   3. If overlays or subtitles: single filter graph that overlays animations
      (with PTS shift so frame 0 lands at the overlay window start)
      and applies `subtitles` filter LAST → final.mp4
@@ -54,6 +54,11 @@ SUB_FORCE_STYLE = (
     "BorderStyle=1,Outline=2,Shadow=0,"
     "Alignment=2,MarginV=90"
 )
+
+# All renders are CFR at this rate; segment durations quantize to whole frames
+# of it so the audio track can be cut to the exact same length (see
+# extract_segment). Keep the -r flag and this constant in lockstep.
+OUTPUT_FPS = 24
 
 # -------- Helpers ------------------------------------------------------------
 
@@ -184,9 +189,20 @@ def extract_segment(
         vf_parts.append(grade_filter)
     vf = ",".join(vf_parts)
 
+    # Quantize the segment to whole output frames, then force the audio to the
+    # exact same duration (PCM intermediates are sample-exact). Otherwise video
+    # rounds up to a whole frame while audio keeps the raw -t length; the
+    # ~17-40ms per-segment mismatch accumulates through the -c copy concat into
+    # audible progressive A/V drift (measured -0.57s over 37 segments).
+    n_frames = max(1, int(round(duration * OUTPUT_FPS)))
+    vdur = n_frames / OUTPUT_FPS
+
     # 30ms audio fades at both edges (Rule 3) — prevent pops
-    fade_out_start = max(0.0, duration - 0.03)
-    af = f"afade=t=in:st=0:d=0.03,afade=t=out:st={fade_out_start:.3f}:d=0.03"
+    fade_out_start = max(0.0, vdur - 0.03)
+    af = (
+        f"afade=t=in:st=0:d=0.03,afade=t=out:st={fade_out_start:.3f}:d=0.03,"
+        f"atrim=end={vdur:.6f},apad=whole_dur={vdur:.6f}"
+    )
 
     if draft:
         preset, crf = "ultrafast", "28"
@@ -199,13 +215,15 @@ def extract_segment(
         "ffmpeg", "-y",
         "-ss", f"{seg_start:.3f}",
         "-i", str(source),
-        "-t", f"{duration:.3f}",
+        # -t overshoots by 0.5s so the audio filters have enough input to
+        # atrim/apad to exactly vdur; video is capped by -frames:v instead.
+        "-t", f"{vdur + 0.5:.3f}",
+        "-frames:v", str(n_frames),
         "-vf", vf,
         "-af", af,
         "-c:v", "libx264", "-preset", preset, "-crf", crf,
-        "-pix_fmt", "yuv420p", "-r", "24",
-        "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
-        "-movflags", "+faststart",
+        "-pix_fmt", "yuv420p", "-r", str(OUTPUT_FPS),
+        "-c:a", "pcm_s16le", "-ar", "48000",
         str(out_path),
     ]
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
@@ -217,7 +235,7 @@ def extract_all_segments(
     preview: bool,
     draft: bool = False,
 ) -> list[Path]:
-    """Extract every EDL range into edit_dir/clips_graded/seg_NN.mp4.
+    """Extract every EDL range into edit_dir/clips_graded/seg_NN.mov.
     Returns the ordered list of segment paths.
 
     If the EDL `grade` is "auto", analyze each segment range with
@@ -244,7 +262,7 @@ def extract_all_segments(
         start = float(r["start"])
         end = float(r["end"])
         duration = end - start
-        out_path = clips_dir / f"seg_{i:02d}_{src_name}.mp4"
+        out_path = clips_dir / f"seg_{i:02d}_{src_name}.mov"
 
         if is_auto:
             seg_filter, _stats = auto_grade_for_clip(src_path, start=start, duration=duration, verbose=False)
@@ -508,8 +526,10 @@ def build_final_composite(
     has_subs = subtitles_path is not None and subtitles_path.exists()
 
     if not has_overlays and not has_subs:
-        # Nothing to do — just rename/copy base to final name
-        run(["ffmpeg", "-y", "-i", str(base_path), "-c", "copy", str(out_path)], quiet=True)
+        # No filters — copy video, encode the PCM intermediate audio to AAC for mp4
+        run(["ffmpeg", "-y", "-i", str(base_path), "-c:v", "copy",
+             "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
+             "-movflags", "+faststart", str(out_path)], quiet=True)
         return
 
     inputs: list[str] = ["-i", str(base_path)]
@@ -560,7 +580,7 @@ def build_final_composite(
         "-map", "0:a",
         "-c:v", "libx264", "-preset", "fast", "-crf", "18",
         "-pix_fmt", "yuv420p",
-        "-c:a", "copy",
+        "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
         "-movflags", "+faststart",
         str(out_path),
     ]
@@ -618,11 +638,11 @@ def main() -> None:
 
     # 2. Concat → base
     if args.draft:
-        base_name = "base_draft.mp4"
+        base_name = "base_draft.mov"
     elif args.preview:
-        base_name = "base_preview.mp4"
+        base_name = "base_preview.mov"
     else:
-        base_name = "base.mp4"
+        base_name = "base.mov"
     base_path = edit_dir / base_name
     concat_segments(segment_paths, base_path, edit_dir)
 


### PR DESCRIPTION
## Summary

Long EDLs render with progressively worsening lip-sync: the audio runs ahead of the video, getting worse toward the end of the timeline. On a real 37-segment / 103 s edit, audio was **−570 ms early** by the last segment — blatantly visible.

## Root cause

`extract_segment()` writes each segment with `-t <duration>` at CFR `-r 24` + AAC audio:

- the **video** stream rounds up to a whole frame (41.7 ms steps at 24 fps)
- the **audio** stream keeps the raw `-t` length (quantized only by AAC's 21.3 ms frame size)

so every segment's audio ends up ~17–40 ms **shorter** than its video. `concat_segments()` then concatenates with `-c copy`, and the concat demuxer packs each stream back-to-back independently — so the mismatch accumulates: segment N's audio plays roughly N × 17 ms before its video.

Measured on a 37-segment EDL (per-segment `ffprobe` stream durations):

| | video sum | audio sum | cumulative |
|---|---|---|---|
| before | 103.792 s | 103.170 s | **−0.622 s** |

Cross-correlating the output audio against the source audio at each segment's video-timeline position (numpy, 16 kHz mono, ±0.8 s search window) confirms the drift is progressive and audible:

| segment | output pos | lag before | lag after |
|---|---|---|---|
| 0 | 0.0 s | −21 ms | 0.0 ms |
| 8 | 27 s | −116 ms | −0.1 ms |
| 19 | 57 s | −318 ms | −0.1 ms |
| 29 | 84 s | −423 ms | 0.0 ms |
| 35 | 101 s | **−569 ms** | 0.0 ms |

(correlation confidence 0.90–1.00 at every checkpoint)

## Fix

1. **Quantize each segment to whole output frames**: `n_frames = round(duration × OUTPUT_FPS)`, `vdur = n_frames / OUTPUT_FPS`; cap video with `-frames:v` (the `-t` now overshoots by 0.5 s purely to give the audio filters enough input).
2. **Force audio to exactly `vdur`** with `atrim=end=vdur,apad=whole_dur=vdur` (the 30 ms fades are unchanged, now timed against `vdur`).
3. **Use sample-exact PCM (`pcm_s16le`) in `.mov` intermediates** instead of AAC mp4 segments — PCM stream durations are sample-accurate, with no encoder priming or frame rounding to survive the concat demuxer.
4. **Encode AAC once at the final composite**: `build_final_composite()`'s early-return and filter paths now use `-c:a aac -b:a 192k` instead of `-c copy`/`-c:a copy`. Final deliverables are unchanged (`.mp4`, h264 + AAC, `+faststart`).

## After

- all 37 segments: |audio − video| = **0.0 ms**, cumulative diff **0.0000 s**
- cross-correlation lag **0.0 ms (±0.1 ms)** at every checkpoint across the 103 s timeline
- container duration now matches the EDL sum exactly (was +0.6 s)

## Notes

- Intermediates are renamed `clips_*/seg_NN_<src>.mov` and `base*.mov` (PCM-in-mp4 is poorly supported; final outputs are still mp4). PCM audio costs ~11.5 MB/min of intermediate disk — negligible next to the video data.
- Behavior when a range overruns the source EOF is unchanged: `apad` fills audio to `vdur`; video may still come up short, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes progressive lip-sync drift across multi-segment renders. Audio now stays aligned with video across the entire timeline (measured −570 ms -> 0 ms on a 103 s/37-segment edit).

- **Bug Fixes**
  - Quantize each segment to whole frames at `OUTPUT_FPS=24` and cap video with `-frames:v`.
  - Force audio to match `vdur` exactly using `atrim` + `apad` (30 ms fades now timed to `vdur`).
  - Switch intermediates to sample-exact PCM `.mov` for safe `-c copy` concat; encode AAC only once in the final composite.
  - Outcome: 0.0 ms drift across the full edit; container duration matches the EDL sum.

- **Migration**
  - Intermediates are now `.mov`: `clips_*/seg_*.mov` and `base*.mov`. Update any scripts that referenced `.mp4`.
  - Final deliverables remain `.mp4` (H.264 + AAC, `+faststart`).

<sup>Written for commit f7206d8822cdc57cc8e6b88a2484c9c722d11f42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

