### PR TITLE
Fix Windows compatibility in helpers

### DIFF
--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -35,6 +35,14 @@ import tempfile
 from pathlib import Path
 
 
+# Windows consoles default to cp1252, which cannot encode the '→' / '≈' / '±'
+# characters used in the status output below — printing one raises
+# UnicodeEncodeError and kills the run. Force UTF-8 on the streams we own.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 PRESETS: dict[str, str] = {
     # Subtle baseline — barely perceptible cleanup. No color shift.
     # Use when auto-analysis isn't available or when you want a safe floor.
@@ -101,15 +109,24 @@ def _sample_frame_stats(
         metadata_path = f.name
 
     try:
+        # `metadata=print:file=...` is a FILTER argument: ':' separates options
+        # and '\' escapes. An absolute Windows path (C:\Users\...) is therefore
+        # mangled by the filter parser ("No option name near ..."), and auto-grade
+        # dies with CalledProcessError. Passing a bare filename plus cwd sidesteps
+        # filter-arg escaping entirely and behaves the same on every platform.
+        meta_file = Path(metadata_path)
         cmd = [
             "ffmpeg", "-y", "-hide_banner", "-nostats",
             "-ss", f"{start:.3f}",
             "-i", str(video),
             "-t", f"{duration:.3f}",
-            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file={metadata_path}",
+            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file={meta_file.name}",
             "-f", "null", "-",
         ]
-        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(
+            cmd, check=True, cwd=str(meta_file.parent),
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
 
         # Parse signalstats metadata. Signalstats reports values in the NATIVE
         # bit depth of the decoded frame (8-bit → 0-255, 10-bit → 0-1023). We

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -21,6 +21,14 @@ import sys
 from pathlib import Path
 
 
+# Windows consoles default to cp1252 and cannot encode '→' / '≥' from the
+# status output below; printing one raises UnicodeEncodeError. Force UTF-8.
+# (The markdown file itself is already written with an explicit utf-8 encoding.)
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 def format_time(seconds: float) -> str:
     """Format a time in seconds as "NNN.NN" with fixed 6-char width for alignment."""
     return f"{seconds:06.2f}"

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -28,6 +28,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+
+# Windows consoles default to cp1252, which cannot encode the '→' / '×' / '…'
+# characters used in the progress output below — printing one raises
+# UnicodeEncodeError mid-render. Force UTF-8 on the streams we own.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 try:
     from grade import get_preset, auto_grade_for_clip  # same directory
 except Exception:
@@ -537,7 +545,17 @@ def build_final_composite(
 
     # Subtitles LAST — Rule 1
     if has_subs:
-        subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
+        # ffmpeg's filter parser treats '\' as an escape character, so a Windows
+        # path (C:\Users\...) arrives at libass with its separators stripped and
+        # fails with "No such file or directory". Forward slashes are accepted by
+        # ffmpeg on Windows and are a no-op on POSIX; the drive colon still needs
+        # escaping because ':' separates filter options.
+        subs_abs = (
+            str(subtitles_path.resolve())
+            .replace("\\", "/")
+            .replace(":", r"\:")
+            .replace("'", r"\'")
+        )
         filter_parts.append(
             f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
         )

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -31,6 +31,13 @@ import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
 
+# Windows consoles default to cp1252 and cannot encode '→' / '≥' from the
+# status output below; printing one raises UnicodeEncodeError. Force UTF-8.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 # -------- Frame extraction ---------------------------------------------------
 
 
@@ -157,6 +164,12 @@ FONT_CANDIDATES = [
     "/System/Library/Fonts/SFNSMono.ttf",
     "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
     "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+    # Windows — without these, PIL falls back to a fixed-size bitmap font that
+    # ignores the requested size, making word labels unreadable at decision time.
+    "C:/Windows/Fonts/consola.ttf",
+    "C:/Windows/Fonts/cour.ttf",
+    "C:/Windows/Fonts/segoeui.ttf",
+    "C:/Windows/Fonts/arial.ttf",
 ]
 
 

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -23,6 +23,13 @@ from pathlib import Path
 from transcribe import load_api_key, transcribe_one
 
 
+# Windows consoles default to cp1252 and cannot encode the '→' in the progress
+# output below; printing one raises UnicodeEncodeError. Force UTF-8.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
 
 


### PR DESCRIPTION
## What

Four defects that make the helpers unusable on Windows. Each was found by running the tool against real footage during a fresh install, not by inspection.

### 1. `grade.py` — auto-grade crashes on every clip

`metadata=print:file=<path>` is a **filter** argument, where `:` separates options and `\` escapes. An absolute Windows path is destroyed by the filter parser:

```
[AVFilterGraph] No option name near 'UsersUserAppDataLocalTempt1.txt'
subprocess.CalledProcessError: Command '[... 'metadata=print:file=C:\Users\...']' returned non-zero exit status 4294967274
```

Fixed by passing a bare filename with `cwd` set, which requires no filter-arg escaping on any platform.

This is the widest-reaching of the four: auto is the default grade mode, and `render.py` calls `auto_grade_for_clip` for every segment whenever the EDL says `"grade": "auto"`.

### 2. `render.py` — subtitle burn-in fails

Same root cause. The existing escaping handled `:` but left `\` for the filter parser to consume, so libass received a path with no separators:

```
[AVFilterGraph] Error initializing filters
Error : No such file or directory
```

Fixed by converting to forward slashes (accepted by ffmpeg on Windows, no-op on POSIX) before escaping the drive colon. Subtitles-applied-last is Hard Rule 1 in `SKILL.md`, so this hits on the first real subtitled render.

### 3. Five helpers — `UnicodeEncodeError` on cp1252 consoles

Windows consoles default to cp1252, which cannot encode the `→` `≥` `±` `×` `…` characters used in progress output:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in position 4
```

`render.py` alone has 14 such prints, so a long render dies partway with the encode work already spent. Each entry point now reconfigures `stdout`/`stderr` to UTF-8.

### 4. `timeline_view.py` — unreadable labels

`FONT_CANDIDATES` listed only macOS and Linux paths, so PIL fell back to a fixed-size bitmap font that ignores the requested size. Word labels and the time ruler were illegible, which defeats the purpose of the drill-down tool at cut-decision time. Added Consolas, Courier New, Segoe UI and Arial *after* the existing entries, so macOS and Linux resolution order is unchanged.

## Verification

Windows 10, ffmpeg 8.1, Python 3.11. A two-segment EDL rendered end to end: per-segment auto-grade → lossless concat → burned subtitles → two-pass loudnorm. A `timeline_view` of the **output** confirms both caption cues are visible and the cut lands where the EDL says. Duration matched expectation (4.10s vs 4.0s, encoder rounding).

Escaping alternatives were tested rather than assumed — for the metadata path, forward-slash-plus-single-escape and double-escape both still fail, while quad-escape and bare-filename-plus-`cwd` both work; the latter was chosen as the one that needs no platform branching.

## Risk

No behavior change on macOS or Linux. The `cwd` change is platform-neutral, `.replace("\\", "/")` is a no-op on POSIX paths, `reconfigure()` is guarded by `hasattr`, and the font additions are appended below the existing candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four Windows-only bugs in the helper scripts so auto-grade, subtitle burn-in, and timeline labels work end to end on Windows. No behavior change on macOS or Linux.

- **Bug Fixes**
  - Auto-grade: pass a bare filename and set `cwd` for `metadata=print:file=...` to avoid Windows filter-arg escaping crashes.
  - Subtitles: convert paths to forward slashes and escape the drive colon before applying the `subtitles` filter.
  - Console output: reconfigure `stdout`/`stderr` to UTF-8 in all entry points to prevent `UnicodeEncodeError` on cp1252 consoles.
  - Timeline fonts: add Windows fallbacks (Consolas, Courier New, Segoe UI, Arial) so labels render at the correct size.

<sup>Written for commit a1b09af73f3ddb3e13590827af8d5a61990fdd4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

