### PR TITLE
fix: remove librosa as a hard dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
     "requests",
-    "librosa",
     "matplotlib",
     "pillow",
     "numpy",


### PR DESCRIPTION
## Summary

- Removes `librosa` from `pyproject.toml` hard dependencies
- `librosa` pulls in `numba → llvmlite`, which requires compiling against LLVM 14 specifically and fails on fresh macOS installs where only newer LLVM is available via brew
- `timeline_view.py` already has an ffmpeg-based fallback for the waveform envelope and explicitly comments that librosa is not a hard dep
- The core editing pipeline (transcription, EDL, render, grade) does not use librosa at all

## Test plan

- [ ] `uv sync` completes without errors on a fresh macOS install
- [ ] `timeline_view.py` waveform generation works via ffmpeg fallback
- [ ] Core edit pipeline (transcribe → pack → render) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `librosa` from `pyproject.toml` to avoid the `numba`/`llvmlite` LLVM 14 build requirement and fix `uv sync` failures on fresh macOS installs. Waveform generation uses the existing `ffmpeg` fallback, and the core editing pipeline is unaffected.

<sup>Written for commit 7f683f3ca7e648abe240f9ac5319f525c2c673b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

