### PR TITLE
Fix subtitles filter path escaping on Windows

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -537,7 +537,17 @@ def build_final_composite(
 
     # Subtitles LAST — Rule 1
     if has_subs:
-        subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
+        # Forward slashes BEFORE escaping the colon: ffmpeg's filtergraph parser
+        # treats "\" as an escape char, so a Windows path like C:\Users\sam
+        # arrives at the subtitles filter as "C:Userssam" and fails to open.
+        # ffmpeg accepts forward slashes on Windows, and this is a no-op on
+        # POSIX where the path has no backslashes to begin with.
+        subs_abs = (
+            str(subtitles_path.resolve())
+            .replace("\\", "/")
+            .replace(":", r"\:")
+            .replace("'", r"\'")
+        )
         filter_parts.append(
             f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
         )


### PR DESCRIPTION
## Problem

On Windows, every render that burns subtitles fails:

```
[Parsed_subtitles_0 @ ...] Unable to open C:UsersmeprojecteditmasterFsrt
[AVFilterGraph @ ...] Error initializing filters
Error : No such file or directory
```

Repro: `python helpers/render.py edit/edl.json -o final.mp4 --build-subtitles` on Windows. Segment extraction, concat and SRT generation all succeed; the failure is in the final composite pass.

## Cause

`build_final_composite` escapes the drive colon but leaves the Windows path separators alone:

```python
subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
```

ffmpeg's filtergraph parser treats `\` as an escape character, so the backslashes are consumed before the `subtitles` filter ever sees them. `C:\Users\me\edit\master.srt` arrives as `C:Usersmeeditmaster.srt`.

## Fix

Convert to forward slashes *before* escaping the colon. ffmpeg accepts forward slashes in filter paths on Windows, and the added `replace` is a no-op on POSIX, where the path contains no backslashes to begin with.

## Testing

- **Windows 11**, ffmpeg 8.1.1, Python 3.12 — `--build-subtitles` now renders end to end: 7 cues burned into a 1920x1080 `final.mp4`, loudnorm pass included. Verified the escaped filtergraph string opens the file by running the generated ffmpeg command directly both before and after the change.
- The change is string-level and platform-agnostic; on POSIX `str(Path.resolve())` yields no backslashes, so the behaviour is byte-identical to before.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subtitle burn-in failures on Windows by normalizing subtitle paths in the final composite filtergraph. Backslashes are converted to forward slashes before escaping the drive colon and quotes, so ffmpeg reads the SRT path correctly; POSIX is unaffected.

<sup>Written for commit 75d6b76f94d3f4cd8994342bad67a8605c5bb2a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

