### PR TITLE
docs: align subtitle and output guidance with render.py

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -181,13 +181,13 @@ Subtitles have three dimensions worth reasoning about: **chunking** (1/2/3/sente
 
 **Worked styles** — pick, adapt, or invent:
 
-**`bold-overlay`** — short-form tech launch, fast-paced social. 2-word chunks, UPPERCASE, break on punctuation, Helvetica 18 Bold, white-on-outline, `MarginV=35`. `render.py` ships with this as `SUB_FORCE_STYLE`.
+**`bold-overlay`** — short-form tech launch, fast-paced social. 2-word chunks, UPPERCASE, break on punctuation, Helvetica 18 Bold, white-on-outline, `MarginV=90`. `render.py` ships with this as `SUB_FORCE_STYLE`.
 
 ```
 FontName=Helvetica,FontSize=18,Bold=1,
 PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,BackColour=&H00000000,
 BorderStyle=1,Outline=2,Shadow=0,
-Alignment=2,MarginV=35
+Alignment=2,MarginV=90
 ```
 
 **`natural-sentence`** (if you invent this mode) — narrative, documentary, education. 4–7 word chunks, sentence case, break on natural pauses, `MarginV=60–80`, larger font for readability, slightly wider max-width. No shipped force_style — design one if you need it.
@@ -263,7 +263,7 @@ One sub-agent = one file (unique filenames, parallel agents don't overwrite each
 
 ## Output spec
 
-Match the source unless the user asked for something specific. Common targets: `1920×1080@24` cinematic, `1920×1080@30` screen content, `1080×1920@30` vertical social, `3840×2160@24` 4K cinema, `1080×1080@30` square. `render.py` defaults the scale to 1080p from any source; pass `--filter` or edit the extract command for other targets. Worth asking the user which delivery format matters.
+Match the source unless the user asked for something specific. Common targets: `1920×1080@24` cinematic, `1920×1080@30` screen content, `1080×1920@30` vertical social, `3840×2160@24` 4K cinema, `1080×1080@30` square. `render.py` currently renders at 24 fps and scales each source's long edge to 1920 pixels (1280 in draft mode). Edit the extraction settings when another delivery target is required; `--filter` belongs to `grade.py`, not `render.py`. Worth asking the user which delivery format matters.
 
 ## EDL format
 

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -10,7 +10,7 @@ Implements the HEURISTICS render pipeline in the correct order:
 
 Optionally builds a master SRT from the per-source transcripts + EDL
 output-timeline offsets, applies the proven force_style (2-word
-UPPERCASE chunks, Helvetica 18 Bold, MarginV=35).
+UPPERCASE chunks, Helvetica 18 Bold, MarginV=90).
 
 Usage:
     python helpers/render.py <edl.json> -o final.mp4


### PR DESCRIPTION
## Summary
- update the documented `bold-overlay` subtitle margin to match `SUB_FORCE_STYLE`
- clarify `render.py`'s current scaling and frame-rate behavior
- point custom FFmpeg filters to `grade.py`, which owns the `--filter` option
- fix the stale subtitle margin in `render.py`'s module documentation

## Problem

The editing guide still documents `MarginV=35`, while the renderer uses `MarginV=90` for vertical-video safe zones. It also suggests passing `--filter` to `render.py`, but that option is exposed by `grade.py` instead.

## Testing
- `python3 -m py_compile helpers/*.py` — passed
- `python3 helpers/render.py --help` — confirmed no `--filter` option
- `python3 helpers/grade.py --help` — confirmed `--filter` is available
- `git diff --check` — passed

Addresses the documentation drift tracked in #64.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align docs with current `render.py` behavior and fix the stale subtitle margin in its docstring. Updated `bold-overlay` to `MarginV=90`, clarified `render.py` renders at 24 fps and scales the long edge to 1920px (1280px in draft), and pointed `--filter` usage to `grade.py`.

<sup>Written for commit 4cd7c04650118362dad877d4a4811c9ece7a777f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

