### PR TITLE
fix(helpers): UTF-8 and correct ffmpeg escaping for non-ASCII paths on Windows

### DIFF
--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -101,12 +101,18 @@ def _sample_frame_stats(
         metadata_path = f.name
 
     try:
+        # `file=` sits inside a filtergraph, so the path needs ffmpeg's escaping,
+        # not the OS's: on Windows a bare `C:\Users\...` fails to parse outright
+        # ("Error parsing a filter description"), which took auto-grade down on
+        # every Windows machine regardless of accents. Quote it, use forward
+        # slashes, and escape the drive colon.
+        meta_arg = "'" + metadata_path.replace("\\", "/").replace(":", r"\:") + "'"
         cmd = [
             "ffmpeg", "-y", "-hide_banner", "-nostats",
             "-ss", f"{start:.3f}",
             "-i", str(video),
             "-t", f"{duration:.3f}",
-            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file={metadata_path}",
+            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file={meta_arg}",
             "-f", "null", "-",
         ]
         subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -127,7 +133,7 @@ def _sample_frame_stats(
             except (ValueError, IndexError):
                 return None
 
-        with open(metadata_path) as f:
+        with open(metadata_path, encoding="utf-8", errors="replace") as f:
             for line in f:
                 line = line.strip()
                 if "lavfi.signalstats.YBITDEPTH" in line:
@@ -291,7 +297,20 @@ def apply_grade(input_path: Path, output_path: Path, filter_string: str) -> None
     subprocess.run(cmd, check=True)
 
 
+def use_utf8_stdio() -> None:
+    """Print through UTF-8 rather than the locale codepage.
+
+    Windows picks the console codepage for stdout (cp1252 on a pt-BR machine),
+    so a progress line carrying a '→' — or an accented source filename — raises
+    UnicodeEncodeError and takes the whole script down. No-op elsewhere.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 def main() -> None:
+    use_utf8_stdio()
     ap = argparse.ArgumentParser(description="Apply a color grade via ffmpeg filter chain")
     ap.add_argument("input", type=Path, nargs="?", help="Input video")
     ap.add_argument("-o", "--output", type=Path, help="Output video")

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -124,7 +124,7 @@ def group_into_phrases(
 
 def pack_one_file(json_path: Path, silence_threshold: float) -> tuple[str, float, list[dict]]:
     """Return (header_name, duration, phrases) for one transcript file."""
-    data = json.loads(json_path.read_text())
+    data = json.loads(json_path.read_text(encoding="utf-8"))
     words = data.get("words", [])
     phrases = group_into_phrases(words, silence_threshold)
     if phrases:
@@ -162,7 +162,20 @@ def render_markdown(entries: list[tuple[str, float, list[dict]]], silence_thresh
     return "\n".join(lines)
 
 
+def use_utf8_stdio() -> None:
+    """Print through UTF-8 rather than the locale codepage.
+
+    Windows picks the console codepage for stdout (cp1252 on a pt-BR machine),
+    so a progress line carrying a '→' — or an accented source filename — raises
+    UnicodeEncodeError and takes the whole script down. No-op elsewhere.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 def main() -> None:
+    use_utf8_stdio()
     ap = argparse.ArgumentParser(description="Pack Scribe transcripts into takes_packed.md")
     ap.add_argument("--edit-dir", type=Path, required=True, help="Edit directory containing transcripts/")
     ap.add_argument(

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -22,10 +22,14 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 
 try:
@@ -56,6 +60,18 @@ SUB_FORCE_STYLE = (
 )
 
 # -------- Helpers ------------------------------------------------------------
+
+
+def use_utf8_stdio() -> None:
+    """Print through UTF-8 rather than the locale codepage.
+
+    Windows picks the console codepage for stdout (cp1252 on a pt-BR machine),
+    so a progress line carrying a '→' — or an accented source filename — raises
+    UnicodeEncodeError and takes the whole render down. No-op elsewhere.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
 
 
 def run(cmd: list[str], quiet: bool = False) -> None:
@@ -90,6 +106,55 @@ def resolve_path(maybe_path: str, base: Path) -> Path:
     if p.is_absolute():
         return p
     return (base / p).resolve()
+
+
+def escape_filter_path(path: Path) -> str:
+    """Quote and escape a path for use *inside* an ffmpeg filtergraph.
+
+    Filenames passed as argv (`-i`, output paths) need none of this — the OS
+    hands those to ffmpeg verbatim. Filenames embedded in a filtergraph go
+    through ffmpeg's own parser first, which on Windows means two traps:
+
+      - Backslash is the filtergraph escape character, so a raw
+        `C:\\Users\\me\\master.srt` reaches the filter as `C:Usersmemaster.srt`
+        and it reports "Unable to open". Forward slashes work fine on Windows.
+      - `:` separates filter options, so the drive letter must be escaped even
+        inside quotes.
+
+    Non-ASCII path components (accents, CJK, Cyrillic) need no special handling
+    once the above are fixed — ffmpeg opens them correctly.
+    """
+    escaped = str(path).replace("\\", "/").replace(":", r"\:")
+    return f"'{escaped}'"
+
+
+@contextlib.contextmanager
+def filtergraph_safe_path(path: Path) -> Iterator[Path]:
+    """Yield a path the filtergraph can actually reference, staging a copy if not.
+
+    Accents, CJK and Cyrillic all survive a filtergraph fine once the path is
+    escaped by `escape_filter_path` — they need no copy. A literal `'` is the one
+    character ffmpeg's two-level parser cannot carry in a filename: every quoting
+    and escaping form of it fails to initialize the filter (checked against
+    ffmpeg 8.1.2). For that case only, stage a copy under a temp directory and
+    point the filter at that instead.
+    """
+    if "'" not in str(path):
+        yield path
+        return
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="video_use_"))
+    try:
+        staged = tmp_dir / path.name.replace("'", "_")
+        shutil.copyfile(path, staged)
+        if "'" in str(staged):
+            print(
+                f"warning: temp directory {tmp_dir} also contains a quote — "
+                f"ffmpeg may not be able to open {path.name}"
+            )
+        yield staged
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 # -------- HDR → SDR tone mapping (HLG / PQ sources) --------------------------
@@ -265,21 +330,47 @@ def extract_all_segments(
 
 
 def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -> None:
-    """Lossless concat via the concat demuxer. No re-encode."""
+    """Lossless concat via the concat demuxer. No re-encode.
+
+    The concat list is read by ffmpeg as UTF-8, so it must be *written* as UTF-8:
+    `write_text()` with no encoding uses the locale codepage, and on a non-English
+    Windows (cp1252 on pt-BR) an accented footage directory such as
+    "Gravações de Tela" lands in the list as `Grava\\347\\365es`. Every entry then
+    resolves to a file that does not exist and ffmpeg exits -22 / EINVAL.
+
+    Belt and braces: the entries are written relative to `edit_dir` and ffmpeg is
+    run with `cwd=edit_dir`, so non-ASCII characters stay out of the list file
+    entirely. Segment paths outside `edit_dir` fall back to an absolute entry,
+    which is still safe now that the file is UTF-8.
+    """
     out_path.parent.mkdir(parents=True, exist_ok=True)
     concat_list = edit_dir / "_concat.txt"
-    concat_list.write_text("".join(f"file '{p.resolve()}'\n" for p in segment_paths))
+
+    entries: list[str] = []
+    for p in segment_paths:
+        try:
+            rel = p.resolve().relative_to(edit_dir.resolve())
+        except ValueError:
+            entries.append(p.resolve().as_posix())
+        else:
+            entries.append(rel.as_posix())
+    concat_list.write_text(
+        "".join(f"file '{e}'\n" for e in entries), encoding="utf-8"
+    )
 
     cmd = [
         "ffmpeg", "-y",
         "-f", "concat", "-safe", "0",
-        "-i", str(concat_list),
+        "-i", concat_list.name,
         "-c", "copy",
         "-movflags", "+faststart",
-        str(out_path),
+        str(out_path.resolve()),
     ]
     print(f"concat → {out_path.name}")
-    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    subprocess.run(
+        cmd, check=True, cwd=str(edit_dir),
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+    )
     concat_list.unlink(missing_ok=True)
 
 
@@ -337,7 +428,7 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
             seg_offset += seg_duration
             continue
 
-        transcript = json.loads(tr_path.read_text())
+        transcript = json.loads(tr_path.read_text(encoding="utf-8"))
         words_in_seg = _words_in_range(transcript, seg_start, seg_end)
 
         # Group into 2-word chunks, break on punctuation
@@ -380,7 +471,9 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
         lines.append(f"{_srt_timestamp(a)} --> {_srt_timestamp(b)}")
         lines.append(t)
         lines.append("")
-    out_path.write_text("\n".join(lines))
+    # UTF-8, always: libass reads the SRT as UTF-8, and captions routinely carry
+    # non-ASCII text (accents, dashes, quotes) even when the paths are ASCII.
+    out_path.write_text("\n".join(lines), encoding="utf-8")
     print(f"master SRT → {out_path.name} ({len(entries)} cues)")
 
 
@@ -535,44 +628,51 @@ def build_final_composite(
         )
         current = next_label
 
-    # Subtitles LAST — Rule 1
-    if has_subs:
-        subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
-        filter_parts.append(
-            f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
-        )
-        out_label = "[outv]"
-    else:
-        # Rename the last overlay output to [outv] for consistency
-        if has_overlays:
-            filter_parts.append(f"{current}null[outv]")
+    # The staged subtitle copy (if one is needed) has to outlive the ffmpeg run,
+    # so the whole command is built and run inside the stack.
+    with contextlib.ExitStack() as stack:
+        # Subtitles LAST — Rule 1
+        if has_subs:
+            subs_file = stack.enter_context(
+                filtergraph_safe_path(subtitles_path.resolve())
+            )
+            subs_arg = escape_filter_path(subs_file)
+            filter_parts.append(
+                f"{current}subtitles={subs_arg}:force_style='{SUB_FORCE_STYLE}'[outv]"
+            )
             out_label = "[outv]"
         else:
-            out_label = "[0:v]"
+            # Rename the last overlay output to [outv] for consistency
+            if has_overlays:
+                filter_parts.append(f"{current}null[outv]")
+                out_label = "[outv]"
+            else:
+                out_label = "[0:v]"
 
-    filter_complex = ";".join(filter_parts)
+        filter_complex = ";".join(filter_parts)
 
-    cmd = [
-        "ffmpeg", "-y",
-        *inputs,
-        "-filter_complex", filter_complex,
-        "-map", out_label,
-        "-map", "0:a",
-        "-c:v", "libx264", "-preset", "fast", "-crf", "18",
-        "-pix_fmt", "yuv420p",
-        "-c:a", "copy",
-        "-movflags", "+faststart",
-        str(out_path),
-    ]
-    print(f"compositing → {out_path.name}")
-    print(f"  overlays: {len(overlays)}, subtitles: {'yes' if has_subs else 'no'}")
-    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        cmd = [
+            "ffmpeg", "-y",
+            *inputs,
+            "-filter_complex", filter_complex,
+            "-map", out_label,
+            "-map", "0:a",
+            "-c:v", "libx264", "-preset", "fast", "-crf", "18",
+            "-pix_fmt", "yuv420p",
+            "-c:a", "copy",
+            "-movflags", "+faststart",
+            str(out_path),
+        ]
+        print(f"compositing → {out_path.name}")
+        print(f"  overlays: {len(overlays)}, subtitles: {'yes' if has_subs else 'no'}")
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
 
 # -------- Main ---------------------------------------------------------------
 
 
 def main() -> None:
+    use_utf8_stdio()
     ap = argparse.ArgumentParser(description="Render a video from an EDL")
     ap.add_argument("edl", type=Path, help="Path to edl.json")
     ap.add_argument("-o", "--output", type=Path, required=True, help="Output video path")
@@ -607,7 +707,7 @@ def main() -> None:
     if not edl_path.exists():
         sys.exit(f"edl not found: {edl_path}")
 
-    edl = json.loads(edl_path.read_text())
+    edl = json.loads(edl_path.read_text(encoding="utf-8"))
     edit_dir = edl_path.parent
     out_path = args.output.resolve()
 

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -118,7 +118,7 @@ def compute_envelope(video: Path, start: float, end: float, samples: int = 2000)
 def words_in_range(transcript_path: Path, start: float, end: float) -> list[dict]:
     if not transcript_path.exists():
         return []
-    data = json.loads(transcript_path.read_text())
+    data = json.loads(transcript_path.read_text(encoding="utf-8"))
     out: list[dict] = []
     for w in data.get("words", []):
         t = w.get("type", "word")
@@ -330,7 +330,20 @@ def render_timeline(
         print(f"saved: {out_path}  ({out_path.stat().st_size // 1024} KB)")
 
 
+def use_utf8_stdio() -> None:
+    """Print through UTF-8 rather than the locale codepage.
+
+    Windows picks the console codepage for stdout (cp1252 on a pt-BR machine),
+    so a progress line carrying a '→' — or an accented source filename — raises
+    UnicodeEncodeError and takes the whole script down. No-op elsewhere.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 def main() -> None:
+    use_utf8_stdio()
     ap = argparse.ArgumentParser(description="Filmstrip + waveform composite for a video range")
     ap.add_argument("video", type=Path, nargs="?", help="Source video")
     ap.add_argument("start", type=float, nargs="?", help="Start time in seconds")

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -33,7 +33,7 @@ SCRIBE_URL = "https://api.elevenlabs.io/v1/speech-to-text"
 def load_api_key() -> str:
     for candidate in [Path(__file__).resolve().parent.parent / ".env", Path(".env")]:
         if candidate.exists():
-            for line in candidate.read_text().splitlines():
+            for line in candidate.read_text(encoding="utf-8").splitlines():
                 line = line.strip()
                 if not line or line.startswith("#") or "=" not in line:
                     continue
@@ -120,7 +120,7 @@ def transcribe_one(
             print(f"  uploading {video.stem}.wav ({size_mb:.1f} MB)", flush=True)
         payload = call_scribe(audio, api_key, language, num_speakers)
 
-    out_path.write_text(json.dumps(payload, indent=2))
+    out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     dt = time.time() - t0
 
     if verbose:
@@ -132,7 +132,20 @@ def transcribe_one(
     return out_path
 
 
+def use_utf8_stdio() -> None:
+    """Print through UTF-8 rather than the locale codepage.
+
+    Windows picks the console codepage for stdout (cp1252 on a pt-BR machine),
+    so a progress line carrying a '→' — or an accented source filename — raises
+    UnicodeEncodeError and takes the whole script down. No-op elsewhere.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 def main() -> None:
+    use_utf8_stdio()
     ap = argparse.ArgumentParser(description="Transcribe a video with ElevenLabs Scribe")
     ap.add_argument("video", type=Path, help="Path to video file")
     ap.add_argument(

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -20,7 +20,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from transcribe import load_api_key, transcribe_one
+from transcribe import load_api_key, transcribe_one, use_utf8_stdio
 
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
@@ -35,6 +35,7 @@ def find_videos(videos_dir: Path) -> list[Path]:
 
 
 def main() -> None:
+    use_utf8_stdio()
     ap = argparse.ArgumentParser(description="Parallel batch transcription of a videos directory")
     ap.add_argument("videos_dir", type=Path, help="Directory containing source videos")
     ap.add_argument(


### PR DESCRIPTION
Rendering fails outright on a non-English Windows whenever the footage
directory contains non-ASCII characters, and `--grade auto` fails on Windows
even with pure-ASCII paths. Four distinct defects, one root cause: the helpers
assume the locale codepage is UTF-8, and assume ffmpeg parses a path the same
way the OS does.

Repro for the original symptom — footage in `C:\Users\me\Videos\Gravações de Tela`:

```
[in#0] Impossible to open '...\Gravações de Tela\edit\clips_graded\seg_00.mp4'
Error opening input: Invalid argument
```

### 1. `concat_segments()` wrote the concat list in the locale codepage

`concat_list.write_text(...)` with no `encoding` uses the locale codepage
(cp1252 on pt-BR Windows), while ffmpeg's concat demuxer reads the list as
UTF-8. `Gravações` was written as the bytes `Grava\347\365es`, so every entry
resolved to a nonexistent file and ffmpeg exited `-22` / `EINVAL`.

Fixed by writing UTF-8, and additionally by writing entries relative to
`edit_dir` and running ffmpeg with `cwd=edit_dir`, which keeps non-ASCII out of
the list file altogether. Segments outside `edit_dir` fall back to an absolute
entry, which is safe now that the file is UTF-8.

### 2. `subtitles=` was passed an unescaped Windows path

`build_final_composite()` escaped `:` and `'` but left backslashes intact.
Backslash is the filtergraph escape character, so `C:\Users\me\master.srt`
reached the filter as `C:Usersmemaster.srt`:

```
[Parsed_subtitles_0] Unable to open C:UsersmeAppData...master.srt
[AVFilterGraph] Error initializing filters
```

Worth noting for anyone who has worked around this: **accents were never the
problem here.** Verified on ffmpeg 8.1.2 that Latin-1, CJK and Cyrillic
subtitle paths all load correctly once the path uses forward slashes and an
escaped drive colon — no ASCII copy required. The new `escape_filter_path()`
does exactly that.

The one character ffmpeg's two-level parser genuinely cannot carry in a
filename is a literal `'` — every quoting and escaping form of it fails to
initialize the filter. `filtergraph_safe_path()` stages a temp copy for that
case only.

### 3. `grade.py` passed a raw Windows path to `metadata=print:file=`

Same class, different filter, and this one is not accent-related at all — it
breaks `--grade auto` on **every** Windows machine:

```
[AVFilterGraph] Error parsing filterchain
'fps=5.00,signalstats,metadata=print:file=C:\Users\...\tmp.txt'
```

Same quoting fix applied.

### 4. `UnicodeEncodeError` when printing progress

Windows selects the console codepage for `sys.stdout`, so a progress line
containing `→` — or an accented source filename — raises `UnicodeEncodeError`
and kills the run before any ffmpeg work starts. `use_utf8_stdio()`
reconfigures stdout/stderr to UTF-8; it is a no-op on Linux and macOS.

### Also

Explicit `encoding="utf-8"` on every `read_text` / `write_text` / `open` in
`helpers/` that can touch a user path or transcript text, including the master
SRT write (libass reads SRT as UTF-8, and captions carry non-ASCII text even
when the paths are ASCII).

## Testing

Windows 11, ffmpeg 8.1.2, Python 3.14, pt-BR locale (`cp1252`).

End-to-end `render.py --build-subtitles` from a directory named
`Gravações de Tela`, with an accented source filename, accented caption text,
and `"grade": "auto"`:

- **after:** exits 0, output written, extracted frame confirms `OLÁ MUNDO`
  renders with the accent intact
- **before:** fails at auto-grade (`-22`), at concat (`-22`), and at subtitles
  (`-2`)

ASCII-path renders were checked for regression and are unaffected. Also
verified a directory containing both an apostrophe and accents
(`Gui's Gravações`) now renders, via the staged-copy path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows rendering failures with non-ASCII paths by using UTF-8 consistently and proper `ffmpeg` filtergraph path escaping. Restores subtitles and `--grade auto`, and prevents console encoding crashes.

- **Bug Fixes**
  - Concat: write `_concat.txt` as UTF-8, use edit-relative entries, and run `ffmpeg` with `cwd=edit_dir`.
  - Subtitles: escape filter paths (forward slashes, escape drive colon) via `escape_filter_path()`; stage a temp copy if the path contains `'` with `filtergraph_safe_path()`.
  - Auto-grade: quote/escape `metadata=print:file=` path inside the filtergraph.
  - IO/console: reconfigure stdout/stderr to UTF-8 with `use_utf8_stdio()`; read/write JSON, SRT, and `.env` with `encoding="utf-8"`.

<sup>Written for commit 03dea217352684a96b4517b03ab2073297fed89f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

