### PR TITLE
render: parametrize output frame rate with --fps (default 24)

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -157,6 +157,7 @@ def extract_segment(
     out_path: Path,
     preview: bool = False,
     draft: bool = False,
+    fps: int = 24,
 ) -> None:
     """Extract a cut range as its own MP4 with grade + 30ms audio fades baked in.
 
@@ -203,7 +204,7 @@ def extract_segment(
         "-vf", vf,
         "-af", af,
         "-c:v", "libx264", "-preset", preset, "-crf", crf,
-        "-pix_fmt", "yuv420p", "-r", "24",
+        "-pix_fmt", "yuv420p", "-r", str(fps),
         "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
         "-movflags", "+faststart",
         str(out_path),
@@ -216,6 +217,7 @@ def extract_all_segments(
     edit_dir: Path,
     preview: bool,
     draft: bool = False,
+    fps: int = 24,
 ) -> list[Path]:
     """Extract every EDL range into edit_dir/clips_graded/seg_NN.mp4.
     Returns the ordered list of segment paths.
@@ -255,7 +257,7 @@ def extract_all_segments(
         print(f"  [{i:02d}] {src_name}  {start:7.2f}-{end:7.2f}  ({duration:5.2f}s)  {note}")
         if is_auto:
             print(f"        grade: {seg_filter or '(none)'}")
-        extract_segment(src_path, start, duration, seg_filter, out_path, preview=preview, draft=draft)
+        extract_segment(src_path, start, duration, seg_filter, out_path, preview=preview, draft=draft, fps=fps)
         seg_paths.append(out_path)
 
     return seg_paths
@@ -587,6 +589,12 @@ def main() -> None:
         help="Draft mode: 720p, ultrafast, CRF 28 — cut-point verification only.",
     )
     ap.add_argument(
+        "--fps",
+        type=int,
+        default=24,
+        help="Output frame rate for segment extraction (default: 24).",
+    )
+    ap.add_argument(
         "--build-subtitles",
         action="store_true",
         help="Build master.srt from transcripts + EDL offsets before compositing",
@@ -613,7 +621,7 @@ def main() -> None:
 
     # 1. Extract per-segment (auto-grade per range if EDL grade is "auto")
     segment_paths = extract_all_segments(
-        edl, edit_dir, preview=args.preview, draft=args.draft
+        edl, edit_dir, preview=args.preview, draft=args.draft, fps=args.fps
     )
 
     # 2. Concat → base


### PR DESCRIPTION
## Problem

`extract_segment()` hardcodes `-r 24`, silently converting every source to 24fps. A 60fps vertical reel comes out at 24 with no warning, and there is no way to opt out — the skill's own guidance of preserving the source FPS cannot be followed.

## Change

Adds `--fps` (default 24, so existing behavior is unchanged) and threads it through `extract_all_segments()` → `extract_segment()`.

## How it was found

Editing a real 1080x1920@60 reel: output came back at 24fps with no indication anywhere. Verified with ffprobe before/after:

```
before: r_frame_rate=24/1   (source was 60/1)
after:  r_frame_rate=60/1   (with --fps 60)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTd52WxWgWPYeakcJAiAnR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--fps` flag to control the output frame rate during segment extraction. Default stays 24, so current behavior is unchanged, and you can now match sources like 60fps.

- **New Features**
  - New CLI flag `--fps` (default 24) for segment outputs.
  - Threads `fps` through `extract_all_segments()` and `extract_segment()`, replacing the hardcoded ffmpeg `-r 24`.
  - Use `--fps 60` to keep 60fps reels at 60fps.

<sup>Written for commit cb906eb56ddb3892fedb2c4a86bba75cae0a7ce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

