### PR TITLE
fix(render): account for rotation metadata in portrait detection

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -137,7 +137,7 @@ def is_portrait_source(video: Path) -> bool:
         out = subprocess.run(
             ["ffprobe", "-v", "error", "-select_streams", "v:0",
              "-show_entries",
-             "stream=width,height:stream_tags=rotate:stream_side_data=rotation",
+             "stream=width,height:stream_side_data=rotation",
              "-of", "json", str(video)],
             capture_output=True, text=True, check=True,
         )
@@ -147,17 +147,15 @@ def is_portrait_source(video: Path) -> bool:
         stream = streams[0]
         w, h = int(stream["width"]), int(stream["height"])
 
-        # Modern containers expose rotation through display-matrix side data;
-        # older files may use a legacy `rotate` stream tag. ffmpeg autorotates
-        # before applying filters, so swap the coded dimensions for quarter-turns
-        # to choose the scale axis from the dimensions the filter actually sees.
-        rotation = None
+        # ffmpeg autorotates display-matrix side data before applying filters.
+        # Swap coded dimensions for quarter-turns so the scale axis is selected
+        # from the dimensions the filter actually sees. A plain metadata tag is
+        # intentionally ignored because it does not guarantee autorotation.
+        rotation = 0
         for side_data in stream.get("side_data_list") or []:
             if side_data.get("rotation") is not None:
                 rotation = side_data["rotation"]
                 break
-        if rotation is None:
-            rotation = (stream.get("tags") or {}).get("rotate", 0)
         if int(round(float(rotation))) % 360 in (90, 270):
             w, h = h, w
         return h > w

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -132,17 +132,44 @@ def is_hdr_source(video: Path) -> bool:
 
 
 def is_portrait_source(video: Path) -> bool:
-    """Return True if the video's height > width (portrait / vertical)."""
+    """Return True if the displayed video is portrait, including rotation."""
     try:
         out = subprocess.run(
             ["ffprobe", "-v", "error", "-select_streams", "v:0",
-             "-show_entries", "stream=width,height",
-             "-of", "csv=p=0", str(video)],
+             "-show_entries",
+             "stream=width,height:stream_tags=rotate:stream_side_data=rotation",
+             "-of", "json", str(video)],
             capture_output=True, text=True, check=True,
         )
-        w, h = map(int, out.stdout.strip().split(","))
+        streams = json.loads(out.stdout).get("streams") or []
+        if not streams:
+            return False
+        stream = streams[0]
+        w, h = int(stream["width"]), int(stream["height"])
+
+        # Modern containers expose rotation through display-matrix side data;
+        # older files may use a legacy `rotate` stream tag. ffmpeg autorotates
+        # before applying filters, so swap the coded dimensions for quarter-turns
+        # to choose the scale axis from the dimensions the filter actually sees.
+        rotation = None
+        for side_data in stream.get("side_data_list") or []:
+            if side_data.get("rotation") is not None:
+                rotation = side_data["rotation"]
+                break
+        if rotation is None:
+            rotation = (stream.get("tags") or {}).get("rotate", 0)
+        if int(round(float(rotation))) % 360 in (90, 270):
+            w, h = h, w
         return h > w
-    except Exception:
+    except (
+        subprocess.CalledProcessError,
+        json.JSONDecodeError,
+        OSError,
+        OverflowError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ):
         return False
 
 

--- a/tests/test_render_orientation.py
+++ b/tests/test_render_orientation.py
@@ -18,8 +18,13 @@ class PortraitDetectionTests(unittest.TestCase):
         result = subprocess.CompletedProcess(
             [], 0, stdout=json.dumps({"streams": [stream]}), stderr=""
         )
-        with patch.object(render.subprocess, "run", return_value=result):
-            return render.is_portrait_source(Path("source.mp4"))
+        with patch.object(render.subprocess, "run", return_value=result) as run:
+            portrait = render.is_portrait_source(Path("source.mp4"))
+        cmd = run.call_args.args[0]
+        show_entries = cmd[cmd.index("-show_entries") + 1]
+        self.assertIn("stream_side_data=rotation", show_entries)
+        self.assertNotIn("stream_tags=rotate", show_entries)
+        return portrait
 
     def test_native_portrait_dimensions(self):
         self.assertTrue(self._is_portrait({"width": 1080, "height": 1920}))
@@ -35,9 +40,9 @@ class PortraitDetectionTests(unittest.TestCase):
         }
         self.assertTrue(self._is_portrait(stream))
 
-    def test_legacy_rotation_tag_is_supported(self):
+    def test_plain_rotation_tag_without_side_data_is_ignored(self):
         stream = {"width": 1920, "height": 1080, "tags": {"rotate": "270"}}
-        self.assertTrue(self._is_portrait(stream))
+        self.assertFalse(self._is_portrait(stream))
 
     def test_rotation_can_turn_coded_portrait_into_landscape(self):
         stream = {

--- a/tests/test_render_orientation.py
+++ b/tests/test_render_orientation.py
@@ -1,0 +1,57 @@
+import importlib.util
+import json
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).parents[1] / "helpers" / "render.py"
+SPEC = importlib.util.spec_from_file_location("video_use_render", MODULE_PATH)
+assert SPEC and SPEC.loader
+render = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(render)
+
+
+class PortraitDetectionTests(unittest.TestCase):
+    def _is_portrait(self, stream: dict) -> bool:
+        result = subprocess.CompletedProcess(
+            [], 0, stdout=json.dumps({"streams": [stream]}), stderr=""
+        )
+        with patch.object(render.subprocess, "run", return_value=result):
+            return render.is_portrait_source(Path("source.mp4"))
+
+    def test_native_portrait_dimensions(self):
+        self.assertTrue(self._is_portrait({"width": 1080, "height": 1920}))
+
+    def test_native_landscape_dimensions(self):
+        self.assertFalse(self._is_portrait({"width": 1920, "height": 1080}))
+
+    def test_side_data_rotation_turns_coded_landscape_into_portrait(self):
+        stream = {
+            "width": 1920,
+            "height": 1080,
+            "side_data_list": [{"rotation": -90}],
+        }
+        self.assertTrue(self._is_portrait(stream))
+
+    def test_legacy_rotation_tag_is_supported(self):
+        stream = {"width": 1920, "height": 1080, "tags": {"rotate": "270"}}
+        self.assertTrue(self._is_portrait(stream))
+
+    def test_rotation_can_turn_coded_portrait_into_landscape(self):
+        stream = {
+            "width": 1080,
+            "height": 1920,
+            "side_data_list": [{"rotation": 90}],
+        }
+        self.assertFalse(self._is_portrait(stream))
+
+    def test_invalid_probe_output_falls_back_to_landscape(self):
+        result = subprocess.CompletedProcess([], 0, stdout="not json", stderr="")
+        with patch.object(render.subprocess, "run", return_value=result):
+            self.assertFalse(render.is_portrait_source(Path("source.mp4")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Portrait detection currently compares coded width and height only. Phone and camera files commonly store landscape-coded frames plus 90 or 270 degree display rotation. ffmpeg autorotates those frames before filters run, but render.py still selects the landscape scale axis, producing an oversized vertical output.

This edge case was identified by cubic during review of #29.

## Fix

- Probe coded dimensions, display-matrix rotation, and the legacy rotate tag in one ffprobe call.
- Swap the effective dimensions for 90 and 270 degree rotations before selecting the scale axis.
- Preserve existing behavior for native portrait and landscape sources.

## Verification

- Six unit tests cover native portrait/landscape, modern side-data rotation, legacy rotate tags, reverse orientation, and invalid probe output.
- Verified with a real synthetic MP4 carrying a 90 degree display matrix: ffprobe reported 320x180 plus rotation=90 and is_portrait_source returned true.
- python -m unittest discover -s tests -v
- python -m py_compile helpers/render.py tests/test_render_orientation.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes portrait detection to honor display-matrix rotation side data so vertical sources scale on the correct axis. Previously we compared coded dimensions only, treating 90/270° rotated videos as landscape.

- Uses one `ffprobe` JSON probe to read width/height and `stream_side_data=rotation`; ignores plain `rotate` tags because they do not guarantee autorotation.
- Swaps effective dimensions for quarter-turn rotations before choosing the scale axis; preserves behavior for native portrait and landscape.
- Defaults to landscape on invalid probe output; adds tests for side-data rotations, ignoring `rotate`, reverse orientation, and error handling.

<sup>Written for commit 4ff8e6006377f9753f3d0b205fe6c01cf6b5835e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

