### PR TITLE
fix: Windows compatibility for subtitle rendering, path escaping and console encoding

### DIFF
--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -34,6 +34,16 @@ import sys
 import tempfile
 from pathlib import Path
 
+# Console output uses arrows (→) below. On Windows, stdout's default
+# encoding is the legacy console codepage (e.g. cp1252), which can't encode
+# them and raises UnicodeEncodeError. Force UTF-8 regardless of platform or
+# locale so the same prints work unmodified on Windows, macOS, and Linux.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
 
 PRESETS: dict[str, str] = {
     # Subtle baseline — barely perceptible cleanup. No color shift.

--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -110,13 +110,26 @@ def _sample_frame_stats(
     with tempfile.NamedTemporaryFile(mode="w+", suffix=".txt", delete=False) as f:
         metadata_path = f.name
 
+    # ffmpeg's filtergraph parser treats both ':' and '\' as syntax (option
+    # separator / escape char). On Windows, tempfile.NamedTemporaryFile()
+    # returns a path like C:\Users\...\tmpXXXX.txt — passed raw into the
+    # metadata=print:file=... filter option, the drive-letter colon and the
+    # backslashes both trip the parser (same failure mode as the subtitles
+    # path in render.py). Normalize to forward slashes first (ffmpeg accepts
+    # them on every platform, including Windows), then escape the
+    # drive-letter colon and any literal quotes. POSIX temp paths have no
+    # backslashes, so the replace is a no-op there. `metadata_path` itself
+    # (used below with plain `open()`) stays untouched.
+    metadata_path_filter = metadata_path.replace("\\", "/")
+    metadata_path_filter = metadata_path_filter.replace(":", r"\:").replace("'", r"\'")
+
     try:
         cmd = [
             "ffmpeg", "-y", "-hide_banner", "-nostats",
             "-ss", f"{start:.3f}",
             "-i", str(video),
             "-t", f"{duration:.3f}",
-            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file={metadata_path}",
+            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file='{metadata_path_filter}'",
             "-f", "null", "-",
         ]
         subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -20,6 +20,16 @@ import json
 import sys
 from pathlib import Path
 
+# The summary print below uses an arrow (→). On Windows, stdout's default
+# encoding is the legacy console codepage (e.g. cp1252), which can't encode
+# it and raises UnicodeEncodeError. Force UTF-8 regardless of platform or
+# locale so the same print works unmodified on Windows, macOS, and Linux.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
 
 def format_time(seconds: float) -> str:
     """Format a time in seconds as "NNN.NN" with fixed 6-char width for alignment."""

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -29,6 +29,16 @@ import sys
 from fractions import Fraction
 from pathlib import Path
 
+# Console output uses arrows (→) below. On Windows, stdout's default
+# encoding is the legacy console codepage (e.g. cp1252), which can't encode
+# them and raises UnicodeEncodeError. Force UTF-8 regardless of platform or
+# locale so the same prints work unmodified on Windows, macOS, and Linux.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
 try:
     from grade import get_preset, auto_grade_for_clip  # same directory
 except Exception:
@@ -50,7 +60,12 @@ except Exception:
 # every major vertical-video platform. Do not drop this below ~75 without a
 # specific reason.
 SUB_FORCE_STYLE = (
-    "FontName=Helvetica,FontSize=18,Bold=1,"
+    # Helvetica isn't installed on Windows, so libass/fontconfig had to
+    # guess a substitute (Arial-BoldMT) at render time. Arial ships as a
+    # core system font on Windows and macOS, so naming it directly removes
+    # that guesswork on both. Linux distros without Arial still get a
+    # graceful fontconfig substitution, same as before.
+    "FontName=Arial,FontSize=18,Bold=1,"
     "PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,BackColour=&H00000000,"
     "BorderStyle=1,Outline=2,Shadow=0,"
     "Alignment=2,MarginV=90"
@@ -484,7 +499,10 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
         lines.append(f"{_srt_timestamp(a)} --> {_srt_timestamp(b)}")
         lines.append(t)
         lines.append("")
-    out_path.write_text("\n".join(lines))
+    # Explicit UTF-8: Path.write_text() otherwise falls back to
+    # locale.getpreferredencoding(), which is cp1252 on Windows and would
+    # mangle Spanish accents/ñ in the burned-in captions.
+    out_path.write_text("\n".join(lines), encoding="utf-8")
     print(f"master SRT → {out_path.name} ({len(entries)} cues)")
 
 
@@ -641,7 +659,16 @@ def build_final_composite(
 
     # Subtitles LAST — Rule 1
     if has_subs:
-        subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
+        # ffmpeg's filtergraph parser treats both ':' and '\' as syntax
+        # (option separator / escape char). On Windows, an absolute path
+        # like C:\Users\...\master.srt trips both at once — escaping only
+        # the colon leaves the raw backslashes to break the parser. Normalize
+        # to forward slashes first (ffmpeg accepts them on every platform,
+        # including Windows), then escape the drive-letter colon and any
+        # literal quotes. POSIX paths have no backslashes, so the replace is
+        # a no-op there and this stays identical to the prior behavior.
+        subs_abs = str(subtitles_path.resolve()).replace("\\", "/")
+        subs_abs = subs_abs.replace(":", r"\:").replace("'", r"\'")
         filter_parts.append(
             f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
         )

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -30,6 +30,16 @@ from pathlib import Path
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
+# Console output uses arrows (→) below. On Windows, stdout's default
+# encoding is the legacy console codepage (e.g. cp1252), which can't encode
+# them and raises UnicodeEncodeError. Force UTF-8 regardless of platform or
+# locale so the same prints work unmodified on Windows, macOS, and Linux.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
 
 # -------- Frame extraction ---------------------------------------------------
 

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -22,6 +22,16 @@ from pathlib import Path
 
 from transcribe import load_api_key, transcribe_one, transcript_path
 
+# Console output uses arrows (→) below. On Windows, stdout's default
+# encoding is the legacy console codepage (e.g. cp1252), which can't encode
+# them and raises UnicodeEncodeError. Force UTF-8 regardless of platform or
+# locale so the same prints work unmodified on Windows, macOS, and Linux.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
 


### PR DESCRIPTION
## Summary

Five Windows-only bugs in the render pipeline, found while running video-use
end-to-end on Windows 11. All fixes normalize to platform-agnostic behavior
(forward-slash paths, explicit UTF-8) rather than special-casing Windows, so
they are no-ops on macOS/Linux. Tested on Windows 11 only.

## Bugs fixed

**1. Subtitle `.srt` path breaks ffmpeg's filtergraph parser (`render.py`, `build_final_composite`)**
The subtitles filter path was built by escaping only `:`, leaving raw
Windows backslashes in place. ffmpeg's filtergraph parser treats both `\`
and `:` as syntax characters, so a path like `C:\Users\...\master.srt`
broke parsing (`ffmpeg` exited with status 4294967294) whenever
`--build-subtitles` or an EDL-referenced subtitle file was used.
Fix: normalize backslashes to forward slashes first (ffmpeg accepts
forward slashes on every platform, including Windows), then escape the
drive-letter colon and any literal quotes. No-op on POSIX, where paths
never contain backslashes.

**2. `master.srt` written without explicit encoding (`render.py`, `build_master_srt`)**
`Path.write_text()` falls back to `locale.getpreferredencoding()` when no
encoding is given — cp1252 on Windows by default, which cannot represent
Spanish accents/ñ and silently corrupts them in the burned-in captions.
Fix: `write_text(..., encoding="utf-8")` explicit. Identical output on
platforms whose locale already defaults to UTF-8.

**3. Console prints crash on non-ASCII characters (`pack_transcripts.py`, `render.py`, `grade.py`, `timeline_view.py`, `transcribe_batch.py`)**
Several progress/status prints use an arrow (`→`). On Windows, `sys.stdout`'s
default encoding is the legacy console codepage (cp1252), which can't
encode it — `UnicodeEncodeError`, crashing the script after useful work
was already done (e.g. `pack_transcripts.py` crashed only in its final
summary print, after `takes_packed.md` had already been written). Fix:
`sys.stdout.reconfigure(encoding="utf-8")` guarded with `hasattr`/`try`,
added once at import time in each of the five files. No message text was
changed — the info stays intact, only the stream encoding is forced.
No-op where stdout is already UTF-8.

**4. Subtitle font relies on fontconfig substitution (`render.py`, `SUB_FORCE_STYLE`)**
`FontName=Helvetica` isn't installed on Windows, so libass/fontconfig had
to guess a substitute at render time (landed on Arial-BoldMT, but with no
guarantee). Fix: name `Arial` directly — a native system font on both
Windows and macOS. Linux distributions without Arial still fall back to
fontconfig substitution exactly as before, so there's no regression there.

**5. Second instance of the path-escaping bug (`grade.py`, `_sample_frame_stats`)**
Same root cause as #1, different call site: the temp file path used for
ffmpeg's `signalstats`/`metadata=print:file=...` filter was passed raw,
so `grade.py --analyze` failed on Windows the same way subtitle
compositing did. Fix: same treatment — normalize slashes, escape `:`
and `'`, in a separate variable so the plain filesystem path (used
afterward with `open()`) is untouched.

## Known issue (not fixed in this PR)

`timeline_view.py` draws an arrow (`→`) directly onto the generated PNG
filmstrip via PIL's `draw.text()`. On Windows this renders as a broken/
missing glyph box rather than crashing — it's a font-rendering gap in
whatever default font PIL falls back to, not a console-encoding issue,
and out of scope for this PR.

## Test plan

- [x] Re-ran the full pipeline (`transcribe.py` → `pack_transcripts.py` →
      `render.py --build-subtitles`) on a real Spanish-language clip with
      **no environment variable workarounds** (no `PYTHONIOENCODING`, no
      `PYTHONUTF8`) — completed end to end, produced a burned-in-subtitle
      MP4 with correctly rendered accents.
- [x] Verified `master.srt` is UTF-8 via `file master.srt`.
- [x] Verified subtitle cue timestamps against source Scribe word timestamps
      (output_time = word.start - segment_start + segment_offset) — exact
      match on multiple cues.
- [x] Re-ran `grade.py --analyze` on the same clip with no environment
      variable workarounds — completed end to end.
- [x] Repo-wide grep for non-ASCII characters inside `print(...)` calls —
      confirms no other file has the same unguarded pattern.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the render pipeline work on Windows 11 by fixing five Windows-only bugs in subtitle rendering, path escaping, and console encoding, without changing behavior on macOS or Linux.

**Bug Fixes**
- Escapes ffmpeg filtergraph paths (subtitles in `render.py`, `signalstats` metadata in `grade.py`) by normalizing backslashes to forward slashes before escaping colons and quotes.
- Writes `master.srt` with explicit `encoding="utf-8"` so Spanish accents and ñ survive under Windows's cp1252 default locale.
- Forces `sys.stdout` to UTF-8 on import in `render.py`, `pack_transcripts.py`, `grade.py`, `timeline_view.py`, and `transcribe_batch.py`, preventing `UnicodeEncodeError` crashes on arrow (→) prints.
- Changes the default subtitle font from Helvetica to Arial, which ships natively on Windows and macOS; Linux falls back to fontconfig substitution as before.
- Left unfixed: the filmstrip PNG in `timeline_view.py` still shows a broken glyph for the arrow, a font-rendering issue outside this PR's scope.

<sup>Written for commit 4459f63a6d824dab8a358fe80ccef12c12387d47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

