### PR TITLE
fix: grammar in transcribe_batch CLI help text

### DIFF
--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -35,7 +35,7 @@ def find_videos(videos_dir: Path) -> list[Path]:
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Parallel batch transcription of a videos directory")
+    ap = argparse.ArgumentParser(description="Parallel batch transcription of a video directory")
     ap.add_argument("videos_dir", type=Path, help="Directory containing source videos")
     ap.add_argument(
         "--edit-dir",


### PR DESCRIPTION
## Summary
- Fixes a small grammar error in the `argparse` description for `helpers/transcribe_batch.py`: "a videos directory" → "a video directory", matching the correctly-worded help text on the very next line.

## Test plan
- [x] Single-line text-only change to a help string; verified by reading the diff (no logic touched).