### PR TITLE
Fix subtitles filter path escaping on Windows

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -537,7 +537,7 @@ def build_final_composite(
 
     # Subtitles LAST — Rule 1
     if has_subs:
-        subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
+        subs_abs = str(subtitles_path.resolve()).replace("\\", "/").replace(":", r"\:").replace("'", r"\'")
         filter_parts.append(
             f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
         )


### PR DESCRIPTION
## Bug

On Windows, `build_final_composite()` in `helpers/render.py` builds a broken `-filter_complex` when burning subtitles. `subtitles_path.resolve()` returns a native Windows path with backslashes (`C:\Users\...`), but the current escaping only handles `:` and `'`:

```python
subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
```

The ffmpeg `subtitles` filter parses backslashes as escape characters inside the filtergraph, so the path never resolves to the actual file and the render fails with exit code `4294967294` (`-2` as unsigned 32-bit).

## Reproduction (Windows)

The generated filter argument looks like `subtitles='C\:\Users\me\edit\subtitles.ass'`:

```
ffmpeg -y -i input.mp4 -filter_complex "[0:v]subtitles='C\:\Users\me\edit\subtitles.ass'[outv]" -map "[outv]" -c:a copy out.mp4
```

fails with:

```
[Parsed_subtitles_0 @ ...] Unable to open C:Usersmeeditsubtitles.ass
Error initializing filters
```

The same command with forward slashes works — ffmpeg accepts forward-slash paths on Windows:

```
ffmpeg -y -i input.mp4 -filter_complex "[0:v]subtitles='C\:/Users/me/edit/subtitles.ass'[outv]" -map "[outv]" -c:a copy out.mp4
```

## Fix

Convert backslashes to forward slashes before the existing `:` and `'` escaping:

```python
subs_abs = str(subtitles_path.resolve()).replace("\\", "/").replace(":", r"\:").replace("'", r"\'")
```

No behavior change on POSIX, where resolved paths contain no backslashes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subtitle burn-in on Windows by normalizing the path passed to the `subtitles` filter. Converts backslashes to forward slashes before escaping so ffmpeg can open the file.

- **Bug Fixes**
  - In `helpers/render.py`, replace "\" with "/" before escaping ":" and "'".
  - No behavior change on POSIX; Windows renders no longer fail with exit code 4294967294.

<sup>Written for commit f00c194421dc5773330e0677f7c98072e222a766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

