### PR TITLE
feat: add Groq Whisper as a free transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,10 @@
+# Transcription. At least one is required.
+
+# Groq Whisper — free, fast, keeps filler words. No speaker diarization.
+# https://console.groq.com/keys
+GROQ_API_KEY=
+
+# ElevenLabs Scribe — paid. Adds speaker diarization + audio events, no upload
+# size cap. Required for multi-speaker footage (interviews, panels).
+# https://elevenlabs.io/app/settings/api-keys
 ELEVENLABS_API_KEY=

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Paste into Claude Code, Codex, Hermes, Openclaw, or any agent with shell access:
 ```text
 Set up https://github.com/browser-use/video-use for me.
 
-Read install.md first to install this repo, wire up ffmpeg, register the skill with whichever agent you're running under, and set up the ElevenLabs API key — ask me to paste it when you need it. Then read SKILL.md for daily usage, and always read helpers/ because that's where the editing scripts live. After install, don't transcribe anything on your own — just tell me it's ready and wait for me to drop footage into a folder.
+Read install.md first to install this repo, wire up ffmpeg, register the skill with whichever agent you're running under, and set up the transcription API key — ask me to paste it when you need it. Then read SKILL.md for daily usage, and always read helpers/ because that's where the editing scripts live. After install, don't transcribe anything on your own — just tell me it's ready and wait for me to drop footage into a folder.
 ```
 
-The agent handles the clone, dependencies, skill registration, and prompts you once for your ElevenLabs API key (grab one at [elevenlabs.io/app/settings/api-keys](https://elevenlabs.io/app/settings/api-keys)).
+The agent handles the clone, dependencies, skill registration, and prompts you once for a transcription key — either a free [Groq](https://console.groq.com/keys) key or a paid [ElevenLabs](https://elevenlabs.io/app/settings/api-keys) one.
 
 Then point your agent at a folder of raw takes:
 
@@ -63,10 +63,25 @@ uv sync                         # or: pip install -e .
 brew install ffmpeg             # required
 brew install yt-dlp             # optional, for downloading online sources
 
-# 3. Add your ElevenLabs API key
+# 3. Add a transcription API key
 cp .env.example .env
-$EDITOR .env                    # ELEVENLABS_API_KEY=...
+$EDITOR .env                    # GROQ_API_KEY=... (free) or ELEVENLABS_API_KEY=...
 ```
+
+## Transcription providers
+
+One key is enough. `transcribe.py` picks Groq when `GROQ_API_KEY` is set and falls back to ElevenLabs; `--provider groq|elevenlabs` overrides.
+
+| | Groq Whisper (`whisper-large-v3-turbo`) | ElevenLabs Scribe |
+|---|---|---|
+| Cost | free | paid |
+| Word-level timestamps | yes | yes |
+| Filler words (`um`, `uh`, false starts) | kept | kept |
+| Speaker diarization | **no** | yes |
+| Audio events (`(laughter)`, `(applause)`) | **no** | yes |
+| Upload cap | 25 MB — about 25 min per take | effectively none |
+
+Use Groq for single-speaker footage, which is most of it. Reach for ElevenLabs when you need speaker labels (interviews, panels) or audio-event beats, or when a single take runs long enough to blow the size cap.
 
 ## How it works
 
@@ -76,7 +91,7 @@ The LLM never watches the video. It **reads** it — through two layers that tog
   <img src="static/timeline-view.svg" alt="timeline_view composite — filmstrip + speaker track + waveform + word labels + silence-gap cut candidates" width="100%">
 </p>
 
-**Layer 1 — Audio transcript (always loaded).** One ElevenLabs Scribe call per source gives word-level timestamps, speaker diarization, and audio events (`(laughter)`, `(applause)`, `(sigh)`). All takes pack into a single ~12KB `takes_packed.md` — the LLM's primary reading view.
+**Layer 1 — Audio transcript (always loaded).** One transcription call per source gives word-level timestamps — plus speaker diarization and audio events (`(laughter)`, `(applause)`, `(sigh)`) on ElevenLabs. All takes pack into a single ~12KB `takes_packed.md` — the LLM's primary reading view.
 
 ```
 ## C0103  (duration: 43.0s, 8 phrases)

--- a/SKILL.md
+++ b/SKILL.md
@@ -24,8 +24,8 @@ These are the things where deviation produces silent failures or broken output. 
 3. **30ms audio fades at every segment boundary** (`afade=t=in:st=0:d=0.03,afade=t=out:st={dur-0.03}:d=0.03`). Otherwise audible pops at every cut.
 4. **Overlays use `setpts=PTS-STARTPTS+T/TB`** to shift the overlay's frame 0 to its window start. Otherwise you see the middle of the animation during the overlay window.
 5. **Master SRT uses output-timeline offsets**: `output_time = word.start - segment_start + segment_offset`. Otherwise captions misalign after segment concat.
-6. **Never cut inside a word.** Snap every cut edge to a word boundary from the Scribe transcript.
-7. **Pad every cut edge.** Working window: 30–200ms. Scribe timestamps drift 50–100ms — padding absorbs the drift. Tighter for fast-paced, looser for cinematic.
+6. **Never cut inside a word.** Snap every cut edge to a word boundary from the transcript.
+7. **Pad every cut edge.** Working window: 30–200ms. Transcript timestamps drift 50–100ms — padding absorbs the drift. Tighter for fast-paced, looser for cinematic.
 8. **Word-level verbatim ASR only.** Never SRT/phrase mode (loses sub-second gap data). Never normalized fillers (loses editorial signal).
 9. **Cache transcripts per source.** Never re-transcribe unless the source file itself changed.
 10. **Parallel sub-agents for multiple animations.** Never sequential. Spawn N at once via the `Agent` tool; total wall time ≈ slowest one.
@@ -45,7 +45,7 @@ The skill lives in `video-use/`. User footage lives wherever they put it. All se
     ├── project.md               ← memory; appended every session
     ├── takes_packed.md          ← phrase-level transcripts, the LLM's primary reading view
     ├── edl.json                 ← cut decisions
-    ├── transcripts/<name>.json  ← cached raw Scribe JSON
+    ├── transcripts/<name>.json  ← cached raw transcript JSON
     ├── animations/slot_<id>/    ← per-animation source + render + reasoning
     ├── clips_graded/            ← per-segment extracts with grade + fades
     ├── master.srt               ← output-timeline subtitles
@@ -59,7 +59,7 @@ The skill lives in `video-use/`. User footage lives wherever they put it. All se
 
 First-time install lives in `install.md` (clone, deps, ffmpeg, skill registration, API key). Don't re-run it every session; on cold start just verify:
 
-- `ELEVENLABS_API_KEY` resolves — either in the environment or in `.env` at the video-use repo root. If missing, ask the user to paste one and write it to `.env` (never to the user's `<videos_dir>`).
+- A transcription key resolves — `GROQ_API_KEY` (free) or `ELEVENLABS_API_KEY` (paid), either in the environment or in `.env` at the video-use repo root. If neither is set, ask the user to paste one and write it to `.env` (never to the user's `<videos_dir>`).
 - `ffmpeg` + `ffprobe` on PATH.
 - Python deps installed (`uv sync` or `pip install -e .` inside the repo).
 - Node.js + npm available if the session needs HyperFrames or Remotion slots. HyperFrames currently requires Node.js 22+.
@@ -71,14 +71,31 @@ Helpers (`helpers/transcribe.py`, `helpers/render.py`, etc.) live alongside this
 
 ## Helpers
 
-- **`transcribe.py <video>`** — single-file Scribe call. `--num-speakers N` optional. Cached.
-- **`transcribe_batch.py <videos_dir>`** — 4-worker parallel transcription. Use for multi-take.
+- **`transcribe.py <video>`** — single-file transcription. `--num-speakers N` optional. Cached. `--provider auto|groq|elevenlabs`.
+- **`transcribe_batch.py <videos_dir>`** — 4-worker parallel transcription. Use for multi-take. Same `--provider` flag.
 - **`pack_transcripts.py --edit-dir <dir>`** — `transcripts/*.json` → `takes_packed.md` (phrase-level, break on silence ≥ 0.5s).
 - **`timeline_view.py <video> <start> <end>`** — filmstrip + waveform PNG. On-demand visual drill-down. **Not a scan tool** — use it at decision points, not constantly.
 - **`render.py <edl.json> -o <out>`** — per-segment extract → concat → overlays (PTS-shifted) → subtitles LAST. `--preview` for 720p fast. `--build-subtitles` to generate master.srt inline.
 - **`grade.py <in> -o <out>`** — ffmpeg filter chain grade. Presets + `--filter '<raw>'` for custom.
 
 For animations, create `<edit>/animations/slot_<id>/` with `Bash` and spawn a sub-agent via the `Agent` tool.
+
+## Transcription providers
+
+`--provider auto` (the default) picks free Groq Whisper when `GROQ_API_KEY` is set, else ElevenLabs Scribe. Both give word-level timestamps with fillers intact, which is what cut selection runs on. They differ in what else they return:
+
+| | Groq (`whisper-large-v3-turbo`) | ElevenLabs Scribe |
+|---|---|---|
+| Cost | free | paid |
+| Speaker diarization (`speaker_id`) | no | yes |
+| Audio events (`(laughs)`, `(applause)`) | no | yes |
+| Upload cap | 25 MB ≈ 25 min per take | none worth planning around |
+
+**Pass `--provider elevenlabs` when the footage is multi-speaker.** Without diarization, `takes_packed.md` has no `S0`/`S1` tags, phrases only break on silence, and the speaker-handoff craft below has nothing to key off. Groq is the right default for single-speaker footage — talking heads, VO, tutorials — which is most of it.
+
+Groq transcripts also carry no `audio_event` entries, so laughs and applause won't appear as beats. Read them off the waveform in `timeline_view` instead, or transcribe that source with ElevenLabs.
+
+A take that overruns the 25 MB cap fails with an explicit error, not a silent truncation. Re-run that source with `--provider elevenlabs`, or split it.
 
 ## The process
 
@@ -310,7 +327,7 @@ Things that consistently fail regardless of style:
 - **Hierarchical pre-computed codec formats** with USABILITY / tone tags / shot layers. Over-engineering. Derive from the transcript at decision time.
 - **Hand-tuned moment-scoring functions.** The LLM picks better than any heuristic you'll write.
 - **Whisper SRT / phrase-level output.** Loses sub-second gap data. Always word-level verbatim.
-- **Running Whisper locally on CPU.** Slow and it normalizes fillers. Use hosted Scribe.
+- **Running Whisper locally on CPU.** Slow, and CPU-grade settings normalize fillers. Use a hosted provider — Groq or Scribe.
 - **Burning subtitles into base before compositing overlays.** Overlays hide them. (Hard Rule 1.)
 - **Single-pass filtergraph when you have overlays.** Double re-encodes. Use per-segment extract → concat.
 - **Linear animation easing.** Looks robotic. Always cubic.

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,7 +27,7 @@ These are the things where deviation produces silent failures or broken output. 
 6. **Never cut inside a word.** Snap every cut edge to a word boundary from the transcript.
 7. **Pad every cut edge.** Working window: 30–200ms. Transcript timestamps drift 50–100ms — padding absorbs the drift. Tighter for fast-paced, looser for cinematic.
 8. **Word-level verbatim ASR only.** Never SRT/phrase mode (loses sub-second gap data). Never normalized fillers (loses editorial signal).
-9. **Cache transcripts per source.** Never re-transcribe unless the source file itself changed.
+9. **Cache transcripts per source.** Never re-transcribe unless the source file itself changed, or the user names a different `--provider` for it.
 10. **Parallel sub-agents for multiple animations.** Never sequential. Spawn N at once via the `Agent` tool; total wall time ≈ slowest one.
 11. **Strategy confirmation before execution.** Never touch the cut until the user has approved the plain-English plan.
 12. **All session outputs in `<videos_dir>/edit/`.** Never write inside the `video-use/` project directory.
@@ -96,6 +96,8 @@ For animations, create `<edit>/animations/slot_<id>/` with `Bash` and spawn a su
 Groq transcripts also carry no `audio_event` entries, so laughs and applause won't appear as beats. Read them off the waveform in `timeline_view` instead, or transcribe that source with ElevenLabs.
 
 A take that overruns the 25 MB cap fails with an explicit error, not a silent truncation. Re-run that source with `--provider elevenlabs`, or split it.
+
+Naming a provider explicitly re-transcribes any source already cached under the other one — that's the documented escape hatch, and the only exception to Hard Rule 9. Under `--provider auto` the cache always wins, so no run re-uploads by accident.
 
 ## The process
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,7 +27,7 @@ These are the things where deviation produces silent failures or broken output. 
 6. **Never cut inside a word.** Snap every cut edge to a word boundary from the transcript.
 7. **Pad every cut edge.** Working window: 30–200ms. Transcript timestamps drift 50–100ms — padding absorbs the drift. Tighter for fast-paced, looser for cinematic.
 8. **Word-level verbatim ASR only.** Never SRT/phrase mode (loses sub-second gap data). Never normalized fillers (loses editorial signal).
-9. **Cache transcripts per source.** Never re-transcribe unless the source file itself changed, or the user names a different `--provider` for it.
+9. **Cache transcripts per source.** Never re-transcribe unless the source file itself changed, or the run deliberately selects a different backend for it (`--provider`, or `--num-speakers` routing to ElevenLabs).
 10. **Parallel sub-agents for multiple animations.** Never sequential. Spawn N at once via the `Agent` tool; total wall time ≈ slowest one.
 11. **Strategy confirmation before execution.** Never touch the cut until the user has approved the plain-English plan.
 12. **All session outputs in `<videos_dir>/edit/`.** Never write inside the `video-use/` project directory.
@@ -97,7 +97,7 @@ Groq transcripts also carry no `audio_event` entries, so laughs and applause won
 
 A take that overruns the 25 MB cap fails with an explicit error, not a silent truncation. Re-run that source with `--provider elevenlabs`, or split it.
 
-Naming a provider explicitly re-transcribes any source already cached under the other one — that's the documented escape hatch, and the only exception to Hard Rule 9. Under `--provider auto` the cache always wins, so no run re-uploads by accident.
+Deliberately picking a backend re-transcribes any source already cached under the other one — either by naming `--provider`, or by passing `--num-speakers`, which routes to ElevenLabs for diarization a cached Groq transcript cannot supply. That's the documented escape hatch and the only exception to Hard Rule 9. Plain `--provider auto` always takes the cache, so no run re-uploads by accident.
 
 ## The process
 

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -11,8 +11,9 @@ Providers:
 
 Default is `auto`: Groq if GROQ_API_KEY resolves, otherwise ElevenLabs.
 
-Cached: if the output file already exists, the upload is skipped — unless
---provider names a backend other than the one that transcript came from.
+Cached: if the output file already exists, the upload is skipped — unless the
+run deliberately picked a different backend than the one that transcript came
+from, via --provider or via --num-speakers routing to ElevenLabs.
 
 Usage:
     python helpers/transcribe.py <video_path>
@@ -86,10 +87,19 @@ def load_provider_key(preferred: str = "auto") -> tuple[str, str]:
     sys.exit("No transcription key: set GROQ_API_KEY (free) or ELEVENLABS_API_KEY in .env")
 
 
-def resolve_provider(preferred: str, num_speakers: int | None) -> tuple[str, str]:
-    """load_provider_key, but route diarization requests away from Groq."""
+def resolve_provider(preferred: str, num_speakers: int | None) -> tuple[str, str, bool]:
+    """load_provider_key, but route diarization requests away from Groq.
+
+    Returns (provider, api_key, explicit). `explicit` means the backend was
+    deliberately chosen — either named outright or forced by --num-speakers —
+    and it is decided here, next to the routing it depends on, so the two can't
+    drift apart. Cache staleness keys off it: asking for diarization has to beat
+    a cached Groq transcript that has no speaker_id to give.
+    """
+    explicit = preferred != "auto"
     if preferred == "auto" and num_speakers and _read_env_var("ELEVENLABS_API_KEY"):
         preferred = "elevenlabs"
+        explicit = True
 
     provider, api_key = load_provider_key(preferred)
     if num_speakers and provider == "groq":
@@ -98,7 +108,7 @@ def resolve_provider(preferred: str, num_speakers: int | None) -> tuple[str, str
             "no speaker_id in the transcript",
             file=sys.stderr,
         )
-    return provider, api_key
+    return provider, api_key, explicit
 
 
 def extract_audio(video_path: Path, dest: Path) -> None:
@@ -332,7 +342,7 @@ def main() -> None:
         sys.exit(f"video not found: {video}")
 
     edit_dir = (args.edit_dir or (video.parent / "edit")).resolve()
-    provider, api_key = resolve_provider(args.provider, args.num_speakers)
+    provider, api_key, provider_explicit = resolve_provider(args.provider, args.num_speakers)
 
     transcribe_one(
         video=video,
@@ -341,7 +351,7 @@ def main() -> None:
         language=args.language,
         num_speakers=args.num_speakers,
         provider=provider,
-        provider_explicit=args.provider != "auto",
+        provider_explicit=provider_explicit,
     )
 
 

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -240,6 +240,22 @@ def _cached_provider(transcript_path: Path) -> str | None:
         return None
 
 
+def is_transcript_stale(path: Path, provider: str, provider_explicit: bool) -> bool:
+    """Whether a cached transcript has to be redone for `provider`.
+
+    The single source of truth for cache staleness — both the single-file and
+    batch paths ask this rather than re-deriving it, so they cannot disagree
+    about which cache entries survive.
+
+    Only a deliberate backend choice invalidates a cache, so an `auto` run
+    answers False without opening the file: the common path parses nothing.
+    """
+    if not provider_explicit:
+        return False
+    cached = _cached_provider(path)
+    return bool(cached and cached != provider)
+
+
 def transcribe_one(
     video: Path,
     edit_dir: Path,
@@ -252,12 +268,10 @@ def transcribe_one(
 ) -> Path:
     """Transcribe a single video. Returns path to transcript JSON.
 
-    Cached: returns the existing path immediately if the transcript already
-    exists. The one exception is `provider_explicit` — someone who asked for a
-    named provider on a source cached under a different one is switching on
-    purpose (multi-speaker footage, or a take over Groq's size cap), and the
-    docs point them here. Under `auto` the cache always wins, so no run ever
-    re-uploads by accident.
+    Cached: returns the existing path immediately unless is_transcript_stale()
+    says the run deliberately picked a different backend — multi-speaker footage,
+    or a take over Groq's size cap, both of which the docs point here. Under
+    `auto` the cache always wins, so no run re-uploads by accident.
 
     `provider` defaults to elevenlabs to keep pre-Groq programmatic callers
     working; both CLIs pass it explicitly.
@@ -267,17 +281,18 @@ def transcribe_one(
     out_path = transcripts_dir / f"{video.stem}.json"
 
     if out_path.exists():
-        cached_provider = _cached_provider(out_path)
-        stale = provider_explicit and cached_provider and cached_provider != provider
-        if not stale:
+        if not is_transcript_stale(out_path, provider, provider_explicit):
             if verbose:
+                # Only read the file to explain the mismatch, never to decide it.
+                cached_provider = _cached_provider(out_path)
                 note = ""
                 if cached_provider and cached_provider != provider:
                     note = f" (from {cached_provider}; --provider {provider} to redo)"
                 print(f"cached: {out_path.name}{note}")
             return out_path
         if verbose:
-            print(f"  re-transcribing {video.name}: cached under {cached_provider}", flush=True)
+            print(f"  re-transcribing {video.name}: cached under "
+                  f"{_cached_provider(out_path)}", flush=True)
 
     if verbose:
         print(f"  extracting audio from {video.name}", flush=True)

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -11,7 +11,8 @@ Providers:
 
 Default is `auto`: Groq if GROQ_API_KEY resolves, otherwise ElevenLabs.
 
-Cached: if the output file already exists, the upload is skipped.
+Cached: if the output file already exists, the upload is skipped — unless
+--provider names a backend other than the one that transcript came from.
 
 Usage:
     python helpers/transcribe.py <video_path>
@@ -219,6 +220,16 @@ def call_groq(
     }
 
 
+def _cached_provider(transcript_path: Path) -> str | None:
+    """Which provider wrote this transcript, or None if it predates the field
+    (or is unreadable). Unknown means 'leave it alone' — never re-upload a
+    transcript we can't prove came from a different provider."""
+    try:
+        return json.loads(transcript_path.read_text()).get("provider")
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
 def transcribe_one(
     video: Path,
     edit_dir: Path,
@@ -226,20 +237,37 @@ def transcribe_one(
     language: str | None = None,
     num_speakers: int | None = None,
     verbose: bool = True,
-    provider: str = "groq",
+    provider: str = "elevenlabs",
+    provider_explicit: bool = False,
 ) -> Path:
     """Transcribe a single video. Returns path to transcript JSON.
 
-    Cached: returns existing path immediately if the transcript already exists.
+    Cached: returns the existing path immediately if the transcript already
+    exists. The one exception is `provider_explicit` — someone who asked for a
+    named provider on a source cached under a different one is switching on
+    purpose (multi-speaker footage, or a take over Groq's size cap), and the
+    docs point them here. Under `auto` the cache always wins, so no run ever
+    re-uploads by accident.
+
+    `provider` defaults to elevenlabs to keep pre-Groq programmatic callers
+    working; both CLIs pass it explicitly.
     """
     transcripts_dir = edit_dir / "transcripts"
     transcripts_dir.mkdir(parents=True, exist_ok=True)
     out_path = transcripts_dir / f"{video.stem}.json"
 
     if out_path.exists():
+        cached_provider = _cached_provider(out_path)
+        stale = provider_explicit and cached_provider and cached_provider != provider
+        if not stale:
+            if verbose:
+                note = ""
+                if cached_provider and cached_provider != provider:
+                    note = f" (from {cached_provider}; --provider {provider} to redo)"
+                print(f"cached: {out_path.name}{note}")
+            return out_path
         if verbose:
-            print(f"cached: {out_path.name}")
-        return out_path
+            print(f"  re-transcribing {video.name}: cached under {cached_provider}", flush=True)
 
     if verbose:
         print(f"  extracting audio from {video.name}", flush=True)
@@ -257,6 +285,7 @@ def transcribe_one(
         else:
             payload = call_scribe(audio, api_key, language, num_speakers)
 
+    payload["provider"] = provider
     out_path.write_text(json.dumps(payload, indent=2))
     dt = time.time() - t0
 
@@ -312,6 +341,7 @@ def main() -> None:
         language=args.language,
         num_speakers=args.num_speakers,
         provider=provider,
+        provider_explicit=args.provider != "auto",
     )
 
 

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -28,22 +28,38 @@ import requests
 
 
 SCRIBE_URL = "https://api.elevenlabs.io/v1/speech-to-text"
+GROQ_URL = "https://api.groq.com/openai/v1/audio/transcriptions"
+GROQ_MODEL = "whisper-large-v3-turbo"
 
 
-def load_api_key() -> str:
-    for candidate in [Path(__file__).resolve().parent.parent / ".env", Path(".env")]:
+def _read_env_var(name: str) -> str:
+    """Look up a var in the repo .env, ~/.agent-ops/env, then the environment."""
+    candidates = [
+        Path(__file__).resolve().parent.parent / ".env",
+        Path(".env"),
+        Path.home() / ".agent-ops" / "env",
+    ]
+    for candidate in candidates:
         if candidate.exists():
             for line in candidate.read_text().splitlines():
                 line = line.strip()
                 if not line or line.startswith("#") or "=" not in line:
                     continue
                 k, v = line.split("=", 1)
-                if k.strip() == "ELEVENLABS_API_KEY":
+                if k.strip().removeprefix("export ").strip() == name:
                     return v.strip().strip('"').strip("'")
-    v = os.environ.get("ELEVENLABS_API_KEY", "")
-    if not v:
-        sys.exit("ELEVENLABS_API_KEY not found in .env or environment")
-    return v
+    return os.environ.get(name, "")
+
+
+def load_provider_key() -> tuple[str, str]:
+    """Prefer free Groq Whisper (word timestamps); fall back to ElevenLabs."""
+    groq = _read_env_var("GROQ_API_KEY")
+    if groq:
+        return "groq", groq
+    eleven = _read_env_var("ELEVENLABS_API_KEY")
+    if eleven:
+        return "elevenlabs", eleven
+    sys.exit("No transcription key: set GROQ_API_KEY or ELEVENLABS_API_KEY in .env")
 
 
 def extract_audio(video_path: Path, dest: Path) -> None:
@@ -87,6 +103,52 @@ def call_scribe(
     return resp.json()
 
 
+def call_groq(
+    audio_path: Path,
+    api_key: str,
+    language: str | None = None,
+) -> dict:
+    """Free Whisper transcription via Groq. Maps to the Scribe payload shape
+    the rest of video-use consumes (words: [{text,start,end,type,speaker_id}]).
+    No diarization/audio-events (fine for single-speaker footage)."""
+    data: dict[str, str] = {
+        "model": GROQ_MODEL,
+        "response_format": "verbose_json",
+        "timestamp_granularities[]": "word",
+    }
+    if language:
+        data["language"] = language
+
+    with open(audio_path, "rb") as f:
+        resp = requests.post(
+            GROQ_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            files={"file": (audio_path.name, f, "audio/wav")},
+            data=data,
+            timeout=1800,
+        )
+
+    if resp.status_code != 200:
+        raise RuntimeError(f"Groq returned {resp.status_code}: {resp.text[:500]}")
+
+    raw = resp.json()
+    words = [
+        {
+            "text": w.get("word", ""),
+            "start": w.get("start", 0.0),
+            "end": w.get("end", 0.0),
+            "type": "word",
+            "speaker_id": None,
+        }
+        for w in raw.get("words", [])
+    ]
+    return {
+        "language_code": raw.get("language", language or ""),
+        "text": raw.get("text", ""),
+        "words": words,
+    }
+
+
 def transcribe_one(
     video: Path,
     edit_dir: Path,
@@ -94,6 +156,7 @@ def transcribe_one(
     language: str | None = None,
     num_speakers: int | None = None,
     verbose: bool = True,
+    provider: str = "groq",
 ) -> Path:
     """Transcribe a single video. Returns path to transcript JSON.
 
@@ -118,7 +181,10 @@ def transcribe_one(
         size_mb = audio.stat().st_size / (1024 * 1024)
         if verbose:
             print(f"  uploading {video.stem}.wav ({size_mb:.1f} MB)", flush=True)
-        payload = call_scribe(audio, api_key, language, num_speakers)
+        if provider == "groq":
+            payload = call_groq(audio, api_key, language)
+        else:
+            payload = call_scribe(audio, api_key, language, num_speakers)
 
     out_path.write_text(json.dumps(payload, indent=2))
     dt = time.time() - t0
@@ -160,7 +226,7 @@ def main() -> None:
         sys.exit(f"video not found: {video}")
 
     edit_dir = (args.edit_dir or (video.parent / "edit")).resolve()
-    api_key = load_api_key()
+    provider, api_key = load_provider_key()
 
     transcribe_one(
         video=video,
@@ -168,6 +234,7 @@ def main() -> None:
         api_key=api_key,
         language=args.language,
         num_speakers=args.num_speakers,
+        provider=provider,
     )
 
 

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -1,8 +1,15 @@
-"""Transcribe a video with ElevenLabs Scribe.
+"""Transcribe a video with Groq Whisper (free) or ElevenLabs Scribe.
 
-Extracts mono 16kHz audio via ffmpeg, uploads to Scribe with verbatim +
-diarize + audio events + word-level timestamps, writes the full response
-to <edit_dir>/transcripts/<video_stem>.json.
+Extracts mono 16kHz audio via ffmpeg, uploads it for word-level timestamps,
+writes the response to <edit_dir>/transcripts/<video_stem>.json.
+
+Providers:
+  groq        whisper-large-v3-turbo. Free, fast, keeps fillers. No diarization,
+              no audio events. 25 MB upload cap (~25 min of 16k mono FLAC).
+  elevenlabs  Scribe. Paid. Adds diarization + audio events, no size cap worth
+              worrying about. Required for multi-speaker footage.
+
+Default is `auto`: Groq if GROQ_API_KEY resolves, otherwise ElevenLabs.
 
 Cached: if the output file already exists, the upload is skipped.
 
@@ -11,6 +18,7 @@ Usage:
     python helpers/transcribe.py <video_path> --edit-dir /custom/edit
     python helpers/transcribe.py <video_path> --language en
     python helpers/transcribe.py <video_path> --num-speakers 2
+    python helpers/transcribe.py <video_path> --provider elevenlabs
 """
 
 from __future__ import annotations
@@ -30,14 +38,20 @@ import requests
 SCRIBE_URL = "https://api.elevenlabs.io/v1/speech-to-text"
 GROQ_URL = "https://api.groq.com/openai/v1/audio/transcriptions"
 GROQ_MODEL = "whisper-large-v3-turbo"
+GROQ_MAX_UPLOAD_MB = 25.0  # free tier; Groq's dev tier allows 100
+
+PROVIDER_KEYS = {"groq": "GROQ_API_KEY", "elevenlabs": "ELEVENLABS_API_KEY"}
 
 
 def _read_env_var(name: str) -> str:
-    """Look up a var in the repo .env, ~/.agent-ops/env, then the environment."""
+    """Look up a var in the repo .env, the cwd .env, then the environment.
+
+    Blank values are skipped, so a placeholder line like `ELEVENLABS_API_KEY=`
+    in a freshly copied .env doesn't shadow a real key set elsewhere.
+    """
     candidates = [
         Path(__file__).resolve().parent.parent / ".env",
         Path(".env"),
-        Path.home() / ".agent-ops" / "env",
     ]
     for candidate in candidates:
         if candidate.exists():
@@ -47,25 +61,53 @@ def _read_env_var(name: str) -> str:
                     continue
                 k, v = line.split("=", 1)
                 if k.strip().removeprefix("export ").strip() == name:
-                    return v.strip().strip('"').strip("'")
+                    v = v.strip().strip('"').strip("'")
+                    if v:
+                        return v
     return os.environ.get(name, "")
 
 
-def load_provider_key() -> tuple[str, str]:
-    """Prefer free Groq Whisper (word timestamps); fall back to ElevenLabs."""
-    groq = _read_env_var("GROQ_API_KEY")
-    if groq:
-        return "groq", groq
-    eleven = _read_env_var("ELEVENLABS_API_KEY")
-    if eleven:
-        return "elevenlabs", eleven
-    sys.exit("No transcription key: set GROQ_API_KEY or ELEVENLABS_API_KEY in .env")
+def load_provider_key(preferred: str = "auto") -> tuple[str, str]:
+    """Resolve (provider, api_key). `preferred` is 'auto', 'groq' or 'elevenlabs'.
+
+    'auto' prefers free Groq Whisper and falls back to ElevenLabs Scribe.
+    """
+    if preferred in PROVIDER_KEYS:
+        key = _read_env_var(PROVIDER_KEYS[preferred])
+        if not key:
+            sys.exit(f"--provider {preferred} needs {PROVIDER_KEYS[preferred]} in .env or environment")
+        return preferred, key
+
+    for provider, env_name in PROVIDER_KEYS.items():
+        key = _read_env_var(env_name)
+        if key:
+            return provider, key
+    sys.exit("No transcription key: set GROQ_API_KEY (free) or ELEVENLABS_API_KEY in .env")
+
+
+def resolve_provider(preferred: str, num_speakers: int | None) -> tuple[str, str]:
+    """load_provider_key, but route diarization requests away from Groq."""
+    if preferred == "auto" and num_speakers and _read_env_var("ELEVENLABS_API_KEY"):
+        preferred = "elevenlabs"
+
+    provider, api_key = load_provider_key(preferred)
+    if num_speakers and provider == "groq":
+        print(
+            "warning: Groq Whisper has no diarization — --num-speakers ignored, "
+            "no speaker_id in the transcript",
+            file=sys.stderr,
+        )
+    return provider, api_key
 
 
 def extract_audio(video_path: Path, dest: Path) -> None:
+    """Mono 16 kHz audio. Codec follows the destination suffix — FLAC for Groq
+    (lossless, smaller than WAV, and what Groq documents as the preferred
+    upload format), plain WAV for Scribe."""
+    codec = "flac" if dest.suffix == ".flac" else "pcm_s16le"
     cmd = [
         "ffmpeg", "-y", "-i", str(video_path),
-        "-vn", "-ac", "1", "-ar", "16000", "-c:a", "pcm_s16le",
+        "-vn", "-ac", "1", "-ar", "16000", "-c:a", codec,
         str(dest),
     ]
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -103,14 +145,52 @@ def call_scribe(
     return resp.json()
 
 
+def _normalize_groq_words(raw_words: list[dict]) -> list[dict]:
+    """Map Whisper words onto the Scribe entry shape the rest of video-use reads:
+    {text, start, end, type, speaker_id}.
+
+    Whisper timestamps occasionally run backwards (a word starting before the
+    previous one ended). Cuts snap to these boundaries, so clamp the sequence
+    monotonic rather than let a negative span reach the EDL. Real silences are
+    untouched — clamping only moves a start that was already behind.
+    """
+    words: list[dict] = []
+    prev_end = 0.0
+    for w in raw_words:
+        text = (w.get("word") or "").strip()
+        if not text:
+            continue
+        start = max(float(w.get("start", prev_end)), prev_end)
+        end = max(float(w.get("end", start)), start)
+        words.append({
+            "text": text,
+            "start": start,
+            "end": end,
+            "type": "word",
+            "speaker_id": None,
+        })
+        prev_end = end
+    return words
+
+
 def call_groq(
     audio_path: Path,
     api_key: str,
     language: str | None = None,
 ) -> dict:
-    """Free Whisper transcription via Groq. Maps to the Scribe payload shape
-    the rest of video-use consumes (words: [{text,start,end,type,speaker_id}]).
-    No diarization/audio-events (fine for single-speaker footage)."""
+    """Free Whisper transcription via Groq. Returns the Scribe payload shape.
+
+    No diarization and no audio events — fine for single-speaker footage, but
+    multi-speaker work wants ElevenLabs.
+    """
+    size_mb = audio_path.stat().st_size / (1024 * 1024)
+    if size_mb > GROQ_MAX_UPLOAD_MB:
+        raise RuntimeError(
+            f"{audio_path.stem}: {size_mb:.1f} MB of audio exceeds Groq's "
+            f"{GROQ_MAX_UPLOAD_MB:.0f} MB upload cap. Use --provider elevenlabs, "
+            f"or split the source into shorter takes."
+        )
+
     data: dict[str, str] = {
         "model": GROQ_MODEL,
         "response_format": "verbose_json",
@@ -123,7 +203,7 @@ def call_groq(
         resp = requests.post(
             GROQ_URL,
             headers={"Authorization": f"Bearer {api_key}"},
-            files={"file": (audio_path.name, f, "audio/wav")},
+            files={"file": (audio_path.name, f, "audio/flac")},
             data=data,
             timeout=1800,
         )
@@ -132,20 +212,10 @@ def call_groq(
         raise RuntimeError(f"Groq returned {resp.status_code}: {resp.text[:500]}")
 
     raw = resp.json()
-    words = [
-        {
-            "text": w.get("word", ""),
-            "start": w.get("start", 0.0),
-            "end": w.get("end", 0.0),
-            "type": "word",
-            "speaker_id": None,
-        }
-        for w in raw.get("words", [])
-    ]
     return {
         "language_code": raw.get("language", language or ""),
         "text": raw.get("text", ""),
-        "words": words,
+        "words": _normalize_groq_words(raw.get("words", [])),
     }
 
 
@@ -176,11 +246,12 @@ def transcribe_one(
 
     t0 = time.time()
     with tempfile.TemporaryDirectory() as tmp:
-        audio = Path(tmp) / f"{video.stem}.wav"
+        suffix = ".flac" if provider == "groq" else ".wav"
+        audio = Path(tmp) / f"{video.stem}{suffix}"
         extract_audio(video, audio)
         size_mb = audio.stat().st_size / (1024 * 1024)
         if verbose:
-            print(f"  uploading {video.stem}.wav ({size_mb:.1f} MB)", flush=True)
+            print(f"  uploading {audio.name} ({size_mb:.1f} MB) to {provider}", flush=True)
         if provider == "groq":
             payload = call_groq(audio, api_key, language)
         else:
@@ -199,7 +270,7 @@ def transcribe_one(
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Transcribe a video with ElevenLabs Scribe")
+    ap = argparse.ArgumentParser(description="Transcribe a video with Groq Whisper or ElevenLabs Scribe")
     ap.add_argument("video", type=Path, help="Path to video file")
     ap.add_argument(
         "--edit-dir",
@@ -217,7 +288,13 @@ def main() -> None:
         "--num-speakers",
         type=int,
         default=None,
-        help="Optional number of speakers when known. Improves diarization accuracy.",
+        help="Optional number of speakers when known. Improves diarization accuracy (ElevenLabs only).",
+    )
+    ap.add_argument(
+        "--provider",
+        choices=["auto", "groq", "elevenlabs"],
+        default="auto",
+        help="Transcription backend. Default auto: free Groq Whisper, else ElevenLabs Scribe.",
     )
     args = ap.parse_args()
 
@@ -226,7 +303,7 @@ def main() -> None:
         sys.exit(f"video not found: {video}")
 
     edit_dir = (args.edit_dir or (video.parent / "edit")).resolve()
-    provider, api_key = load_provider_key()
+    provider, api_key = resolve_provider(args.provider, args.num_speakers)
 
     transcribe_one(
         video=video,

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -4,8 +4,9 @@ Walks <videos_dir> for common video extensions, transcribes each via Groq
 Whisper or ElevenLabs Scribe, writes transcripts to
 <videos_dir>/edit/transcripts/<name>.json.
 
-Cached per-file: any source that already has a transcript is skipped, unless
---provider names a backend other than the one that transcript came from.
+Cached per-file: any source that already has a transcript is skipped, unless the
+run deliberately picked a different backend than the one that transcript came
+from, via --provider or via --num-speakers routing to ElevenLabs.
 
 Usage:
     python helpers/transcribe_batch.py <videos_dir>
@@ -78,8 +79,7 @@ def main() -> None:
     if not videos:
         sys.exit(f"no videos found in {videos_dir}")
 
-    provider, api_key = resolve_provider(args.provider, args.num_speakers)
-    provider_explicit = args.provider != "auto"
+    provider, api_key, provider_explicit = resolve_provider(args.provider, args.num_speakers)
 
     def is_cached(video: Path) -> bool:
         path = edit_dir / "transcripts" / f"{video.stem}.json"

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -4,7 +4,8 @@ Walks <videos_dir> for common video extensions, transcribes each via Groq
 Whisper or ElevenLabs Scribe, writes transcripts to
 <videos_dir>/edit/transcripts/<name>.json.
 
-Cached per-file: any source that already has a transcript is skipped.
+Cached per-file: any source that already has a transcript is skipped, unless
+--provider names a backend other than the one that transcript came from.
 
 Usage:
     python helpers/transcribe_batch.py <videos_dir>
@@ -22,7 +23,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from transcribe import resolve_provider, transcribe_one
+from transcribe import _cached_provider, resolve_provider, transcribe_one
 
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
@@ -77,15 +78,24 @@ def main() -> None:
     if not videos:
         sys.exit(f"no videos found in {videos_dir}")
 
-    already_cached = [v for v in videos if (edit_dir / "transcripts" / f"{v.stem}.json").exists()]
+    provider, api_key = resolve_provider(args.provider, args.num_speakers)
+    provider_explicit = args.provider != "auto"
+
+    def is_cached(video: Path) -> bool:
+        path = edit_dir / "transcripts" / f"{video.stem}.json"
+        if not path.exists():
+            return False
+        # An explicit --provider re-does sources cached under a different one.
+        cached = _cached_provider(path)
+        return not (provider_explicit and cached and cached != provider)
+
+    already_cached = [v for v in videos if is_cached(v)]
     pending = [v for v in videos if v not in already_cached]
 
     print(f"found {len(videos)} videos ({len(already_cached)} cached, {len(pending)} to transcribe)")
     if not pending:
         print("nothing to do")
         return
-
-    provider, api_key = resolve_provider(args.provider, args.num_speakers)
 
     print(f"transcribing {len(pending)} files with {args.workers} parallel workers ({provider})")
     t0 = time.time()
@@ -102,6 +112,7 @@ def main() -> None:
                 num_speakers=args.num_speakers,
                 verbose=False,
                 provider=provider,
+                provider_explicit=provider_explicit,
             ): v
             for v in pending
         }

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -20,7 +20,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from transcribe import load_api_key, transcribe_one
+from transcribe import load_provider_key, transcribe_one
 
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
@@ -77,9 +77,9 @@ def main() -> None:
         print("nothing to do")
         return
 
-    api_key = load_api_key()
+    provider, api_key = load_provider_key()
 
-    print(f"transcribing {len(pending)} files with {args.workers} parallel workers")
+    print(f"transcribing {len(pending)} files with {args.workers} parallel workers ({provider})")
     t0 = time.time()
 
     errors: list[tuple[Path, str]] = []
@@ -93,6 +93,7 @@ def main() -> None:
                 language=args.language,
                 num_speakers=args.num_speakers,
                 verbose=False,
+                provider=provider,
             ): v
             for v in pending
         }

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -24,7 +24,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from transcribe import _cached_provider, resolve_provider, transcribe_one
+from transcribe import is_transcript_stale, resolve_provider, transcribe_one
 
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
@@ -83,11 +83,7 @@ def main() -> None:
 
     def is_cached(video: Path) -> bool:
         path = edit_dir / "transcripts" / f"{video.stem}.json"
-        if not path.exists():
-            return False
-        # An explicit --provider re-does sources cached under a different one.
-        cached = _cached_provider(path)
-        return not (provider_explicit and cached and cached != provider)
+        return path.exists() and not is_transcript_stale(path, provider, provider_explicit)
 
     already_cached = [v for v in videos if is_cached(v)]
     pending = [v for v in videos if v not in already_cached]

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -1,7 +1,8 @@
 """Batch-transcribe every video in a directory with 4 parallel workers.
 
-Walks <videos_dir> for common video extensions, runs ElevenLabs Scribe on
-each, writes transcripts to <videos_dir>/edit/transcripts/<name>.json.
+Walks <videos_dir> for common video extensions, transcribes each via Groq
+Whisper or ElevenLabs Scribe, writes transcripts to
+<videos_dir>/edit/transcripts/<name>.json.
 
 Cached per-file: any source that already has a transcript is skipped.
 
@@ -10,6 +11,7 @@ Usage:
     python helpers/transcribe_batch.py <videos_dir> --workers 4
     python helpers/transcribe_batch.py <videos_dir> --num-speakers 2
     python helpers/transcribe_batch.py <videos_dir> --edit-dir /custom/edit
+    python helpers/transcribe_batch.py <videos_dir> --provider elevenlabs
 """
 
 from __future__ import annotations
@@ -20,7 +22,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from transcribe import load_provider_key, transcribe_one
+from transcribe import resolve_provider, transcribe_one
 
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
@@ -54,7 +56,13 @@ def main() -> None:
         "--num-speakers",
         type=int,
         default=None,
-        help="Optional number of speakers. Improves diarization when known.",
+        help="Optional number of speakers. Improves diarization when known (ElevenLabs only).",
+    )
+    ap.add_argument(
+        "--provider",
+        choices=["auto", "groq", "elevenlabs"],
+        default="auto",
+        help="Transcription backend. Default auto: free Groq Whisper, else ElevenLabs Scribe.",
     )
     args = ap.parse_args()
 
@@ -77,7 +85,7 @@ def main() -> None:
         print("nothing to do")
         return
 
-    provider, api_key = load_provider_key()
+    provider, api_key = resolve_provider(args.provider, args.num_speakers)
 
     print(f"transcribing {len(pending)} files with {args.workers} parallel workers ({provider})")
     t0 = time.time()

--- a/install.md
+++ b/install.md
@@ -109,11 +109,12 @@ Without a key, nothing transcribes. Two providers work; **one key is enough**:
 
     > I need a transcription key. Free option: a Groq key from https://console.groq.com/keys — good for single-speaker footage. Paid option: ElevenLabs from https://elevenlabs.io/app/settings/api-keys, which adds speaker labels and audio events and handles long takes. Paste whichever you want and I'll write it to `~/Developer/video-use/.env`. If you already have one exported, say "use env" and I'll skip.
 
-    When the user pastes a key, write it to `~/Developer/video-use/.env` under the matching name (`GROQ_API_KEY` or `ELEVENLABS_API_KEY`):
+    When the user pastes a key, write it to `~/Developer/video-use/.env`. **Set `VAR` to match the key they actually gave you** — writing an ElevenLabs key under `GROQ_API_KEY` means the default `auto` provider sends it to Groq and the first transcription fails with a 401:
 
     ```bash
+    VAR=GROQ_API_KEY          # or ELEVENLABS_API_KEY, matching what the user pasted
     cp -n ~/Developer/video-use/.env.example ~/Developer/video-use/.env
-    printf 'GROQ_API_KEY=%s\n' "$KEY" >> ~/Developer/video-use/.env
+    printf '%s=%s\n' "$VAR" "$KEY" >> ~/Developer/video-use/.env
     chmod 600 ~/Developer/video-use/.env
     ```
 

--- a/install.md
+++ b/install.md
@@ -1,6 +1,6 @@
 ---
 name: video-use-install
-description: Install video-use into the current agent (Claude Code, Codex, Hermes, Openclaw, etc.) and wire up ffmpeg + the ElevenLabs API key so the user can start editing immediately.
+description: Install video-use into the current agent (Claude Code, Codex, Hermes, Openclaw, etc.) and wire up ffmpeg + a transcription API key so the user can start editing immediately.
 ---
 
 # video-use install
@@ -15,7 +15,7 @@ Three things must exist on this machine:
 
 1. The `video-use` repo cloned somewhere stable.
 2. `ffmpeg` on `$PATH` (plus optional `yt-dlp` for online sources).
-3. An ElevenLabs API key in `.env` at the repo root (for Scribe transcription).
+3. A transcription API key in `.env` at the repo root — `GROQ_API_KEY` (free) or `ELEVENLABS_API_KEY` (paid).
 
 And one thing must be true about the current agent:
 
@@ -23,7 +23,7 @@ And one thing must be true about the current agent:
 
 ## Install prompt contract
 
-- Do everything yourself. Only ask the user for things you cannot generate — the ElevenLabs API key, and confirmation before `brew install`.
+- Do everything yourself. Only ask the user for things you cannot generate — the transcription API key, and confirmation before `brew install`.
 - Prefer a stable clone path like `~/Developer/video-use` (not `/tmp`, not `~/Downloads`).
 - The skill references helpers by bare name (`transcribe.py`, `render.py`). That works because SKILL.md and `helpers/` ship together — keep them as siblings when you register the skill.
 - After install, verify by running one real command against one real file. Don't declare success on file-existence checks alone.
@@ -89,33 +89,45 @@ Figure out which agent you are running under, and register once. A symlink of th
 
 If you can't tell which agent you're in, ask the user once: "which agent am I running under — Claude Code, Codex, or something else?" Then pick the right target.
 
-### 5. ElevenLabs API key
+### 5. Transcription API key
 
-Scribe (ElevenLabs) does all transcription. Without a key, nothing transcribes.
+Without a key, nothing transcribes. Two providers work; **one key is enough**:
 
-1. Check existing state in this order and stop at the first hit:
+- **Groq Whisper** (`GROQ_API_KEY`) — free, fast, keeps filler words. No speaker diarization, no audio events, 25 MB upload cap (~25 min per take). Default for single-speaker footage.
+- **ElevenLabs Scribe** (`ELEVENLABS_API_KEY`) — paid. Adds diarization + audio events and has no practical size cap. Needed for interviews, panels, anything multi-speaker.
+
+1. Check existing state and stop at the first hit:
 
     ```bash
     # a) env var already exported
-    [ -n "$ELEVENLABS_API_KEY" ] && echo "env"
-    # b) .env at repo root already has it
-    grep -q '^ELEVENLABS_API_KEY=..' ~/Developer/video-use/.env 2>/dev/null && echo "dotenv"
+    [ -n "$GROQ_API_KEY" ] || [ -n "$ELEVENLABS_API_KEY" ] && echo "env"
+    # b) .env at repo root already has one
+    grep -qE '^(GROQ|ELEVENLABS)_API_KEY=..' ~/Developer/video-use/.env 2>/dev/null && echo "dotenv"
     ```
 
 2. If neither is set, ask the user exactly once:
 
-    > I need an ElevenLabs API key for transcription (word-level timestamps, speaker diarization, filler tagging). Grab one at https://elevenlabs.io/app/settings/api-keys and paste it here — I'll write it to `~/Developer/video-use/.env`. Or if you already have it exported as `ELEVENLABS_API_KEY`, say "use env" and I'll skip.
+    > I need a transcription key. Free option: a Groq key from https://console.groq.com/keys — good for single-speaker footage. Paid option: ElevenLabs from https://elevenlabs.io/app/settings/api-keys, which adds speaker labels and audio events and handles long takes. Paste whichever you want and I'll write it to `~/Developer/video-use/.env`. If you already have one exported, say "use env" and I'll skip.
 
-    When the user pastes a key, write it to `~/Developer/video-use/.env`:
+    When the user pastes a key, write it to `~/Developer/video-use/.env` under the matching name (`GROQ_API_KEY` or `ELEVENLABS_API_KEY`):
 
     ```bash
-    printf 'ELEVENLABS_API_KEY=%s\n' "$KEY" > ~/Developer/video-use/.env
+    cp -n ~/Developer/video-use/.env.example ~/Developer/video-use/.env
+    printf 'GROQ_API_KEY=%s\n' "$KEY" >> ~/Developer/video-use/.env
     chmod 600 ~/Developer/video-use/.env
     ```
 
     Never echo the key back in tool output. Never commit `.env`.
 
-3. Sanity check with a cheap, quota-free call:
+3. Sanity check with a cheap, quota-free call — Groq:
+
+    ```bash
+    curl -s -o /dev/null -w '%{http_code}\n' \
+      -H "Authorization: Bearer $(sed -n 's/^GROQ_API_KEY=//p' ~/Developer/video-use/.env)" \
+      https://api.groq.com/openai/v1/models
+    ```
+
+    or ElevenLabs:
 
     ```bash
     curl -s -o /dev/null -w '%{http_code}\n' \
@@ -134,7 +146,7 @@ python ~/Developer/video-use/helpers/timeline_view.py --help >/dev/null && echo 
 ffprobe -version | head -1
 ```
 
-Full transcription test is optional at install time — it burns Scribe credits. Better to wait until the user hands you their first clip.
+Full transcription test is optional at install time — on ElevenLabs it burns Scribe credits. Better to wait until the user hands you their first clip.
 
 ### 7. Hand off
 
@@ -158,5 +170,5 @@ Tell the user, in one short message:
 - `yt-dlp` is optional. Don't block install on it; install lazily the first time a user asks to pull from a URL.
 - Node.js/npm are only needed for HyperFrames or Remotion slots. HyperFrames currently requires Node.js 22+.
 - HyperFrames, Remotion, and Manim are optional animation engines. Don't install or prefer one globally during setup; pick the engine per animation slot in `SKILL.md`. HyperFrames can run through `npx --yes hyperframes ...` in the slot directory. Remotion can be scaffolded with `npx create-video@latest` or installed inside the slot before rendering.
-- Never run transcription as part of install verification unless the user explicitly asks — Scribe costs real money.
+- Never run transcription as part of install verification unless the user explicitly asks — on ElevenLabs, Scribe costs real money.
 - If the user is on Linux without a package manager Claude recognizes, print the manual `ffmpeg` install URL and wait rather than guessing.


### PR DESCRIPTION
## What

Adds Groq's hosted `whisper-large-v3-turbo` as a second transcription backend alongside ElevenLabs Scribe, and makes it the default when a `GROQ_API_KEY` is present.

Both scripts gain `--provider auto|groq|elevenlabs`. `auto` prefers Groq and falls back to Scribe, so existing ElevenLabs-only setups keep working with no change.

## Why

`transcribe.py` only spoke to Scribe, so running any part of video-use required a paid ElevenLabs key. Groq hosts Whisper free and returns word-level timestamps, which is the one thing the rest of the pipeline actually needs from a transcript. `call_groq()` maps Groq's `verbose_json` into the Scribe payload shape (`words[]` of `{text, start, end, type, speaker_id}`), so `pack_transcripts.py`, `render.py`, and `timeline_view.py` consume it unchanged.

## Trade-offs a reviewer should know

Groq does **not** diarize and does not tag audio events. That is fine for single-speaker footage, which is most of it, but it matters for two documented use cases:

- **Multi-speaker footage** (interviews, panels) loses `S0`/`S1` tags in `takes_packed.md`, and phrases then only break on silence. `--provider elevenlabs` is the answer, and SKILL.md now says so at the point of use.
- **Audio-event beats** (`(laughs)`, `(applause)`) don't appear. SKILL.md points at reading them off the waveform in `timeline_view` instead.

`--num-speakers` now routes to ElevenLabs when its key is available, and warns when only Groq is — previously the flag would have been silently ignored.

Groq's free tier also caps uploads at 25 MB (~25 min per take). Audio is extracted as 16k mono FLAC rather than WAV for Groq, per Groq's documented preference, and an over-cap take fails before upload with a message naming the fix rather than a raw 413 partway through a batch.

## Correctness fixes found while testing

- **Non-monotonic word timestamps.** Whisper occasionally emits a word starting before the previous one ended (observed −0.42s on real output). Hard Rule 6 snaps cut edges to word boundaries, so a negative span would have reached the EDL. `_normalize_groq_words()` clamps the sequence monotonic and drops empty tokens; real silence gaps are untouched, since clamping only moves a start that was already behind.
- **Blank `.env` values shadowed real keys.** The shipped `.env.example` placeholder `ELEVENLABS_API_KEY=` beat a key exported in the environment. Pre-existing; blank values are now skipped.

## Filler words

Hard Rule 8 requires verbatim ASR with fillers intact, and SKILL.md's anti-pattern list warned that Whisper normalizes them. That holds for local CPU-grade settings but not for hosted turbo — verified output keeps `um`, `uh`, and stutters (`we, we fixed this`). That anti-pattern entry is corrected rather than removed.

## Docs

`.env.example`, `README.md`, `install.md`, and `SKILL.md` now cover both providers, the comparison table, the multi-speaker caveat, the size cap, and the flag. Install now accepts either key and sanity-checks whichever was given.

## Test plan

No test suite exists in this repo, so verification was live API calls rather than mocks:

- [x] Single-file and 4-worker batch transcription from a clean state, feeding `pack_transcripts.py`
- [x] Fillers and stutters preserved in output
- [x] Real 1.2s silences produce correct phrase breaks in `takes_packed.md` (3 phrases from a 3-utterance clip)
- [x] Zero timestamp violations (`end < start`, or overlap with previous word) across outputs
- [x] Error paths: missing key per provider, no keys at all, size guard, cache hit, diarization warning
- [x] `py_compile` on all helpers

Not covered: the ElevenLabs path was not re-run (no key on hand), but it is untouched apart from receiving `.wav` via the same `extract_audio` call it always did.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Groq Whisper as a free transcription provider and makes it the default when `GROQ_API_KEY` is set; ElevenLabs Scribe remains available for diarization and audio events via `--provider` or `--num-speakers`. Centralizes cache staleness logic to keep CLI and batch behavior consistent and avoid unnecessary reads on `auto`.

- **New Features**
  - Added Groq `whisper-large-v3-turbo`; response mapped to the Scribe shape (`words[] {text,start,end,type,speaker_id}`) so downstream tools work unchanged.
  - Provider selection: `--provider auto|groq|elevenlabs`; `auto` prefers Groq and falls back to Scribe.
  - Diarization routing: `--num-speakers` upgrades to ElevenLabs when its key is present; warns if only Groq is available.
  - Audio extraction: FLAC for Groq, WAV for Scribe; batch mode logs the chosen provider; docs and `.env.example` updated.

- **Bug Fixes**
  - Provider-aware caching: transcripts now store `provider`; explicit `--provider` or a `--num-speakers`-driven switch re-transcribes when mismatched; under `auto` the cache wins; legacy transcripts are left untouched. Centralized staleness in `is_transcript_stale()` so single and batch paths agree and `auto` avoids reading cached files.
  - Backward compatibility: `transcribe_one()` defaults to `elevenlabs` for programmatic callers; CLIs pass `--provider` explicitly.
  - Clamped non-monotonic Whisper word timestamps and dropped empty tokens to keep cut boundaries valid.
  - Ignored blank `.env` values and tolerated `export KEY=value`; install snippet now writes the correct var name (`GROQ_API_KEY` or `ELEVENLABS_API_KEY`).
  - Checked Groq’s 25 MB upload cap before upload with a clear error.

<sup>Written for commit 8b706711ed8afae7c29220f2df8fa73298299294. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

