### PR TITLE
docs: add API key link to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
+# Get your key at: https://elevenlabs.io/app/settings/api-keys
 ELEVENLABS_API_KEY=


### PR DESCRIPTION
## Summary

- Adds a comment to `.env.example` pointing to the ElevenLabs settings page where users get their API key
- New users copying the file previously had no hint where to obtain the key without reading the README first

## Test plan

- [ ] Verify `.env.example` renders correctly on GitHub
- [ ] Confirm the URL is accurate: https://elevenlabs.io/app/settings/api-keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a comment to `.env.example` with a direct link to the ElevenLabs API keys page so users can quickly find and set `ELEVENLABS_API_KEY`. This reduces setup friction for new installs.

<sup>Written for commit 5c037f3b8114134f8fabb95959af25f4e3a43568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

