### PR TITLE
docs: make Codex manual install path explicit (closes #92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,13 @@ If you'd rather do it by hand:
 ```bash
 # 1. Clone and symlink into your agent's skills directory
 git clone https://github.com/browser-use/video-use ~/Developer/video-use
-ln -sfn ~/Developer/video-use ~/.claude/skills/video-use        # Claude Code
-# ln -sfn ~/Developer/video-use ~/.codex/skills/video-use       # Codex
+
+# Claude Code
+ln -sfn ~/Developer/video-use ~/.claude/skills/video-use
+
+# Codex
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+ln -sfn ~/Developer/video-use "${CODEX_HOME:-$HOME/.codex}/skills/video-use"
 
 # 2. Install deps
 cd ~/Developer/video-use


### PR DESCRIPTION
### Problem

Issue #92: The README manual install section has the Codex symlink commented out, making it easy for Codex users to miss or copy the Claude-only path. The auto-installer (`install.md`) already has a dedicated Codex step but the manual instructions don't match.

### Changes

- Uncommented and restructured the Codex symlink into its own explicit install step
- Added `mkdir -p` for `CODEX_HOME` before symlinking (matching `install.md` behavior)
- Both Claude Code and Codex paths are now clearly labeled as separate options

### Before

```bash
# 1. Clone and symlink into your agent's skills directory
git clone https://github.com/browser-use/video-use ~/Developer/video-use
ln -sfn ~/Developer/video-use ~/.claude/skills/video-use        # Claude Code
# ln -sfn ~/Developer/video-use ~/.codex/skills/video-use       # Codex
```

### After

```bash
# 1. Clone and symlink into your agent's skills directory
git clone https://github.com/browser-use/video-use ~/Developer/video-use

# Claude Code
ln -sfn ~/Developer/video-use ~/.claude/skills/video-use

# Codex
mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
ln -sfn ~/Developer/video-use "${CODEX_HOME:-$HOME/.codex}/skills/video-use"
```

Now consistent with the automated installer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the manual install in README by making the Codex path explicit. Adds a dedicated Codex step with `mkdir -p` and separates Claude Code vs Codex instructions to match `install.md` and prevent missed Codex installs.

<sup>Written for commit 0a9138541a846d0afab4bcd7f0248acee8c84646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

