### PR TITLE
Fix subtitle path escaping on Windows in render.py

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -616,7 +616,12 @@ def build_final_composite(
 
     # Subtitles LAST — Rule 1
     if has_subs:
-        subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
+        # ffmpeg's filtergraph parser treats "\" as its own escape char, so a raw
+        # Windows path (C:\apps\...) gets its backslashes eaten before the colon
+        # escape even applies — "C:\apps\..." comes out as "Capps...". Forward
+        # slashes sidestep the whole problem; ffmpeg accepts them natively on
+        # Windows too, so there's no backslash-escaping to get wrong.
+        subs_abs = str(subtitles_path.resolve()).replace("\\", "/").replace(":", r"\:").replace("'", r"\'")
         filter_parts.append(
             f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
         )


### PR DESCRIPTION
## Summary
- On Windows, `render.py`'s subtitle compositing step fails with an ffmpeg error like \`Unable to open C:appsprojectedit master.srt\` — the drive-letter colon and backslashes get mangled before reaching ffmpeg.
- Root cause: ffmpeg's own filtergraph parser treats `\` as its escape character, so it consumes the path's backslashes before the code's own `.replace(":", r"\:")` colon-escaping can take effect. A raw Windows path like `C:\apps\project\edit\master.srt` ends up losing its backslashes and the colon escape never lands where it should, producing a broken path.
- Fix: normalize to forward slashes first (`.replace("\\", "/")`), which ffmpeg accepts natively on Windows, before applying the existing colon/quote escaping. This sidesteps the backslash-escaping problem entirely instead of trying to double-escape it.

Found and fixed while using this tool for a real edit session on Windows (verified via a full render with subtitles + overlays, output confirmed correct via ffprobe and visual inspection).

## Test plan
- [x] `python -m ast` / syntax check on the modified file
- [x] Full `render.py` run on Windows with `subtitles` set in the EDL — subtitle filter now resolves the path correctly and the render completes
- [x] Verified output video has burned-in subtitles matching the source `.srt`, correctly timed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subtitle path escaping on Windows in `render.py` so ffmpeg's filtergraph parser no longer mangles the path and renders complete with correct burned-in subtitles.

**Bug Fixes**
- Normalizes Windows paths to forward slashes before applying colon and quote escaping, sidestepping ffmpeg's backslash escape handling.

<sup>Written for commit 3ddf20bf7932449c7ab31b1010cb840fe6a7f244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

