### PR TITLE
feat: add video environment preflight

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -59,6 +59,7 @@ The skill lives in `video-use/`. User footage lives wherever they put it. All se
 
 First-time install lives in `install.md` (clone, deps, ffmpeg, skill registration, API key). Don't re-run it every session; on cold start just verify:
 
+- `python helpers/check_env.py --videos-dir <videos_dir>` passes. Add `--require manim`, `--require remotion`, or `--require hyperframes` when the session will use that backend.
 - `ELEVENLABS_API_KEY` resolves — either in the environment or in `.env` at the video-use repo root. If missing, ask the user to paste one and write it to `.env` (never to the user's `<videos_dir>`).
 - `ffmpeg` + `ffprobe` on PATH.
 - Python deps installed (`uv sync` or `pip install -e .` inside the repo).

--- a/helpers/check_env.py
+++ b/helpers/check_env.py
@@ -1,0 +1,176 @@
+"""Preflight checks for video-use's external tools and session directories."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+MIN_FFMPEG_MAJOR = 4
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class Backend:
+    command: str
+    args: tuple[str, ...]
+    description: str
+
+
+BACKENDS = {
+    "hyperframes": Backend(
+        command="npx",
+        args=("--no-install", "hyperframes", "--version"),
+        description="HyperFrames via the local npm project",
+    ),
+    "remotion": Backend(
+        command="npx",
+        args=("--no-install", "remotion", "--version"),
+        description="Remotion via the local npm project",
+    ),
+    "manim": Backend(
+        command="manim",
+        args=("--version",),
+        description="Manim Community Edition",
+    ),
+}
+
+
+_VERSION_RE = re.compile(r"\bversion\s+([0-9]+(?:\.[0-9]+)*)\b", re.IGNORECASE)
+_V_VERSION_RE = re.compile(r"\bv([0-9]+(?:\.[0-9]+)*)\b", re.IGNORECASE)
+_BARE_VERSION_RE = re.compile(r"^\s*([0-9]+(?:\.[0-9]+)+)\s*$")
+
+
+def _version_text(executable: str, args: Sequence[str]) -> tuple[str | None, str]:
+    try:
+        completed = subprocess.run(
+            [executable, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, str(exc)
+
+    output = (completed.stdout or "") + (completed.stderr or "")
+    match = None
+    for line in output.splitlines()[:5]:
+        match = _VERSION_RE.search(line) or _V_VERSION_RE.search(line) or _BARE_VERSION_RE.search(line)
+        if match:
+            break
+    if not match:
+        first_line = output.strip().splitlines()[0] if output.strip() else "no version output"
+        return None, first_line
+    if completed.returncode != 0:
+        return None, f"command exited {completed.returncode}"
+    return match.group(1), ""
+
+
+def check_media_tool(name: str) -> CheckResult:
+    executable = shutil.which(name)
+    if executable is None:
+        return CheckResult(name, False, "not found on PATH")
+
+    version, error = _version_text(executable, ("-version",))
+    if version is None:
+        return CheckResult(name, False, f"could not read version ({error})")
+    if int(version.split(".", 1)[0]) < MIN_FFMPEG_MAJOR:
+        return CheckResult(name, False, f"version {version} is older than {MIN_FFMPEG_MAJOR}.0")
+    return CheckResult(name, True, f"{version} ({executable})")
+
+
+def check_writable_directory(name: str, path: Path, *, create: bool = False) -> CheckResult:
+    try:
+        if create:
+            path.mkdir(parents=True, exist_ok=True)
+        if not path.exists():
+            return CheckResult(name, False, f"does not exist: {path}")
+        if not path.is_dir():
+            return CheckResult(name, False, f"is not a directory: {path}")
+        with tempfile.NamedTemporaryFile(
+            prefix=".video-use-doctor-",
+            dir=path,
+            delete=True,
+        ):
+            pass
+    except OSError as exc:
+        return CheckResult(name, False, f"not writable ({exc})")
+    return CheckResult(name, True, str(path))
+
+
+def check_backend(name: str) -> CheckResult:
+    backend = BACKENDS[name]
+    executable = shutil.which(backend.command)
+    if executable is None:
+        return CheckResult(name, False, f"{backend.command} not found on PATH")
+
+    version, error = _version_text(executable, backend.args)
+    if version is None:
+        return CheckResult(name, False, f"{backend.description} unavailable ({error})")
+    return CheckResult(name, True, f"{version} ({backend.description})")
+
+
+def run_checks(videos_dir: Path, required_backends: Sequence[str]) -> list[CheckResult]:
+    results = [check_media_tool(name) for name in ("ffmpeg", "ffprobe")]
+    footage_result = check_writable_directory("footage", videos_dir)
+    results.append(footage_result)
+    results.append(
+        check_writable_directory(
+            "edit output",
+            videos_dir / "edit",
+            create=footage_result.ok,
+        )
+    )
+    results.extend(check_backend(name) for name in required_backends)
+    return results
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify video-use dependencies and session directories before editing."
+    )
+    parser.add_argument(
+        "--videos-dir",
+        type=Path,
+        default=Path.cwd(),
+        help="Footage directory; defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--require",
+        dest="required_backends",
+        action="append",
+        choices=sorted(BACKENDS),
+        metavar="BACKEND",
+        help="Also verify an optional backend (repeat for multiple backends).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    results = run_checks(args.videos_dir.expanduser().resolve(), args.required_backends or [])
+    passed = 0
+    for result in results:
+        status = "PASS" if result.ok else "FAIL"
+        print(f"[{status}] {result.name}: {result.detail}")
+        passed += result.ok
+    failed = len(results) - passed
+    print(f"Summary: {passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/install.md
+++ b/install.md
@@ -130,9 +130,24 @@ Scribe (ElevenLabs) does all transcription. Without a key, nothing transcribes.
 Run one real thing. Prefer the lightest verification that still proves the pipeline is wired up:
 
 ```bash
+python helpers/check_env.py --videos-dir /path/to/your/videos
 python ~/Developer/video-use/helpers/timeline_view.py --help >/dev/null && echo "helpers OK"
 ffprobe -version | head -1
 ```
+
+The preflight command checks `ffmpeg`, `ffprobe`, the footage directory, and the
+`edit/` output directory. Optional animation engines are checked only when
+requested, for example:
+
+```bash
+python helpers/check_env.py \
+  --videos-dir /path/to/your/videos \
+  --require manim \
+  --require remotion
+```
+
+It exits non-zero when a required check fails. It doesn't install anything or
+contact external services.
 
 Full transcription test is optional at install time — it burns Scribe credits. Better to wait until the user hands you their first clip.
 

--- a/tests/test_check_env.py
+++ b/tests/test_check_env.py
@@ -1,0 +1,95 @@
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from helpers import check_env
+
+
+class CheckEnvTests(unittest.TestCase):
+    def test_missing_media_tool_is_failure(self):
+        with patch.object(check_env.shutil, "which", return_value=None):
+            result = check_env.check_media_tool("ffmpeg")
+        self.assertFalse(result.ok)
+        self.assertIn("not found", result.detail)
+
+    def test_old_media_tool_is_failure(self):
+        with (
+            patch.object(check_env.shutil, "which", return_value="/usr/bin/ffmpeg"),
+            patch.object(
+                check_env,
+                "_version_text",
+                return_value=("3.4.11", ""),
+            ),
+        ):
+            result = check_env.check_media_tool("ffmpeg")
+        self.assertFalse(result.ok)
+        self.assertIn("older", result.detail)
+
+    def test_writable_directory_check_creates_edit_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = check_env.check_writable_directory(
+                "edit output",
+                Path(temp_dir) / "edit",
+                create=True,
+            )
+        self.assertTrue(result.ok)
+
+    def test_read_only_directory_is_failure(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir)
+            path.chmod(stat.S_IRUSR | stat.S_IXUSR)
+            try:
+                result = check_env.check_writable_directory("footage", path)
+            finally:
+                path.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        self.assertFalse(result.ok)
+
+    def test_optional_backend_is_not_checked_by_default(self):
+        with patch.object(check_env, "check_backend") as check_backend:
+            results = check_env.run_checks(Path.cwd(), [])
+        check_backend.assert_not_called()
+        self.assertEqual([result.name for result in results[-2:]], ["footage", "edit output"])
+
+    def test_missing_footage_directory_does_not_create_edit_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            videos_dir = Path(temp_dir) / "missing"
+            results = check_env.run_checks(videos_dir, [])
+        self.assertFalse(results[2].ok)
+        self.assertFalse((videos_dir / "edit").exists())
+
+    def test_required_backend_is_checked(self):
+        expected = check_env.CheckResult("manim", True, "0.20.1")
+        with (
+            patch.object(check_env, "check_media_tool", return_value=check_env.CheckResult("tool", True, "ok")),
+            patch.object(check_env, "check_writable_directory", return_value=check_env.CheckResult("dir", True, "ok")),
+            patch.object(check_env, "check_backend", return_value=expected) as check_backend,
+        ):
+            results = check_env.run_checks(Path.cwd(), ["manim"])
+        check_backend.assert_called_once_with("manim")
+        self.assertEqual(results[-1], expected)
+
+    def test_backend_version_output_is_supported(self):
+        with (
+            patch.object(check_env.shutil, "which", return_value="/usr/local/bin/manim"),
+            patch.object(check_env, "_version_text", return_value=("0.20.1", "")),
+        ):
+            result = check_env.check_backend("manim")
+        self.assertTrue(result.ok)
+        self.assertIn("0.20.1", result.detail)
+
+    def test_version_text_accepts_v_prefixed_output(self):
+        completed = type("Completed", (), {
+            "returncode": 0,
+            "stdout": "Manim Community v0.20.1\n",
+            "stderr": "",
+        })()
+        with patch.object(check_env.subprocess, "run", return_value=completed):
+            version, error = check_env._version_text("manim", ("--version",))
+        self.assertEqual(version, "0.20.1")
+        self.assertEqual(error, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What Changed

Adds a dependency-free preflight command for video-use:

```bash
python helpers/check_env.py --videos-dir /path/to/your/videos
```

It checks:

- `ffmpeg` and `ffprobe` are available and version 4+
- the footage directory exists and is writable
- the `<videos_dir>/edit/` output directory can be created and written to
- optional HyperFrames, Remotion, or Manim backends when explicitly requested with `--require`

It exits non-zero when a required check fails. It doesn't install packages or contact external services.

Closes #121.

## Why This Approach

The repository has no runtime dependency on a specific CLI framework and no existing test suite, so the command uses only the Python standard library. Optional animation engines stay opt-in because video-use installs them lazily per animation slot.

The check writes and removes a temporary file in the target directories instead of relying only on permission bits, which reflects the real failure mode on macOS, Linux, and WSL.

## Documentation

- `install.md` now uses the preflight command during setup verification.
- `SKILL.md` now recommends it on cold start and documents optional backend checks.

## Verification

- `python3 -m unittest discover -s tests -v`: **9 passed**
- `python3 -m py_compile helpers/check_env.py tests/test_check_env.py`: passed
- `python3 -m compileall -q helpers tests`: passed
- `python3 helpers/timeline_view.py --help`: passed
- Real temporary writable footage directory: **4 passed, 0 failed**, exit 0; `edit/` created
- Missing footage directory: **2 passed, 2 failed**, exit 1; no directory created
- `git diff --check`: passed

## Scope / Non-Goals

- No automatic installation
- No ElevenLabs API calls
- No transcription or rendering
- No mandatory Node, Remotion, HyperFrames, Manim, or LaTeX dependency
