### PR TITLE
render: clamp composite output to the base video duration

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -552,6 +552,21 @@ def build_final_composite(
 
     filter_complex = ";".join(filter_parts)
 
+    # Clamp output to the base duration. overlay's framesync would otherwise
+    # extend the output with frozen frames whenever an overlay input outlasts
+    # the base video (e.g. a caption layer rendered with a trailing hold).
+    base_dur = None
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=duration",
+             "-of", "default=noprint_wrappers=1:nokey=1", str(base_path)],
+            capture_output=True, text=True, check=True,
+        )
+        base_dur = float(out.stdout.strip().splitlines()[0])
+    except Exception:
+        pass
+
     cmd = [
         "ffmpeg", "-y",
         *inputs,
@@ -561,6 +576,7 @@ def build_final_composite(
         "-c:v", "libx264", "-preset", "fast", "-crf", "18",
         "-pix_fmt", "yuv420p",
         "-c:a", "copy",
+        *(["-t", f"{base_dur:.3f}"] if base_dur else []),
         "-movflags", "+faststart",
         str(out_path),
     ]


### PR DESCRIPTION
## Problem

In `build_final_composite()`, overlay's framesync extends the output whenever an overlay input outlasts the base video: the last base frame is frozen and repeated until the overlay ends. An overlay even slightly longer than the base — e.g. a caption layer with a trailing hold on its last page — silently stretches the final video with frozen frames at the end.

## Change

Probe the base duration with ffprobe and pass `-t <base_dur>` to the composite command. Falls back to previous behavior if the probe fails, so the failure mode is the status quo.

## How it was found

Compositing a caption overlay (68.98s, rendered with a 300ms hold after the last word) over a 68.73s base: the output came out 250ms longer than the EDL's `total_duration_s`, with the last frame frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTd52WxWgWPYeakcJAiAnR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp the final composite to the base video’s duration to prevent frozen-frame tails when an overlay outlasts the base. We probe the base duration with `ffprobe` and pass `-t` to `ffmpeg`; if probing fails, we keep the previous behavior.

<sup>Written for commit 44be066227a03100397b21dad0b444767285fc67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

