### PR TITLE
fix: correct auto-grade adjustment bounds in docstrings

### DIFF
--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -9,7 +9,8 @@ Two modes:
      per-clip correction. Samples N frames via ffmpeg, computes mean brightness,
      RMS contrast, saturation. Emits a bounded filter string that corrects
      under-exposure, flatness, and mild desaturation without applying any
-     creative color shift. All adjustments capped at ±8% on any axis.
+     creative color shift. Adjustments are bounded: contrast ±8%, gamma +10%/-6%,
+     saturation ±6%.
 
      The goal is "make it look clean without looking graded". Never applies
      creative LUTs, teal/orange splits, or filmic curves. For creative looks,
@@ -183,8 +184,9 @@ def auto_grade_for_clip(
 ) -> tuple[str, dict[str, float]]:
     """Analyze a clip range and emit a subtle per-clip correction filter.
 
-    Returns (filter_string, stats_dict). The filter is bounded to ±8% on any axis
-    and applies NO color shift. It only addresses:
+    Returns (filter_string, stats_dict). Adjustments are bounded per axis
+    (contrast ±8%, gamma +10%/-6%, saturation ±6%) and apply NO color shift.
+    It only addresses:
       - Underexposure (lift gamma slightly if too dark)
       - Flatness (tiny contrast boost if range is narrow)
       - Desaturation (tiny sat boost if extremely flat)


### PR DESCRIPTION
## What

Corrects two docstrings in `helpers/grade.py` that claimed auto-grade adjustments are "capped at +-8% on any axis." The actual bounds differ per axis.

## Why

The real clamps in `auto_grade_for_clip` are:

```python
contrast_adj = max(0.94, min(1.08, contrast_adj))  # [-6%, +8%]
gamma_adj    = max(0.94, min(1.10, gamma_adj))      # [-6%, +10%]
sat_adj      = max(0.94, min(1.06, sat_adj))        # [-6%, +6%]
```

Gamma can go up to +10% for underexposed clips, not +8%. The module-level docstring and the `auto_grade_for_clip` docstring both stated "+-8%" which is misleading — a reader checking the docs before tuning the caps would see the wrong range.

## Changes

- Module docstring: replaced "All adjustments capped at +-8% on any axis" with per-axis bounds.
- `auto_grade_for_clip` docstring: same correction.

No logic changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update module and `auto_grade_for_clip` docstrings to state the real per-axis bounds for auto-grade adjustments: contrast ±8%, gamma +10%/-6%, saturation ±6%. Fixes the misleading “±8% on any axis” wording; no behavior changes.

<sup>Written for commit e1375adaa35030ba26692c4ac8342dbb67c95ace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

