### PR TITLE
Fix is_portrait_source: account for display-matrix rotation

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -131,8 +131,37 @@ def is_hdr_source(video: Path) -> bool:
         return False
 
 
+def _probe_rotation(video: Path) -> int:
+    """Display rotation in degrees, normalized to a 0/90 orientation-swap flag.
+
+    Returns 90 when the display matrix rotates the picture a quarter turn
+    (±90 / ±270), else 0. 180 keeps orientation, so it maps to 0.
+    """
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream_side_data=rotation:stream_tags=rotate",
+             "-of", "default=nw=1:nk=1", str(video)],
+            capture_output=True, text=True, check=True,
+        )
+        for line in out.stdout.splitlines():
+            tok = line.strip()
+            if tok.lstrip("-").isdigit():
+                return abs(int(tok)) % 180  # 90 -> swap, 0/180 -> no swap
+        return 0
+    except Exception:
+        return 0
+
+
 def is_portrait_source(video: Path) -> bool:
-    """Return True if the video's height > width (portrait / vertical)."""
+    """Return True if the video DISPLAYS taller than wide (portrait / vertical).
+
+    Accounts for rotation metadata: a phone clip stored 848x480 with rotation
+    ±90 actually displays as 480x848 (portrait). ffmpeg auto-applies the display
+    matrix on decode, so the scale filter must match the DISPLAYED orientation.
+    Comparing only raw width/height misclassifies rotated mobile sources and
+    blows up the output geometry (e.g. 1920x3392 instead of 1080x1920).
+    """
     try:
         out = subprocess.run(
             ["ffprobe", "-v", "error", "-select_streams", "v:0",
@@ -140,7 +169,9 @@ def is_portrait_source(video: Path) -> bool:
              "-of", "csv=p=0", str(video)],
             capture_output=True, text=True, check=True,
         )
-        w, h = map(int, out.stdout.strip().split(","))
+        w, h = map(int, out.stdout.strip().split(",")[:2])
+        if _probe_rotation(video) == 90:
+            w, h = h, w
         return h > w
     except Exception:
         return False


### PR DESCRIPTION
Renders of vertical phone footage come out with broken geometry because `is_portrait_source` ignores rotation metadata.

## Repro
A clip shot on a phone is often stored **landscape** (e.g. `848x480`) with a `rotation=-90` display matrix, and displays **vertically** (`480x848`). ffmpeg auto-applies the display matrix on decode.

`is_portrait_source` only compares raw `width`/`height`, so it classifies the clip as landscape and `extract_segment` picks `scale=1920:-2`. After ffmpeg applies the rotation, scaling the (now portrait) frame by width to 1920 yields a stretched **1920x3392** instead of ~**1080x1920** — wrong aspect, and roughly double the file size.

```
$ ffprobe -select_streams v:0 -show_entries stream_side_data=rotation in.mp4
rotation=-90
# before this patch:
$ ffprobe -select_streams v:0 -show_entries stream=width,height final.mp4
width=1920
height=3392
```

## Fix
Add `_probe_rotation()` (reads `stream_side_data=rotation` / `stream_tags=rotate`) and have `is_portrait_source` swap orientation on a quarter-turn (±90/±270; 180 keeps orientation). The scale branch then matches the displayed frame.

## Verification
Same real `848x480`, `rotation=-90` clip after the patch:

```
width=1086
height=1920
```

Correct 9:16, file size roughly halved. No change for non-rotated or genuinely-landscape sources (rotation 0/180 → no swap).

---
Assisted-By: Claude (Anthropic) — patch authored with Claude Code; human is sole author of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes portrait detection to respect display-matrix rotation so vertical phone footage scales correctly. Prevents stretched outputs (e.g., 1920x3392) and lowers file size.

- **Bug Fixes**
  - Added `_probe_rotation()` to read `stream_side_data=rotation` and `stream_tags=rotate` via `ffprobe`.
  - Updated `is_portrait_source` to swap width/height on ±90/±270; 0/180 unchanged.
  - Scaling now matches displayed orientation; a rotated 848x480 clip renders ~1080x1920 instead of 1920x3392.
  - No change for non-rotated or 180° sources.

<sup>Written for commit e71134acd92a87b7667e68f9e43040ad51da32e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

