### PR TITLE
docs: make Codex manual install path explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ If you'd rather do it by hand:
 # 1. Clone and symlink into your agent's skills directory
 git clone https://github.com/browser-use/video-use ~/Developer/video-use
 ln -sfn ~/Developer/video-use ~/.claude/skills/video-use        # Claude Code
-# ln -sfn ~/Developer/video-use ~/.codex/skills/video-use       # Codex
+
+# Codex
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+ln -sfn ~/Developer/video-use "${CODEX_HOME:-$HOME/.codex}/skills/video-use"
 
 # 2. Install deps
 cd ~/Developer/video-use


### PR DESCRIPTION
Closes #92.

The manual install section in README.md had the Codex symlink line commented out, while `install.md` already documents the full Codex registration step explicitly (`mkdir` + `ln -sfn` using `$CODEX_HOME`). This updates the README's manual install block to match `install.md`, so Codex users don't have to notice and uncomment a commented-out line or risk copying the Claude-only path.

No functional change — `install.md` already had this correct. This only brings the README's manual install section in line with it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the Codex manual install steps in README by replacing the commented symlink with explicit `mkdir` and `ln -sfn` commands using `CODEX_HOME`, matching `install.md`. This prevents users from missing the Codex registration or using the Claude-only path.

<sup>Written for commit 5fc455d68c067a414d051e200297aaafc2804ce6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

