### PR TITLE
transcribe: select the audio track, and refuse to upload a silent one

### DIFF
--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -113,6 +113,18 @@ def call_scribe(
     return resp.json()
 
 
+def transcript_path(edit_dir: Path, video: Path, audio_track: int = 0) -> Path:
+    """Where a video's transcript lands.
+
+    The track belongs in the name, or a rerun with --audio-track hands back the transcript of
+    the track it is meant to replace. Track 0 keeps the plain name, so transcripts made before
+    the flag existed stay valid. Batch mode tests its cache with this too — one function, so
+    the two cannot drift apart.
+    """
+    suffix = "" if audio_track == 0 else f".track{audio_track}"
+    return edit_dir / "transcripts" / f"{video.stem}{suffix}.json"
+
+
 def transcribe_one(
     video: Path,
     edit_dir: Path,
@@ -128,8 +140,7 @@ def transcribe_one(
     """
     transcripts_dir = edit_dir / "transcripts"
     transcripts_dir.mkdir(parents=True, exist_ok=True)
-    suffix = "" if audio_track == 0 else f".track{audio_track}"
-    out_path = transcripts_dir / f"{video.stem}{suffix}.json"
+    out_path = transcript_path(edit_dir, video, audio_track)
 
     if out_path.exists():
         if verbose:

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -61,12 +61,13 @@ def count_audio_tracks(video_path: Path) -> int:
 
 def peak_dbfs(wav_path: Path) -> float:
     """Peak level of a 16-bit PCM wav, in dBFS. -inf for digital silence."""
+    peak = 0
     with wave.open(str(wav_path), "rb") as w:
-        frames = w.readframes(w.getnframes())
-    if not frames:
-        return float("-inf")
-    samples = array.array("h", frames)
-    peak = max(max(samples), -min(samples)) if samples else 0
+        # A chunk at a time: batch mode runs several of these at once, and a two-hour
+        # take is 230 MB of 16 kHz mono before the array copy doubles it.
+        while frames := w.readframes(1 << 16):
+            samples = array.array("h", frames)
+            peak = max(peak, max(samples), -min(samples))
     return 20 * math.log10(peak / 32768) if peak > 0 else float("-inf")
 
 
@@ -127,7 +128,8 @@ def transcribe_one(
     """
     transcripts_dir = edit_dir / "transcripts"
     transcripts_dir.mkdir(parents=True, exist_ok=True)
-    out_path = transcripts_dir / f"{video.stem}.json"
+    suffix = "" if audio_track == 0 else f".track{audio_track}"
+    out_path = transcripts_dir / f"{video.stem}{suffix}.json"
 
     if out_path.exists():
         if verbose:
@@ -155,7 +157,7 @@ def transcribe_one(
                 f"track {audio_track + 1} of {video.name} is silent "
                 f"(peak {peak:.1f} dBFS) - not uploading. "
                 + (f"The file has {n_tracks} audio tracks; try --audio-track "
-                   f"{1 if audio_track == 0 else 0}."
+                   + " or ".join(str(i) for i in range(n_tracks) if i != audio_track) + "."
                    if n_tracks > 1 else "Check the source audio.")
             )
 
@@ -202,7 +204,8 @@ def main() -> None:
         type=int,
         default=0,
         help="Zero-based audio track to transcribe. OBS writes the game on track 0 "
-             "and the mic on track 1; ffmpeg would otherwise take track 0.",
+             "and the mic on track 1; without this ffmpeg applies its default audio "
+             "stream selection, which picks the track with the most channels.",
     )
     args = ap.parse_args()
 

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -16,12 +16,15 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import array
 import json
+import math
 import os
 import subprocess
 import sys
 import tempfile
 import time
+import wave
 from pathlib import Path
 
 import requests
@@ -46,9 +49,31 @@ def load_api_key() -> str:
     return v
 
 
-def extract_audio(video_path: Path, dest: Path) -> None:
+def count_audio_tracks(video_path: Path) -> int:
+    """How many audio streams the container holds."""
+    out = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "a",
+         "-show_entries", "stream=index", "-of", "csv=p=0", str(video_path)],
+        capture_output=True, text=True,
+    )
+    return len([ln for ln in out.stdout.splitlines() if ln.strip()])
+
+
+def peak_dbfs(wav_path: Path) -> float:
+    """Peak level of a 16-bit PCM wav, in dBFS. -inf for digital silence."""
+    with wave.open(str(wav_path), "rb") as w:
+        frames = w.readframes(w.getnframes())
+    if not frames:
+        return float("-inf")
+    samples = array.array("h", frames)
+    peak = max(max(samples), -min(samples)) if samples else 0
+    return 20 * math.log10(peak / 32768) if peak > 0 else float("-inf")
+
+
+def extract_audio(video_path: Path, dest: Path, audio_track: int = 0) -> None:
     cmd = [
         "ffmpeg", "-y", "-i", str(video_path),
+        "-map", f"0:a:{audio_track}",
         "-vn", "-ac", "1", "-ar", "16000", "-c:a", "pcm_s16le",
         str(dest),
     ]
@@ -94,6 +119,7 @@ def transcribe_one(
     language: str | None = None,
     num_speakers: int | None = None,
     verbose: bool = True,
+    audio_track: int = 0,
 ) -> Path:
     """Transcribe a single video. Returns path to transcript JSON.
 
@@ -111,10 +137,28 @@ def transcribe_one(
     if verbose:
         print(f"  extracting audio from {video.name}", flush=True)
 
+    n_tracks = count_audio_tracks(video)
+    if n_tracks > 1 and verbose:
+        print(f"  note: {video.name} has {n_tracks} audio tracks, using track "
+              f"{audio_track + 1} (--audio-track to change)", flush=True)
+
     t0 = time.time()
     with tempfile.TemporaryDirectory() as tmp:
         audio = Path(tmp) / f"{video.stem}.wav"
-        extract_audio(video, audio)
+        extract_audio(video, audio, audio_track)
+
+        # Uploading silence costs the same as uploading speech and returns
+        # nothing, so catch the wrong-track case before paying for it.
+        peak = peak_dbfs(audio)
+        if peak < -60.0:
+            raise RuntimeError(
+                f"track {audio_track + 1} of {video.name} is silent "
+                f"(peak {peak:.1f} dBFS) - not uploading. "
+                + (f"The file has {n_tracks} audio tracks; try --audio-track "
+                   f"{1 if audio_track == 0 else 0}."
+                   if n_tracks > 1 else "Check the source audio.")
+            )
+
         size_mb = audio.stat().st_size / (1024 * 1024)
         if verbose:
             print(f"  uploading {video.stem}.wav ({size_mb:.1f} MB)", flush=True)
@@ -153,6 +197,13 @@ def main() -> None:
         default=None,
         help="Optional number of speakers when known. Improves diarization accuracy.",
     )
+    ap.add_argument(
+        "--audio-track",
+        type=int,
+        default=0,
+        help="Zero-based audio track to transcribe. OBS writes the game on track 0 "
+             "and the mic on track 1; ffmpeg would otherwise take track 0.",
+    )
     args = ap.parse_args()
 
     video = args.video.resolve()
@@ -168,6 +219,7 @@ def main() -> None:
         api_key=api_key,
         language=args.language,
         num_speakers=args.num_speakers,
+        audio_track=args.audio_track,
     )
 
 

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -56,6 +56,12 @@ def main() -> None:
         default=None,
         help="Optional number of speakers. Improves diarization when known.",
     )
+    ap.add_argument(
+        "--audio-track",
+        type=int,
+        default=0,
+        help="Zero-based audio track to transcribe (OBS: 0 = game, 1 = mic).",
+    )
     args = ap.parse_args()
 
     videos_dir = args.videos_dir.resolve()
@@ -93,6 +99,7 @@ def main() -> None:
                 language=args.language,
                 num_speakers=args.num_speakers,
                 verbose=False,
+                audio_track=args.audio_track,
             ): v
             for v in pending
         }

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -20,7 +20,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from transcribe import load_api_key, transcribe_one
+from transcribe import load_api_key, transcribe_one, transcript_path
 
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
@@ -75,7 +75,8 @@ def main() -> None:
     if not videos:
         sys.exit(f"no videos found in {videos_dir}")
 
-    already_cached = [v for v in videos if (edit_dir / "transcripts" / f"{v.stem}.json").exists()]
+    already_cached = [v for v in videos
+                      if transcript_path(edit_dir, v, args.audio_track).exists()]
     pending = [v for v in videos if v not in already_cached]
 
     print(f"found {len(videos)} videos ({len(already_cached)} cached, {len(pending)} to transcribe)")


### PR DESCRIPTION
`extract_audio` ran without `-map`, so ffmpeg applied its default stream selection and took a single audio track. A screen capture normally has two: OBS writes the application on track 0 and the microphone on track 1. Transcribing such a file uploaded the application audio and dropped the narration without saying so. The result is a transcript of the wrong thing, not an error.

`--audio-track` selects the stream, zero-based, and defaults to 0. Note this makes the choice deterministic rather than preserving it exactly: ffmpeg's default selection picks the audio stream with the most channels, which is the first track when both are stereo, but not in general. A file with more than one track now says so in verbose output.

The extracted wav is also level-checked before it's sent. A peak under -60 dBFS means the track is silent, which in practice means the wrong track was picked, and Scribe bills silence the same as speech. The error names the track count and points at the flag:

```
RuntimeError: track 2 of capture.mkv is silent (peak -inf dBFS) - not uploading.
The file has 2 audio tracks; try --audio-track 0.
```

Verified on a two-track OBS capture where the microphone track is digital silence: the guard fires and nothing is uploaded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Selects the audio track to transcribe, rejects silent tracks, and keys the transcript cache by track. Previously `ffmpeg`’s default often picked app/game audio instead of the mic, and a cache hit could hide a wrong-track rerun.

- Adds `--audio-track` (zero-based, default 0) to `transcribe.py` and `transcribe_batch.py`; uses `-map 0:a:<n>` in `ffmpeg` for deterministic selection. For OBS mic, pass `--audio-track 1`. Single‑track files are unchanged.
- Notes multi‑track inputs in verbose mode; checks WAV peak and refuses to upload below −60 dBFS. On silence, raises and suggests valid tracks. Action: rerun with the correct `--audio-track`.
- Keys the transcript cache by track: `<video>.json` for track 0 and `<video>.trackN.json` otherwise. Single and batch modes share `transcript_path()`, so batch cache checks match writes and avoid re-uploads.
- Scans peak in chunks to reduce memory in batch runs.

<sup>Written for commit a6fdea16a8a1a44f860f98c9c40ffb658a7f4a7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

