### PR TITLE
fix: Windows ffmpeg filter paths + signalstats bit-depth normalisation

### DIFF
--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import tempfile
@@ -75,6 +76,44 @@ def get_preset(name: str) -> str:
 # -------- Auto grade (data-driven, per-clip) --------------------------------
 
 
+def _source_bit_depth(video: Path) -> int:
+    """True luma bit depth of the source, derived from its pixel format.
+
+    `signalstats`' YBITDEPTH cannot be used for this. That field is the popcount
+    of the bitwise OR of every sample value in the frame, so it describes the
+    frame's content, not the format. Measured against synthetic sources:
+
+        flat black  (Y=16  = 0b00010000) -> YBITDEPTH 1
+        flat white  (Y=235 = 0b11101011) -> YBITDEPTH 6
+        flat grey   (Y=126 = 0b01111110) -> YBITDEPTH 6
+        192..193 gradient (OR = 0b11000001) -> YBITDEPTH 3
+        full-range testsrc2                 -> YBITDEPTH 8
+
+    Normalising by 2**that - 1 therefore inflates flat frames enormously: pure
+    white would read as 235/63 = 3.73 ("373% brightness") and pure black as
+    16/1 = 16.0. On dark or flat footage the auto-grade then corrects hard in the
+    wrong direction. The pixel format is the only reliable source of the depth.
+    """
+    cmd = [
+        "ffprobe", "-v", "error", "-select_streams", "v:0",
+        "-show_entries", "stream=pix_fmt",
+        "-of", "default=noprint_wrappers=1:nokey=1",
+        str(video),
+    ]
+    try:
+        pix_fmt = subprocess.check_output(cmd).decode().strip().splitlines()[0]
+    except Exception:
+        return 8
+
+    # yuv420p10le -> 10, p010le -> 10, gray16le -> 16, yuv420p -> 8, rgb24 -> 8
+    name = re.sub(r"(le|be)$", "", pix_fmt.strip())
+    m = re.search(r"p(\d+)$", name) or re.search(r"gray(\d+)$", name)
+    if not m:
+        return 8
+    depth = int(m.group(1))
+    return depth if 8 <= depth <= 16 else 8
+
+
 def _sample_frame_stats(
     video: Path,
     start: float,
@@ -100,26 +139,31 @@ def _sample_frame_stats(
     with tempfile.NamedTemporaryFile(mode="w+", suffix=".txt", delete=False) as f:
         metadata_path = f.name
 
+    # A raw Windows path breaks the -vf parser twice over: backslashes are eaten
+    # and the drive colon reads as the filter's option separator. Forward slashes
+    # plus an escaped colon plus single quotes around the value survives both.
+    meta_arg = metadata_path.replace("\\", "/").replace(":", r"\:")
+
     try:
         cmd = [
             "ffmpeg", "-y", "-hide_banner", "-nostats",
             "-ss", f"{start:.3f}",
             "-i", str(video),
             "-t", f"{duration:.3f}",
-            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file={metadata_path}",
+            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file='{meta_arg}'",
             "-f", "null", "-",
         ]
         subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-        # Parse signalstats metadata. Signalstats reports values in the NATIVE
-        # bit depth of the decoded frame (8-bit → 0-255, 10-bit → 0-1023). We
-        # read YBITDEPTH and normalize by (2^depth - 1) so downstream math is
-        # in 0..1 regardless of source bit depth.
+        # Parse signalstats metadata. Values arrive in the source's native bit
+        # depth (8-bit → 0-255, 10-bit → 0-1023) and need normalising to 0..1 —
+        # but the depth comes from the pixel format, never from YBITDEPTH. See
+        # _source_bit_depth for the measurements behind that.
         y_avgs: list[float] = []
         y_mins: list[float] = []
         y_maxs: list[float] = []
         sat_avgs: list[float] = []
-        bit_depth: int = 8
+        bit_depth = _source_bit_depth(video)
 
         def _parse_value(line: str) -> float | None:
             try:
@@ -130,11 +174,7 @@ def _sample_frame_stats(
         with open(metadata_path) as f:
             for line in f:
                 line = line.strip()
-                if "lavfi.signalstats.YBITDEPTH" in line:
-                    v = _parse_value(line)
-                    if v is not None:
-                        bit_depth = int(v)
-                elif "lavfi.signalstats.YAVG" in line:
+                if "lavfi.signalstats.YAVG" in line:
                     v = _parse_value(line)
                     if v is not None:
                         y_avgs.append(v)
@@ -155,7 +195,7 @@ def _sample_frame_stats(
             # Analysis failed — return neutral defaults (no correction)
             return {"y_mean": 0.5, "y_std": 0.18, "sat_mean": 0.25}
 
-        # Normalize by native bit-depth max value
+        # Normalize by the format's max sample value
         max_val = (2 ** bit_depth) - 1
 
         y_mean = (sum(y_avgs) / len(y_avgs)) / max_val

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -48,8 +48,11 @@ except Exception:
 # baseline roughly 30% up from the bottom on any aspect — clear of the UI on
 # every major vertical-video platform. Do not drop this below ~75 without a
 # specific reason.
+# FontName: Helvetica does not exist on Windows; libass then silently falls back
+# to its default face and the proven metrics above no longer hold. Arial is
+# metric-compatible with Helvetica and present on Windows and macOS both.
 SUB_FORCE_STYLE = (
-    "FontName=Helvetica,FontSize=18,Bold=1,"
+    "FontName=Arial,FontSize=18,Bold=1,"
     "PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,BackColour=&H00000000,"
     "BorderStyle=1,Outline=2,Shadow=0,"
     "Alignment=2,MarginV=90"
@@ -537,7 +540,16 @@ def build_final_composite(
 
     # Subtitles LAST — Rule 1
     if has_subs:
-        subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
+        # Backslashes are eaten by the filtergraph parser, so a Windows path
+        # arrives as "C:UsersvitorFoo" and the filter fails with ENOENT. Convert
+        # to forward slashes BEFORE escaping the drive colon; ffmpeg accepts
+        # forward slashes on Windows.
+        subs_abs = (
+            str(subtitles_path.resolve())
+            .replace("\\", "/")
+            .replace(":", r"\:")
+            .replace("'", r"\'")
+        )
         filter_parts.append(
             f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
         )

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -157,6 +157,12 @@ FONT_CANDIDATES = [
     "/System/Library/Fonts/SFNSMono.ttf",
     "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
     "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+    # Windows. Without these, load_default() returns a fixed ~11px bitmap face
+    # that ignores `size`, and the timestamp labels the self-eval pass depends on
+    # come out unreadable.
+    "C:/Windows/Fonts/consola.ttf",
+    "C:/Windows/Fonts/lucon.ttf",
+    "C:/Windows/Fonts/arial.ttf",
 ]
 
 


### PR DESCRIPTION
Two independent problems found while running video-use end to end on Windows 11 against ~3h of gameplay footage. The first commit is Windows-only; the second is a correctness bug that affects every platform.

## 1. Subtitles never render on Windows, and the QC filmstrips are unreadable

`build_final_composite` escapes the drive colon in the subtitles path but leaves the backslashes. The filtergraph parser eats them, so the filter receives a mangled path and fails:

```
[Parsed_subtitles_0] Unable to open C:UsersvitorAppDataLocalTempmaster.srt
[AVFilterGraph] Error initializing filters
```

Converting to forward slashes **before** escaping the colon fixes it — ffmpeg accepts forward slashes on Windows.

Reproduction, with any 1s video and any `.srt`:

```bash
# fails
ffmpeg -i base.mp4 -filter_complex "[0:v]subtitles='C\:\Users\me\test.srt'[outv]" -map "[outv]" out.mp4
# works
ffmpeg -i base.mp4 -filter_complex "[0:v]subtitles='C\:/Users/me/test.srt'[outv]" -map "[outv]" out.mp4
```

Two smaller items in the same commit:

- `SUB_FORCE_STYLE` requests `FontName=Helvetica`, which Windows does not ship. libass substitutes its default face, so the carefully tuned `FontSize`/`Outline`/`MarginV` no longer describe what is rendered. Switched to Arial, which is metric-compatible and present on Windows and macOS both.
- `timeline_view.FONT_CANDIDATES` lists only macOS and Linux paths, so on Windows `load_font` falls through to `ImageFont.load_default()` — a fixed ~11px bitmap face that ignores the requested size. The filename and timestamp labels come out unreadable in exactly the QC images the skill's self-eval step depends on. Added the Windows console/Arial paths.

## 2. `grade.py` normalises by YBITDEPTH, which inverts the auto-grade

`_sample_frame_stats` divides `YAVG`/`YMIN`/`YMAX`/`SATAVG` by `(2**YBITDEPTH - 1)`, with a comment describing YBITDEPTH as "the NATIVE bit depth of the decoded frame".

It is not. `signalstats` computes it as the **popcount of the bitwise OR of every sample value in the frame**, so it describes content, not format. Measured on synthetic sources, all `yuv420p` 8-bit:

| source | Y | binary | popcount | YBITDEPTH |
| --- | --- | --- | --- | --- |
| flat black | 16 | `00010000` | 1 | **1** |
| flat white | 235 | `11101011` | 6 | **6** |
| flat grey | 126 | `01111110` | 6 | **6** |
| gradient 192–193 | OR `11000001` | 3 | **3** |
| full-range `testsrc2` | — | — | 8 | **8** |

Reproduce:

```bash
ffmpeg -f lavfi -i color=c=white:s=320x240 -t 0.2 \
  -vf "signalstats,metadata=print" -pix_fmt yuv420p -f null -  2>&1 | grep -E "YBITDEPTH|YAVG"
# lavfi.signalstats.YAVG=235
# lavfi.signalstats.YBITDEPTH=6      <- not 8
```

The parser also keeps whichever value appears last in the metadata file, so the divisor depends on the final sampled frame.

The consequence is not a rounding error, it flips the sign of the correction. On a dark 1080p clip whose last sampled frame reported 2:

| | `y_mean` | `sat_mean` | emitted filter |
| --- | --- | --- | --- |
| before | `18.3955` | `3.4061` | `eq=contrast=1.030:gamma=0.970:saturation=0.960` |
| after | `0.2164` | `0.0401` | `eq=contrast=1.030:gamma=1.100:saturation=1.040` |

Because 18.4 and 3.4 read as "very overexposed, very saturated", the auto-grade darkened and desaturated footage that was already dark and desaturated. Anything shot in a dark interior gets graded the wrong way.

Fixed by adding `_source_bit_depth()`, which reads `pix_fmt` via ffprobe and falls back to 8 if the probe fails.

The same commit also quotes and slash-normalises the `metadata=print:file=` path. A raw Windows path breaks the `-vf` parser twice — once on the eaten backslashes, once on the drive colon reading as the filter's own option separator. That one was invisible because the subprocess sends stderr to `DEVNULL`, so the analysis silently fell back to neutral defaults.

## Verification

- `helpers/*.py --help` all still import and run.
- `grade.py --analyze`, `--list-presets`, and `--preset warm_cinematic` verified end to end.
- Full `render.py` run over a 2-segment EDL with a grade, a PTS-shifted overlay and burnt-in subtitles: correct 6.04s output, captions visible above the overlay, 30ms fades intact at the cut.
- Bit-depth handling spot-checked on flat white (`0.9216` = 235/255), flat black (`0.0627` = 16/255), full-range `testsrc2`, and real 8-bit footage.

Tested on Windows 11, ffmpeg 9.0, Python 3.14.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows subtitle burn-in and QC label readability, and corrects auto‑grade normalization so grades are accurate on all platforms. Paths now parse on Windows and grading uses real source bit depth, preventing inverted corrections on dark footage.

- **Bug Fixes**
  - Windows paths: convert backslashes to forward slashes, escape the drive colon, and quote filter args so `ffmpeg` parses `subtitles=` and `metadata=print:file=` correctly; captions now render.
  - Fonts: switch `SUB_FORCE_STYLE` to Arial and add Windows font candidates so QC filmstrip labels are legible.
  - Auto‑grade: stop using `signalstats` `YBITDEPTH`; add `_source_bit_depth()` to read `pix_fmt` via `ffprobe` and normalize by the format’s max value.

<sup>Written for commit 0ae9b8ad648d82f48ef107562730607278d5dc4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

