### PR TITLE
Fix Windows console/file UTF-8 encoding crashes

### DIFF
--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -34,6 +34,11 @@ import sys
 import tempfile
 from pathlib import Path
 
+# Windows consoles default to a non-UTF-8 codepage (e.g. cp1252), which raises
+# UnicodeEncodeError on the arrows this module prints. Force UTF-8 stdout
+# unconditionally rather than relying on PYTHONIOENCODING being set.
+sys.stdout.reconfigure(encoding="utf-8")
+
 
 PRESETS: dict[str, str] = {
     # Subtle baseline — barely perceptible cleanup. No color shift.

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -20,6 +20,11 @@ import json
 import sys
 from pathlib import Path
 
+# Windows consoles default to a non-UTF-8 codepage (e.g. cp1252), which raises
+# UnicodeEncodeError on the arrow this module prints. Force UTF-8 stdout
+# unconditionally rather than relying on PYTHONIOENCODING being set.
+sys.stdout.reconfigure(encoding="utf-8")
+
 
 def format_time(seconds: float) -> str:
     """Format a time in seconds as "NNN.NN" with fixed 6-char width for alignment."""

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -28,6 +28,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows consoles default to a non-UTF-8 codepage (e.g. cp1252), which raises
+# UnicodeEncodeError on the arrows/em-dashes this module prints. Force UTF-8
+# stdout unconditionally rather than relying on PYTHONIOENCODING being set.
+sys.stdout.reconfigure(encoding="utf-8")
+
 try:
     from grade import get_preset, auto_grade_for_clip  # same directory
 except Exception:
@@ -380,7 +385,7 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
         lines.append(f"{_srt_timestamp(a)} --> {_srt_timestamp(b)}")
         lines.append(t)
         lines.append("")
-    out_path.write_text("\n".join(lines))
+    out_path.write_text("\n".join(lines), encoding="utf-8")
     print(f"master SRT → {out_path.name} ({len(entries)} cues)")
 
 
@@ -537,7 +542,9 @@ def build_final_composite(
 
     # Subtitles LAST — Rule 1
     if has_subs:
-        subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
+        # Windows: ffmpeg's subtitles filter needs forward slashes and an escaped
+        # drive-letter colon; backslashes otherwise collide with filtergraph escaping.
+        subs_abs = str(subtitles_path.resolve()).replace("\\", "/").replace(":", r"\:").replace("'", r"\'")
         filter_parts.append(
             f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
         )

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -27,6 +27,11 @@ import sys
 import tempfile
 from pathlib import Path
 
+# Windows consoles default to a non-UTF-8 codepage (e.g. cp1252), which raises
+# UnicodeEncodeError on the arrows this module prints. Force UTF-8 stdout
+# unconditionally rather than relying on PYTHONIOENCODING being set.
+sys.stdout.reconfigure(encoding="utf-8")
+
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -20,6 +20,11 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+# Windows consoles default to a non-UTF-8 codepage (e.g. cp1252), which raises
+# UnicodeEncodeError on the arrow this module prints. Force UTF-8 stdout
+# unconditionally rather than relying on PYTHONIOENCODING being set.
+sys.stdout.reconfigure(encoding="utf-8")
+
 from transcribe import load_api_key, transcribe_one
 
 


### PR DESCRIPTION
## Summary
- Several `helpers/*.py` scripts print non-ASCII characters (arrows); on a stock Windows console (non-UTF-8 codepage, e.g. cp1252) this raises `UnicodeEncodeError` unless the caller happens to set `PYTHONIOENCODING=utf-8` first. Reconfigure stdout to UTF-8 unconditionally at import time in `render.py`, `grade.py`, `pack_transcripts.py`, `timeline_view.py`, and `transcribe_batch.py`.
- `render.py`'s `build_master_srt` wrote `master.srt` without an explicit encoding, corrupting accented characters on Windows and breaking the downstream ffmpeg subtitles burn (`Invalid UTF-8 in decoded subtitles text`). Now written explicitly as UTF-8.
- `render.py`'s `build_final_composite`: after the encoding fix, ffmpeg's `subtitles` filter still failed on Windows (`Invalid data found when processing input`) because the absolute subtitles path used backslashes, colliding with the filter's own escaping syntax. Normalized to forward slashes before escaping the drive-letter colon.

Found and fixed while running the full transcribe → pack → render pipeline end-to-end on Windows against real footage.

## Test plan
- [x] Ran `pack_transcripts.py` on a real transcript on Windows without `PYTHONIOENCODING` set — no crash, arrow prints correctly.
- [x] Ran the full `render.py` pipeline (extract → concat → subtitles burn) on Windows — `master.srt` accents intact, ffmpeg subtitles filter succeeds.
- [ ] Not tested on macOS/Linux (the encoding issue is Windows-specific; `reconfigure(encoding="utf-8")` is a no-op there since stdout is already UTF-8).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows-specific Unicode and path issues that caused UnicodeEncodeError in helper output and subtitle burn failures. Previously: helpers printed non-ASCII to a non-UTF-8 console and `master.srt` used the default encoding/backslash paths; now: stdout is UTF-8, `master.srt` is UTF-8, and subtitle paths use forward slashes with an escaped drive colon.

- Reconfigure stdout to UTF-8 at import in `helpers/render.py`, `helpers/grade.py`, `helpers/pack_transcripts.py`, `helpers/timeline_view.py`, and `helpers/transcribe_batch.py`. Callers no longer need PYTHONIOENCODING set. No-op on macOS/Linux.
- Write `master.srt` with UTF-8 encoding to preserve accents and satisfy `ffmpeg` subtitle parsing.
- Normalize subtitle path for `ffmpeg` by replacing backslashes with forward slashes and escaping the drive-letter colon to avoid filtergraph escaping conflicts on Windows.

<sup>Written for commit 4e7cc82c8516d0d13a5f4930dcf865a4897c1379. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

