### PR TITLE
chore: add security floors to dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,19 +4,22 @@ version = "0.1.0"
 description = "Conversation-driven video editor skill for Claude Code"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
+# Lower bounds are security floors: each is the highest version any OSV advisory
+# for that package names as fixed. librosa and matplotlib carry no advisories and
+# stay unconstrained. All floors support requires-python >= 3.10.
 dependencies = [
-    "requests",
+    "requests>=2.33.0",
     "librosa",
     "matplotlib",
-    "pillow",
-    "numpy",
+    "pillow>=12.3.0",
+    "numpy>=1.22",
 ]
 
 [project.optional-dependencies]
 animations = ["manim"]
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
## What

Adds lower bounds to the dependency declarations in `pyproject.toml`. Floors, not equality pins.

```diff
-    "requests",
+    "requests>=2.33.0",
     "librosa",
     "matplotlib",
-    "pillow",
+    "pillow>=12.3.0",
-    "numpy",
+    "numpy>=1.22",

-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=83.0.0"]
```

## Why

Two of these currently admit versions with known vulnerabilities:

- **`setuptools>=61.0`** permits [CVE-2024-6345](https://osv.dev/vulnerability/GHSA-cx63-2mw6-8hw5) (command injection via `package_index`, fixed 70.0.0), [CVE-2025-47273](https://osv.dev/vulnerability/GHSA-5rjg-fvgr-3xxf) (path traversal in `PackageIndex.download`, fixed 78.1.1), and [GHSA-h35f-9h28-mq5c](https://osv.dev/vulnerability/GHSA-h35f-9h28-mq5c) (MANIFEST.in exclusion bypass in sdist via Unicode NFC/NFD collision on macOS APFS/HFS+, fixed 83.0.0 — this one can leak files you thought you'd excluded).
- **`pillow` unconstrained** means a fresh install can resolve below 12.3.0, which fixes its most recent advisory.

`requests` and `numpy` are unconstrained too. Their current resolutions already clear their advisories, but the floors make that a guarantee rather than a coincidence of resolution order.

## How the floors were chosen

Each is the highest version any OSV advisory for that package names as `fixed`, queried from the OSV API rather than picked by hand. `librosa` and `matplotlib` have no advisories in OSV, so they stay unconstrained rather than pinned for its own sake.

Worth noting for anyone reproducing this: a naive `max()` over OSV results gives `pillow >= 27.0.0b2`, because the query returns cross-ecosystem advisories — that number comes from an Electron GHSA. The floors here filter to `affected.package.ecosystem == "PyPI"` and a matching package name.

## Why floors and not `==`

Equality pins would let a scanner resolve exact versions, but they stop users receiving patch updates and force a resolution onto every consuming environment. For a tool people `pip install -e .` into their own venv, floors are the right trade: they close the vulnerable range without dictating the upper one.

## Compatibility

All four floors support the declared `requires-python = ">=3.10"` — checked against each release's own `requires_python` metadata, so this does not narrow the supported Python range.

## Test plan

- [x] `uv pip compile pyproject.toml` resolves cleanly → librosa 0.11.0, matplotlib 3.11.1, numpy 2.4.6, pillow 12.3.0, requests 2.34.2
- [x] `uv build --wheel` succeeds under the raised setuptools floor
- [x] Each floor's `requires_python` verified against `requires-python = ">=3.10"`

Independent of #114 — either can merge first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add lower-bound security floors to dependencies to block vulnerable versions without pinning. Also raises the build requirement to a safe `setuptools` version.

- **Dependencies**
  - Floors: `requests>=2.33.0`, `pillow>=12.3.0`, `numpy>=1.22`; build: `setuptools>=83.0.0`.
  - `librosa` and `matplotlib` remain unconstrained (no OSV advisories).
  - Verified to resolve and build on Python `>=3.10`.

<sup>Written for commit 7f26c07d9bbfba6d100c872696deaac228fdd42c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

