### PR TITLE
render: fix WebM overlay alpha and ffmpeg 8 subtitles filter syntax

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -515,6 +515,11 @@ def build_final_composite(
     inputs: list[str] = ["-i", str(base_path)]
     for ov in overlays:
         ov_path = resolve_path(ov["file"], edit_dir)
+        # WebM/VP9 alpha lives in a side-channel that ffmpeg's native vp9
+        # decoder ignores; force libvpx-vp9 so transparent overlays stay
+        # transparent instead of compositing as opaque black.
+        if ov_path.suffix.lower() == ".webm":
+            inputs += ["-c:v", "libvpx-vp9"]
         inputs += ["-i", str(ov_path)]
 
     filter_parts: list[str] = []
@@ -538,9 +543,15 @@ def build_final_composite(
     # Subtitles LAST — Rule 1
     if has_subs:
         subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
-        filter_parts.append(
-            f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
-        )
+        # filename= (named option) is required: ffmpeg 8's filtergraph parser
+        # rejects the positional quoted form when the path needs quoting.
+        if subtitles_path.suffix.lower() == ".ass":
+            # ASS files carry their own styles — force_style would clobber them.
+            filter_parts.append(f"{current}subtitles=filename='{subs_abs}'[outv]")
+        else:
+            filter_parts.append(
+                f"{current}subtitles=filename='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
+            )
         out_label = "[outv]"
     else:
         # Rename the last overlay output to [outv] for consistency


### PR DESCRIPTION
Two small rendering bugfixes in `helpers/render.py`, independent of each other and of #62:

**1. WebM overlay transparency is lost (composites as opaque black).**
ffmpeg's built-in `vp9` decoder ignores the alpha side-channel in WebM/VP9, so any transparent overlay rendered to `.webm` composites as a solid black box. Fix: pass `-c:v libvpx-vp9` for `.webm` overlay inputs so the alpha plane is actually decoded.

**2. Subtitle burns fail to parse on ffmpeg 8.**
ffmpeg 8's filtergraph parser rejects the positional quoted form `subtitles='/abs/path'` whenever the path needs quoting; the render dies with a filter parse error. Fix: use the `filename=` named-option syntax, which works on ffmpeg 5–8. While here: `.ass` inputs now skip `force_style` — ASS files carry their own embedded styles, and `force_style` was clobbering them.

Both found in production use editing 4K talking-head videos with transparent motion-graphic overlays and burned captions on ffmpeg 8.1/macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two rendering issues: transparent `.webm` overlays now keep alpha, and subtitle burns work on `ffmpeg 8` while preserving `.ass` styles.

- **Bug Fixes**
  - WebM overlays: force `-c:v libvpx-vp9` for `.webm` overlay inputs so the alpha channel is decoded.
  - Subtitles: use `subtitles=filename='...'` to avoid `ffmpeg 8` parse errors; skip `force_style` for `.ass` to keep embedded styles.

<sup>Written for commit 532446e8a0f829b21f988200147bb35897d19e9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

