### PR TITLE
fix(render): detect portrait sources that carry rotation metadata

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -132,15 +132,33 @@ def is_hdr_source(video: Path) -> bool:
 
 
 def is_portrait_source(video: Path) -> bool:
-    """Return True if the video's height > width (portrait / vertical)."""
+    """Return True if the video displays taller than wide (portrait / vertical).
+
+    Phone cameras store vertical footage as a landscape stream plus a rotation
+    entry. ffmpeg auto-rotates on decode, so the displayed dimensions -- not the
+    stored ones -- decide which axis to scale by.
+    """
     try:
         out = subprocess.run(
             ["ffprobe", "-v", "error", "-select_streams", "v:0",
-             "-show_entries", "stream=width,height",
-             "-of", "csv=p=0", str(video)],
+             "-show_entries", "stream=width,height:stream_side_data=rotation:stream_tags=rotate",
+             "-of", "json", str(video)],
             capture_output=True, text=True, check=True,
         )
-        w, h = map(int, out.stdout.strip().split(","))
+        stream = json.loads(out.stdout)["streams"][0]
+        w, h = int(stream["width"]), int(stream["height"])
+
+        rotation = 0
+        for side_data in stream.get("side_data_list", []):
+            if "rotation" in side_data:
+                rotation = int(side_data["rotation"])
+                break
+        else:
+            # ffmpeg < 5 exposes the display matrix as a stream tag instead.
+            rotation = int(stream.get("tags", {}).get("rotate", 0))
+
+        if rotation % 180 != 0:
+            w, h = h, w
         return h > w
     except Exception:
         return False


### PR DESCRIPTION
## Problem

`is_portrait_source()` compares the dimensions ffprobe reports for the stored stream. Phone cameras record vertical footage as a **landscape stream plus a rotation entry** in the display matrix. ffmpeg auto-rotates on decode, so the filter graph receives a portrait frame while `is_portrait_source()` reports landscape — and `scale=1920:-2` gets applied to a portrait frame.

Real phone clip (Android, 4:55, shot vertically):

```
$ ffprobe -v error -select_streams v:0 \
    -show_entries stream=width,height:stream_side_data=rotation ...
width=1280
height=720
rotation=-90        # displayed as 720x1280
```

`extract_segment()` on that file, before this change:

```
1920x3414
```

A 720p vertical clip upscaled to 3414px tall, on the CPU-bound libx264 path.

#29 fixed sources whose stream is *stored* portrait (`h > w`). Sources rotated by metadata — which is how essentially all phone footage is stored — still fall through to the landscape branch. #64 lists portrait orientation as already handled, which is true only for the stored-portrait case.

## Fix

Probe the rotation side data (falling back to the `rotate` stream tag for ffmpeg < 5) and swap width/height when rotation is an odd multiple of 90°. No new dependencies; `json` was already imported.

## Verification

`is_portrait_source()` across every orientation case:

| source | expected | result |
|---|---|---|
| 1280x720, no rotation | landscape | ✅ |
| 720x1280, stored portrait (#29) | portrait | ✅ |
| 1280x720 + rotation 90 | portrait | ✅ |
| 1280x720 + rotation -90 | portrait | ✅ |
| 1280x720 + rotation 180 | landscape | ✅ |
| real phone clip (1280x720 + rotation -90) | portrait | ✅ |
| unreadable path | `False` fallback | ✅ |

End-to-end through `extract_segment()` on the real phone clip: **1920x3414 → 720x1280**.

Rotation-180 sources stay landscape, and the existing `except` fallback is unchanged.

## Note

This touches the same function as the open #104 (`--vertical output`). Happy to rebase if that lands first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix portrait detection for videos that store rotation metadata. `is_portrait_source()` now reads display rotation so vertical phone clips scale on the correct axis.

- **Bug Fixes**
  - Parse rotation from `ffprobe` JSON (`side_data.rotation`, fallback to `tags.rotate`) and swap width/height for odd 90° rotations.
  - Keep 180° rotation and error fallback unchanged; prevents 1920x3414 mis-scaling and outputs 720x1280 for rotated 720p clips.

<sup>Written for commit f38ba27f2466321f25077c5052d6f43e751b0821. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

