### PR TITLE
Fix subtitle burn-in: Homebrew's ffmpeg formula lacks libass

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ ln -sfn ~/Developer/video-use ~/.claude/skills/video-use        # Claude Code
 # 2. Install deps
 cd ~/Developer/video-use
 uv sync                         # or: pip install -e .
-brew install ffmpeg             # required
+brew install ffmpeg-full        # required — plain `ffmpeg` lacks libass, so
+brew link --overwrite ffmpeg-full   # subtitle burn-in (Hard Rule 1) silently breaks
 brew install yt-dlp             # optional, for downloading online sources
 
 # 3. Add your ElevenLabs API key

--- a/install.md
+++ b/install.md
@@ -50,22 +50,29 @@ command -v uv >/dev/null && uv sync || pip install -e .
 
 ### 3. Install ffmpeg (+ optional yt-dlp)
 
-`ffmpeg` and `ffprobe` are hard requirements. `yt-dlp` is only needed if the user wants to pull sources from URLs. Animation engines such as HyperFrames, Remotion, and Manim are installed lazily the first time a project actually needs them.
+`ffmpeg` and `ffprobe` are hard requirements. `ffmpeg` specifically **must be built with `libass`** — Hard Rule 1 (subtitles burned in) depends on the `subtitles` filter, which doesn't exist without it. `yt-dlp` is only needed if the user wants to pull sources from URLs. Animation engines such as HyperFrames, Remotion, and Manim are installed lazily the first time a project actually needs them.
 
 ```bash
-# macOS
-command -v ffmpeg >/dev/null || brew install ffmpeg
+# macOS — Homebrew's plain `ffmpeg` formula ships WITHOUT libass (no subtitles
+# filter). `ffmpeg-full` has it. Check first; only reinstall if missing.
+if ! ffmpeg -h filter=subtitles 2>&1 | grep -q "Filter subtitles"; then
+  brew install ffmpeg-full
+  brew link --overwrite ffmpeg-full
+fi
 command -v yt-dlp >/dev/null || brew install yt-dlp     # optional
 
-# Debian / Ubuntu
+# Debian / Ubuntu — apt's ffmpeg is built with libass by default, but verify:
 # sudo apt-get update && sudo apt-get install -y ffmpeg
+# ffmpeg -h filter=subtitles 2>&1 | grep -q "Filter subtitles" || echo "rebuild ffmpeg with --enable-libass"
 # pip install yt-dlp
 
-# Arch
+# Arch — pacman's ffmpeg is built with libass by default, but verify the same way.
 # sudo pacman -S ffmpeg yt-dlp
 ```
 
 If `brew` / `apt` / `pacman` requires a sudo prompt, tell the user the exact command and wait. Do not invent a password.
+
+`brew link --overwrite ffmpeg-full` repoints the global `ffmpeg`/`ffprobe` symlinks at the fuller build — it's a system-wide change (any other tool that shells out to `ffmpeg` gets the new binary too). `ffmpeg-full` is a superset of plain `ffmpeg` so this is safe in practice, but tell the user what you're doing rather than silently relinking.
 
 ### 4. Register the skill with the current agent
 
@@ -132,6 +139,7 @@ Run one real thing. Prefer the lightest verification that still proves the pipel
 ```bash
 python ~/Developer/video-use/helpers/timeline_view.py --help >/dev/null && echo "helpers OK"
 ffprobe -version | head -1
+ffmpeg -h filter=subtitles 2>&1 | grep -q "Filter subtitles" && echo "libass OK (subtitles filter present)"
 ```
 
 Full transcription test is optional at install time — it burns Scribe credits. Better to wait until the user hands you their first clip.
@@ -154,7 +162,7 @@ Tell the user, in one short message:
 
 - Symlink the **whole directory**, not just `SKILL.md`. The helpers need to sit next to it.
 - If `.env` exists but the key is empty, treat it the same as missing — don't assume existence means validity.
-- `ffmpeg` from static builds works fine. Any modern (≥ 4.x) build is enough.
+- `ffmpeg` from static builds works fine. Any modern (≥ 4.x) build is enough — as long as it has `libass` (check with `ffmpeg -h filter=subtitles`). A build without it will fail deep into a render, at the subtitles-burn step, which is a much worse place to discover this than at install time.
 - `yt-dlp` is optional. Don't block install on it; install lazily the first time a user asks to pull from a URL.
 - Node.js/npm are only needed for HyperFrames or Remotion slots. HyperFrames currently requires Node.js 22+.
 - HyperFrames, Remotion, and Manim are optional animation engines. Don't install or prefer one globally during setup; pick the engine per animation slot in `SKILL.md`. HyperFrames can run through `npx --yes hyperframes ...` in the slot directory. Remotion can be scaffolded with `npx create-video@latest` or installed inside the slot before rendering.


### PR DESCRIPTION
## Summary

On macOS, plain `brew install ffmpeg` (what `install.md` currently tells every agent to run) ships **without libass**, so the `subtitles` filter doesn't exist in that build at all. Since Hard Rule 1 (subtitles burned in last, after every overlay) depends entirely on that filter, any render that burns captions fails — but only when it gets to that step, deep into a render, not at install time where it'd be cheap to catch.

`ffmpeg-full` (also in homebrew-core) is a superset build that includes libass. This PR:

- Checks for the `subtitles` filter first (`ffmpeg -h filter=subtitles`) before doing anything, so machines that already have a libass-enabled `ffmpeg` (common on Linux — apt/pacman both build with libass by default) aren't affected.
- Falls back to `brew install ffmpeg-full && brew link --overwrite ffmpeg-full` only when the filter is missing.
- Adds a verification line at the end of `install.md`'s end-to-end check so this surfaces immediately on install rather than during someone's first real render.
- Updates the manual-install path in `README.md` to match.

Found this the hard way while rendering vertical clips with burned captions — `ffmpeg` ran without error but silently had no `subtitles` filter registered.

## Test plan

- [x] Confirmed plain `brew install ffmpeg` on macOS (Homebrew core formula) has no `libass`/`subtitles` filter (`ffmpeg -h filter=subtitles` → `Unknown filter 'subtitles'`)
- [x] Confirmed `ffmpeg-full` has it (`ffmpeg -h filter=subtitles` → `Filter subtitles / Render text subtitles onto input video using the libass library.`)
- [x] `brew link --overwrite ffmpeg-full` correctly repoints the global `ffmpeg`/`ffprobe` symlinks
- [x] Burned a real 2-word subtitle onto a rendered clip afterward and confirmed it rendered correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subtitle burn-in on macOS by ensuring `ffmpeg` includes `libass`. Previously, Homebrew’s default `ffmpeg` lacked the `subtitles` filter, so caption burn-in failed late in renders; we now detect this early and install/link `ffmpeg-full` when needed.

- macOS install now checks `ffmpeg -h filter=subtitles`; if missing, runs `brew install ffmpeg-full` and `brew link --overwrite ffmpeg-full`.
- Adds an install verification step that confirms the `subtitles` filter is present so issues surface at setup, not during a render.
- Updates manual install in `README.md` to use `brew install ffmpeg-full` plus a link step.
- Notes for Linux distros: default packages usually include `libass`, but we document how to verify.
- Side effect: linking `ffmpeg-full` updates system-wide `ffmpeg`/`ffprobe` symlinks; it’s a superset of `ffmpeg`.
- Migration: macOS developers with an existing Homebrew `ffmpeg` should rerun the install step or manually `brew install ffmpeg-full && brew link --overwrite ffmpeg-full`.

<sup>Written for commit e5824faae528d299d9ed33551d9d26a894c10c06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

