### PR TITLE
Add plugin manifest and skill entry for agent marketplaces

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "video-use",
+  "version": "0.1.0",
+  "description": "Edit videos with a coding agent. Transcribe, cut filler, color grade, generate overlay animations, burn subtitles — conversational, no presets. Ships skills only; clone + ffmpeg + ElevenLabs key are a one-time install prerequisite.",
+  "author": { "name": "Browser Use", "url": "https://browser-use.com" },
+  "homepage": "https://github.com/browser-use/video-use",
+  "repository": "https://github.com/browser-use/video-use",
+  "license": "MIT",
+  "keywords": ["video", "editing", "ffmpeg", "transcript", "subtitles", "elevenlabs", "browser-use"]
+}

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "video-use",
+  "version": "0.1.0",
+  "description": "Edit videos with a coding agent. Transcribe, cut filler, color grade, generate overlay animations, burn subtitles — conversational, no presets. Ships skills only; clone + ffmpeg + ElevenLabs key are a one-time install prerequisite.",
+  "author": { "name": "Browser Use", "url": "https://browser-use.com" },
+  "homepage": "https://github.com/browser-use/video-use",
+  "repository": "https://github.com/browser-use/video-use",
+  "license": "MIT",
+  "keywords": ["video", "editing", "ffmpeg", "transcript", "subtitles", "elevenlabs", "browser-use"]
+}

--- a/skills/video-use/SKILL.md
+++ b/skills/video-use/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: video-use
+description: Edit any video by conversation. Transcribe, cut, color grade, generate overlay animations, burn subtitles — for talking heads, montages, tutorials, travel, interviews. No presets, no menus. Ask questions, confirm the plan, execute, iterate, persist. Production-correctness rules are hard; everything else is artistic freedom.
+---
+
+# video-use
+
+This is the plugin entry point for video-use. The full production rules, editing craft, and pipeline live in the repo-root `SKILL.md`; the editing scripts live in `helpers/`.
+
+## Prerequisite (one-time — NOT part of the AI workflow)
+
+video-use needs the repo cloned plus `ffmpeg` and an ElevenLabs API key. If `${CLAUDE_PLUGIN_ROOT}/helpers/transcribe.py` and `ffmpeg` aren't available, do the one-time setup in [`${CLAUDE_PLUGIN_ROOT}/install.md`](../../install.md) first.
+
+## Start here
+
+1. Read the complete skill — production rules, the ask→confirm→execute→self-eval→persist loop, and the cut craft — at **`${CLAUDE_PLUGIN_ROOT}/SKILL.md`**. That file is authoritative; follow it exactly.
+2. The editing scripts (`transcribe.py`, `render.py`, `timeline_view.py`, …) are in **`${CLAUDE_PLUGIN_ROOT}/helpers/`**. Always read them before running — that's where the real logic lives.
+3. For animation overlays, the `manim-video` skill in this plugin covers Manim-based generation.
+
+## The one-line model
+
+The LLM never watches the video — it *reads* it: a packed word-level transcript (`takes_packed.md`) is the primary surface, and `timeline_view` renders a filmstrip + waveform PNG only at decision points. Cuts come from speech boundaries and silence, never frame-dumping. Don't touch the cut without strategy approval.


### PR DESCRIPTION
Makes video-use the canonical, no-drift source of its own plugin, so the `browser-use/plugins` marketplace can remote-source this repo instead of vendoring a copy.

- `.grok-plugin/` + `.claude-plugin/` manifests.
- `skills/video-use/SKILL.md` — thin entry redirecting to the root `SKILL.md` and `helpers/` via `${CLAUDE_PLUGIN_ROOT}`. Non-destructive: root `SKILL.md`, `helpers/`, `install.md`, and the `manim-video` skill are untouched. `claude plugin details` then shows both skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds plugin manifests and a thin skill entry so `video-use` can be installed from agent marketplaces (Claude Code, xAI Grok) directly from this repo. This removes vendored copies and makes this repo the canonical source.

- **New Features**
  - Added `.claude-plugin/plugin.json` and `.grok-plugin/plugin.json` with plugin metadata.
  - Added `skills/video-use/SKILL.md` that redirects to root `SKILL.md` and `helpers/` via `${CLAUDE_PLUGIN_ROOT}`; existing root docs and `manim-video` stay unchanged.
  - Keeps install model the same (clone + `ffmpeg` + ElevenLabs key). Marketplaces like `browser-use/plugins` can remote-source this repo; `claude plugin details` shows both skills.

<sup>Written for commit 3e7cf02feaff4c9d8b5843fe35aa724cadcf2587. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

