### PR TITLE
Fix subtitle path escaping on Windows in render.py

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -537,7 +537,7 @@ def build_final_composite(
 
     # Subtitles LAST — Rule 1
     if has_subs:
-        subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
+        subs_abs = str(subtitles_path.resolve()).replace("\\", "/").replace(":", r"\:").replace("'", r"\'")
         filter_parts.append(
             f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
         )


### PR DESCRIPTION
## Summary
- On Windows, `build_final_composite`'s subtitles filter only escaped colons in the SRT path, leaving raw backslashes (e.g. `C:\Users\...\master.srt`) unescaped.
- ffmpeg's filtergraph parser treats backslash as an escape character too, so the resulting `subtitles='...'` filter string was malformed and the render failed with a non-zero exit whenever `--build-subtitles` (or any EDL with a `subtitles` path) was used on Windows.
- Fix: convert backslashes to forward slashes before escaping the drive-letter colon. ffmpeg's `subtitles` filter accepts forward slashes on Windows, which sidesteps the double-escaping problem entirely.

## Test plan
- [x] Reproduced the failure on Windows running `render.py --build-subtitles` against a Windows absolute path EDL — composite step failed with a `CalledProcessError` from the `subtitles=` filter.
- [x] Applied the fix and re-ran the same render end-to-end (5 separate EDLs, single and multi-segment) — subtitles composited correctly, no errors.
- [ ] Not tested on macOS/Linux (change is a no-op there since paths never contain backslashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows subtitle path escaping in the ffmpeg filter to stop renders from failing when using `--build-subtitles` or EDL subtitles.

- **Bug Fixes**
  - Replace backslashes with forward slashes before escaping the drive-letter colon and quotes in the subtitles path so ffmpeg parses it correctly on Windows.

<sup>Written for commit 5e9c4f7bc214cd7d603a1b3fa5ab3a224491458f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

