### PR TITLE
Windows: escape the metadata path, decode JSON as UTF-8, find a font

### DIFF
--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -77,7 +77,7 @@ def get_preset(name: str) -> str:
 
 def _esc_filter_path(path: str) -> str:
     """A filesystem path safe to embed in an ffmpeg filter option value."""
-    return path.replace("\\", "/").replace(":", r"\:")
+    return path.replace("\\", "/").replace(":", r"\:").replace("'", r"\'")
 
 
 def _sample_frame_stats(

--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -75,6 +75,11 @@ def get_preset(name: str) -> str:
 # -------- Auto grade (data-driven, per-clip) --------------------------------
 
 
+def _esc_filter_path(path: str) -> str:
+    """A filesystem path safe to embed in an ffmpeg filter option value."""
+    return path.replace("\\", "/").replace(":", r"\:")
+
+
 def _sample_frame_stats(
     video: Path,
     start: float,
@@ -106,7 +111,10 @@ def _sample_frame_stats(
             "-ss", f"{start:.3f}",
             "-i", str(video),
             "-t", f"{duration:.3f}",
-            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file={metadata_path}",
+            # The path lands inside a filter option value, where the parser reads the
+            # drive colon as an option separator: C:\tmp\x.txt becomes an option named
+            # "tmp\x.txt". Escaped the same way subtitles= already is in render.py.
+            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file='{_esc_filter_path(metadata_path)}'",
             "-f", "null", "-",
         ]
         subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -124,7 +124,7 @@ def group_into_phrases(
 
 def pack_one_file(json_path: Path, silence_threshold: float) -> tuple[str, float, list[dict]]:
     """Return (header_name, duration, phrases) for one transcript file."""
-    data = json.loads(json_path.read_text())
+    data = json.loads(json_path.read_text(encoding="utf-8"))
     words = data.get("words", [])
     phrases = group_into_phrases(words, silence_threshold)
     if phrases:

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -337,7 +337,7 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
             seg_offset += seg_duration
             continue
 
-        transcript = json.loads(tr_path.read_text())
+        transcript = json.loads(tr_path.read_text(encoding="utf-8"))
         words_in_seg = _words_in_range(transcript, seg_start, seg_end)
 
         # Group into 2-word chunks, break on punctuation
@@ -607,7 +607,7 @@ def main() -> None:
     if not edl_path.exists():
         sys.exit(f"edl not found: {edl_path}")
 
-    edl = json.loads(edl_path.read_text())
+    edl = json.loads(edl_path.read_text(encoding="utf-8"))
     edit_dir = edl_path.parent
     out_path = args.output.resolve()
 

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -268,7 +268,8 @@ def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -
     """Lossless concat via the concat demuxer. No re-encode."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
     concat_list = edit_dir / "_concat.txt"
-    concat_list.write_text("".join(f"file '{p.resolve()}'\n" for p in segment_paths))
+    concat_list.write_text("".join(f"file '{p.resolve()}'\n" for p in segment_paths),
+                           encoding="utf-8")
 
     cmd = [
         "ffmpeg", "-y",
@@ -380,7 +381,7 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
         lines.append(f"{_srt_timestamp(a)} --> {_srt_timestamp(b)}")
         lines.append(t)
         lines.append("")
-    out_path.write_text("\n".join(lines))
+    out_path.write_text("\n".join(lines), encoding="utf-8")
     print(f"master SRT → {out_path.name} ({len(entries)} cues)")
 
 

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -118,7 +118,7 @@ def compute_envelope(video: Path, start: float, end: float, samples: int = 2000)
 def words_in_range(transcript_path: Path, start: float, end: float) -> list[dict]:
     if not transcript_path.exists():
         return []
-    data = json.loads(transcript_path.read_text())
+    data = json.loads(transcript_path.read_text(encoding="utf-8"))
     out: list[dict] = []
     for w in data.get("words", []):
         t = w.get("type", "word")
@@ -157,6 +157,8 @@ FONT_CANDIDATES = [
     "/System/Library/Fonts/SFNSMono.ttf",
     "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
     "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+    "C:/Windows/Fonts/consola.ttf",
+    "C:/Windows/Fonts/arial.ttf",
 ]
 
 


### PR DESCRIPTION
Windows failures around paths and text encoding, each one reproduced on this machine. The branch leaves out the stdout reconfigure from #131 and the subtitles path escaping from #128, so it can land on top of either.

**`grade.py`, filter option value.** `_sample_frame_stats` passes a temp file path into `metadata=print:file=`. Inside a filter option value the drive colon reads as an option separator, so the graph never builds and the analysis dies before a frame is sampled:

```
[AVFilterGraph] No option name near 'UsersRunnerAppDataLocalTemptmpxp9d38w9.txt'
[AVFilterGraph] Error parsing a filter
```

The path is now escaped the way `render.py` escapes the subtitles path, colon and quote both. Verified with `--analyze` on a real capture: the filter it computes is identical to a run where the path parses.

**Reads decoded with the locale codepage.** `render.py` and `timeline_view.py` load the transcript and the EDL with `read_text()`. What happens next depends on the bytes, and both outcomes are worse than an obvious error. A real EDL from my project, holding Cyrillic beat labels, dies with `UnicodeDecodeError: 'charmap' codec can't decode byte 0x98`. A payload that happens to map cleanly comes back as mojibake instead: `"привет"` reads as `"Рїсђрёрірес‚"`, and the subtitles are built from that. `pack_transcripts.py` reads the same JSON the same way. All three files are JSON, so UTF-8 is the only correct decoding.

**Writes encoded with the locale codepage.** The concat list is written with `write_text()`, so a segment under a non-ASCII path is written in a form ffmpeg won't open ("Impossible to open ..."), and the concat stops. Written as UTF-8, the same list works. The master SRT has the same bug with a worse ending, because it's the artifact the viewer sees: libass reads it as UTF-8 and the subtitles come out garbled. #131 carries that one line as well; it's here so this branch fixes reading and writing together rather than half of each.

**`timeline_view.py`, fonts.** `FONT_CANDIDATES` lists macOS and Linux paths only. `load_font` falls back to `ImageFont.load_default()`, so the timeline still renders, in a bitmap font at a fixed size. Consolas and Arial appended.

Windows 11, Python 3.11.9, ffmpeg N-121793.
