### PR TITLE
fix(render): avoid shared concat list file

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -26,6 +26,7 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 try:
@@ -267,8 +268,17 @@ def extract_all_segments(
 def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -> None:
     """Lossless concat via the concat demuxer. No re-encode."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    concat_list = edit_dir / "_concat.txt"
-    concat_list.write_text("".join(f"file '{p.resolve()}'\n" for p in segment_paths))
+    edit_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=edit_dir,
+        prefix="_concat_",
+        suffix=".txt",
+        delete=False,
+    ) as fh:
+        fh.write("".join(f"file '{p.resolve()}'\n" for p in segment_paths))
+        concat_list = Path(fh.name)
 
     cmd = [
         "ffmpeg", "-y",
@@ -279,8 +289,10 @@ def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -
         str(out_path),
     ]
     print(f"concat → {out_path.name}")
-    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
-    concat_list.unlink(missing_ok=True)
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    finally:
+        concat_list.unlink(missing_ok=True)
 
 
 # -------- Master SRT (Rule 5) ------------------------------------------------

--- a/tests/test_render_concat.py
+++ b/tests/test_render_concat.py
@@ -1,0 +1,51 @@
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from helpers.render import concat_segments  # noqa: E402
+
+
+class ConcatSegmentsTest(unittest.TestCase):
+    def test_concat_list_is_unique_and_cleaned_up(self):
+        with TemporaryDirectory() as tmp:
+            edit_dir = Path(tmp)
+            segment_paths = [edit_dir / "seg_01.mp4", edit_dir / "seg_02.mp4"]
+            for segment_path in segment_paths:
+                segment_path.write_bytes(b"")
+
+            concat_lists: list[Path] = []
+
+            def fake_run(cmd, check, stdout, stderr):
+                concat_list = Path(cmd[cmd.index("-i") + 1])
+                self.assertTrue(concat_list.exists())
+                self.assertEqual(concat_list.parent, edit_dir)
+                self.assertTrue(concat_list.name.startswith("_concat_"))
+                self.assertNotEqual(concat_list.name, "_concat.txt")
+                self.assertEqual(
+                    concat_list.read_text(encoding="utf-8"),
+                    "".join(f"file '{p.resolve()}'\n" for p in segment_paths),
+                )
+                concat_lists.append(concat_list)
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with patch("helpers.render.subprocess.run", fake_run):
+                with redirect_stdout(StringIO()):
+                    concat_segments(segment_paths, edit_dir / "out_1.mp4", edit_dir)
+                    concat_segments(segment_paths, edit_dir / "out_2.mp4", edit_dir)
+
+            self.assertEqual(len(concat_lists), 2)
+            self.assertEqual(len(set(concat_lists)), 2)
+            self.assertFalse((edit_dir / "_concat.txt").exists())
+            for concat_list in concat_lists:
+                self.assertFalse(concat_list.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Write the ffmpeg concat demuxer list to a per-call temp file in `edit_dir` instead of the fixed `_concat.txt` path.
- Clean the temp concat list in a `finally` block so failed ffmpeg runs do not leave stale list files behind.
- Add a stdlib unittest covering unique concat-list names and cleanup.

## Why
Issue #64 calls out that concurrent renders in the same edit directory can clobber the shared `_concat.txt` file. Keeping the temp file inside `edit_dir` preserves the concat demuxer's filesystem behavior while avoiding cross-render overwrites.

## Test plan
- `python -m unittest tests.test_render_concat`
- `python -m unittest discover -s tests`
- `python -m py_compile helpers/render.py tests/test_render_concat.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Write the ffmpeg concat list to a unique temp file per render in `edit_dir` and delete it after the run. This avoids `_concat.txt` collisions during concurrent renders and prevents stale files.

- **Bug Fixes**
  - Use `tempfile.NamedTemporaryFile` to create `_concat_*.txt` in `edit_dir`.
  - Remove the temp list in a `finally` block, even if ffmpeg fails.
  - Add `tests/test_render_concat.py` to verify unique names and cleanup.

<sup>Written for commit f71ec1dd121dd59c1478ae7c7ecb78b961a342e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

