### PR TITLE
fix: make helper output safe on non-UTF-8 consoles

### DIFF
--- a/helpers/_util.py
+++ b/helpers/_util.py
@@ -1,0 +1,11 @@
+"""Shared helpers for command-line entry points."""
+
+from __future__ import annotations
+
+import sys
+
+
+def configure_stdout() -> None:
+    """Keep progress output safe when the locale encoding is not UTF-8."""
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")

--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -35,6 +35,12 @@ import tempfile
 from pathlib import Path
 
 
+def configure_stdout() -> None:
+    """Keep progress output safe when the locale encoding is not UTF-8."""
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+
 PRESETS: dict[str, str] = {
     # Subtle baseline — barely perceptible cleanup. No color shift.
     # Use when auto-analysis isn't available or when you want a safe floor.
@@ -292,6 +298,7 @@ def apply_grade(input_path: Path, output_path: Path, filter_string: str) -> None
 
 
 def main() -> None:
+    configure_stdout()
     ap = argparse.ArgumentParser(description="Apply a color grade via ffmpeg filter chain")
     ap.add_argument("input", type=Path, nargs="?", help="Input video")
     ap.add_argument("-o", "--output", type=Path, help="Output video")

--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -34,11 +34,10 @@ import sys
 import tempfile
 from pathlib import Path
 
-
-def configure_stdout() -> None:
-    """Keep progress output safe when the locale encoding is not UTF-8."""
-    if hasattr(sys.stdout, "reconfigure"):
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+try:
+    from _util import configure_stdout
+except ModuleNotFoundError:
+    from helpers._util import configure_stdout
 
 
 PRESETS: dict[str, str] = {

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -20,11 +20,10 @@ import json
 import sys
 from pathlib import Path
 
-
-def configure_stdout() -> None:
-    """Keep progress output safe when the locale encoding is not UTF-8."""
-    if hasattr(sys.stdout, "reconfigure"):
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+try:
+    from _util import configure_stdout
+except ModuleNotFoundError:
+    from helpers._util import configure_stdout
 
 
 def format_time(seconds: float) -> str:

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -21,6 +21,12 @@ import sys
 from pathlib import Path
 
 
+def configure_stdout() -> None:
+    """Keep progress output safe when the locale encoding is not UTF-8."""
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+
 def format_time(seconds: float) -> str:
     """Format a time in seconds as "NNN.NN" with fixed 6-char width for alignment."""
     return f"{seconds:06.2f}"
@@ -163,6 +169,7 @@ def render_markdown(entries: list[tuple[str, float, list[dict]]], silence_thresh
 
 
 def main() -> None:
+    configure_stdout()
     ap = argparse.ArgumentParser(description="Pack Scribe transcripts into takes_packed.md")
     ap.add_argument("--edit-dir", type=Path, required=True, help="Edit directory containing transcripts/")
     ap.add_argument(

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -29,6 +29,13 @@ import sys
 from fractions import Fraction
 from pathlib import Path
 
+
+def configure_stdout() -> None:
+    """Keep progress output safe when the locale encoding is not UTF-8."""
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+
 try:
     from grade import get_preset, auto_grade_for_clip  # same directory
 except Exception:
@@ -677,6 +684,7 @@ def build_final_composite(
 
 
 def main() -> None:
+    configure_stdout()
     ap = argparse.ArgumentParser(description="Render a video from an EDL")
     ap.add_argument("edl", type=Path, help="Path to edl.json")
     ap.add_argument("-o", "--output", type=Path, required=True, help="Output video path")

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -29,11 +29,10 @@ import sys
 from fractions import Fraction
 from pathlib import Path
 
-
-def configure_stdout() -> None:
-    """Keep progress output safe when the locale encoding is not UTF-8."""
-    if hasattr(sys.stdout, "reconfigure"):
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+try:
+    from _util import configure_stdout
+except ModuleNotFoundError:
+    from helpers._util import configure_stdout
 
 
 try:

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -20,13 +20,11 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+try:
+    from _util import configure_stdout
+except ModuleNotFoundError:
+    from helpers._util import configure_stdout
 from transcribe import load_api_key, transcribe_one, transcript_path
-
-
-def configure_stdout() -> None:
-    """Keep progress output safe when the locale encoding is not UTF-8."""
-    if hasattr(sys.stdout, "reconfigure"):
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -23,6 +23,12 @@ from pathlib import Path
 from transcribe import load_api_key, transcribe_one, transcript_path
 
 
+def configure_stdout() -> None:
+    """Keep progress output safe when the locale encoding is not UTF-8."""
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
 
 
@@ -35,6 +41,7 @@ def find_videos(videos_dir: Path) -> list[Path]:
 
 
 def main() -> None:
+    configure_stdout()
     ap = argparse.ArgumentParser(description="Parallel batch transcription of a videos directory")
     ap.add_argument("videos_dir", type=Path, help="Directory containing source videos")
     ap.add_argument(

--- a/tests/test_stdout_encoding.py
+++ b/tests/test_stdout_encoding.py
@@ -1,0 +1,55 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parents[1]
+
+
+class StdoutEncodingTests(unittest.TestCase):
+    def test_pack_transcripts_handles_ascii_redirected_stdout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            edit_dir = Path(tmp)
+            transcripts_dir = edit_dir / "transcripts"
+            transcripts_dir.mkdir()
+            (transcripts_dir / "take.json").write_text(
+                json.dumps(
+                    {
+                        "words": [
+                            {
+                                "type": "word",
+                                "text": "hello",
+                                "start": 0.0,
+                                "end": 0.4,
+                                "speaker_id": "speaker_0",
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env["PYTHONIOENCODING"] = "ascii"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "helpers" / "pack_transcripts.py"),
+                    "--edit-dir",
+                    str(edit_dir),
+                ],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr.decode("utf-8"))
+            self.assertIn("→", result.stdout.decode("utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stdout_encoding.py
+++ b/tests/test_stdout_encoding.py
@@ -1,54 +1,37 @@
-import json
 import os
 import subprocess
 import sys
-import tempfile
 import unittest
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).parents[1]
+HELPERS = ("pack_transcripts", "render", "grade", "transcribe_batch")
 
 
 class StdoutEncodingTests(unittest.TestCase):
-    def test_pack_transcripts_handles_ascii_redirected_stdout(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            edit_dir = Path(tmp)
-            transcripts_dir = edit_dir / "transcripts"
-            transcripts_dir.mkdir()
-            (transcripts_dir / "take.json").write_text(
-                json.dumps(
-                    {
-                        "words": [
-                            {
-                                "type": "word",
-                                "text": "hello",
-                                "start": 0.0,
-                                "end": 0.4,
-                                "speaker_id": "speaker_0",
-                            }
-                        ]
-                    }
-                ),
-                encoding="utf-8",
-            )
-            env = os.environ.copy()
-            env["PYTHONIOENCODING"] = "ascii"
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    str(REPO_ROOT / "helpers" / "pack_transcripts.py"),
-                    "--edit-dir",
-                    str(edit_dir),
-                ],
-                env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=False,
-            )
+    def test_helpers_handle_ascii_redirected_stdout(self):
+        probe = (
+            "import importlib, sys; "
+            "module = importlib.import_module(sys.argv[1]); "
+            "module.configure_stdout(); "
+            "print('→')"
+        )
+        for helper in HELPERS:
+            with self.subTest(helper=helper):
+                env = os.environ.copy()
+                env["PYTHONIOENCODING"] = "ascii"
+                result = subprocess.run(
+                    [sys.executable, "-c", probe, helper],
+                    cwd=REPO_ROOT / "helpers",
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=False,
+                )
 
-            self.assertEqual(result.returncode, 0, result.stderr.decode("utf-8"))
-            self.assertIn("→", result.stdout.decode("utf-8"))
+                self.assertEqual(result.returncode, 0, result.stderr.decode("utf-8"))
+                self.assertEqual(result.stdout.decode("utf-8"), "→\n")
 
 
 if __name__ == "__main__":

--- a/tests/test_stdout_encoding.py
+++ b/tests/test_stdout_encoding.py
@@ -6,16 +6,22 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).parents[1]
-HELPERS = ("pack_transcripts", "render", "grade", "transcribe_batch")
+HELPERS = (
+    "pack_transcripts.py",
+    "render.py",
+    "grade.py",
+    "transcribe_batch.py",
+)
 
 
 class StdoutEncodingTests(unittest.TestCase):
     def test_helpers_handle_ascii_redirected_stdout(self):
         probe = (
-            "import importlib, sys; "
-            "module = importlib.import_module(sys.argv[1]); "
-            "module.configure_stdout(); "
-            "print('→')"
+            "import atexit, runpy, sys; "
+            "helper = sys.argv[1]; "
+            "atexit.register(lambda: print('→')); "
+            "sys.argv = [helper, '--help']; "
+            "runpy.run_path(helper, run_name='__main__')"
         )
         for helper in HELPERS:
             with self.subTest(helper=helper):
@@ -31,7 +37,7 @@ class StdoutEncodingTests(unittest.TestCase):
                 )
 
                 self.assertEqual(result.returncode, 0, result.stderr.decode("utf-8"))
-                self.assertEqual(result.stdout.decode("utf-8"), "→\n")
+                self.assertTrue(result.stdout.decode("utf-8").endswith("→\n"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- configure stdout as UTF-8 with replacement in the four affected helper entry points
- preserve the existing progress glyphs without crashing redirected non-UTF-8 streams
- add a regression test using an ASCII-configured redirected stdout

## Validation
- `python3 -m unittest discover -s tests -v` (17 tests passed)
- `python3 -m py_compile helpers/render.py helpers/grade.py helpers/pack_transcripts.py helpers/transcribe_batch.py tests/test_stdout_encoding.py`
- `git diff --check`

## AI assistance disclosure

TRAE assisted with issue analysis, implementation, regression-test drafting, and an independent P0-P2 review of this change. The human author reviewed the final diff and ran the validation commands listed above.

Closes #125

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes helper scripts crashing on non-UTF-8 consoles by reconfiguring stdout to UTF-8 with replacement. Redirected output now shows progress glyphs instead of failing.

- Adds a regression test for ASCII-configured redirected stdout.

Closes #125.

<sup>Written for commit 28abe4883cf49cb167a02fce4f67aea0c28887e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

