### PR TITLE
add agent guidance, comment convention, and skill contract guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,8 @@ from being overwritten by another:
   history, so a later sync silently discards it.
 - Hard rules in `SKILL.md` are append-only. New rules get the next number.
   Removing or renumbering a rule requires an explicit reason in the commit.
-- Procedure prose belongs in `references/<feature>.md`. Edits to `SKILL.md`
+- Procedure prose belongs in `references/<feature>.md` at the repository root;
+  create that folder with the first reference file. Edits to `SKILL.md`
   are limited to rules, helper-index bullets, directory-tree lines, the EDL
   example, and one-line pointers to the reference files.
 - `tests/test_skill_contract.py` checks that the rules and every referenced

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# video-use repository context
+
+video-use is a public, conversation-driven video production framework. Changes
+made here may be packaged into the skill and reused by people with different
+machines, media, workflows, providers, brands, and output goals. Treat the
+repository as a general product, never as one person's customized clone.
+
+## Product principles
+
+- The delivered video is the product. Prioritize visual and audio quality,
+  editorial judgment, factual correctness, synchronization, pacing, and
+  production reliability.
+- Design reusable contracts and capabilities. Do not hardcode personal paths,
+  credentials, account ids, prompts, brands, preferences, lane history, or
+  assumptions about one project.
+- Keep provider-specific behavior behind narrow boundaries. Core EDL validation,
+  rendering, reframing, and QC must remain usable without the localhost GUI or
+  Modal.
+- Preserve backwards compatibility when practical. If a format must change,
+  provide a clear migration path and reject unsupported input with an actionable
+  error.
+- Never silently downgrade a requested feature. A missing source, track, model,
+  codec, or dependency should fail before expensive work begins and explain what
+  is required.
+- Defaults should be safe and broadly useful, while explicit project or user
+  requirements always win.
+- Keep credentials out of source, logs, fixtures, prompts, and generated
+  artifacts. Configuration belongs in environment variables or provider secret
+  stores.
+
+## Architecture boundaries
+
+- `SKILL.md` defines the agent workflow and public editing contract.
+- `helpers/` contains provider-independent production tools and validation.
+- `skills/` contains focused companion skills and reusable production assets.
+- `gui/` is an optional internal client and remote-execution adapter. It may
+  orchestrate core features but must not become the only place those features
+  exist.
+- `tests/` and `gui/tests/` protect public behavior and adapter behavior
+  respectively.
+
+Keep decision data explicit in portable project files such as `edit/edl.json`.
+Renderers should consume declared inputs deterministically. UI state, agent
+history, and cloud runtime state must not be required to reproduce an output.
+
+## Experimental GUI harness
+
+The four-lane GUI in `gui/` exists to generate many independent outputs quickly
+so developers can find ugly frames, weak editorial decisions, unsupported
+queries, and renderer failures before video-use users encounter them.
+
+- Use the four parallel Modal lanes for this branch's output-discovery runs.
+  Avoid one-off manual local benchmark renders when the harness can run the same
+  experiment and preserve comparable evidence.
+- Do not assume the public video-use workflow will adopt the GUI, Modal, its lane
+  model, or its run-storage APIs. Promote a finding into `helpers/`, `skills/`,
+  or `SKILL.md` only when the underlying capability is generally useful without
+  the harness.
+- Keep each lane's agent context fresh. Past run traces are evaluation evidence
+  for developers and must not leak into a new lane's creative context.
+- Preserve every run's durable evidence through `gui/run_store.py`: the compact
+  `run_summary.md`, deduplicated `trace.json`, raw Codex protocol when available,
+  complete `render.log`, generated edit handoff, and returned outputs.
+- Prefer `run_summary.md` when an agent needs quick context. Read the raw trace or
+  protocol only to investigate a specific decision, tool call, or failure.
+- Pin valuable successes and representative failures before cleanup. Never
+  delete a pinned run, and never delete an active lane.
+
+## Change workflow
+
+1. Identify whether a change belongs to the public editing contract, a reusable
+   helper, a focused skill, or an optional adapter.
+2. Implement the smallest complete general capability at the lowest reusable
+   layer. Wire adapters to that capability instead of duplicating it.
+3. Validate inputs locally before uploads or paid compute. Validate again at
+   remote execution boundaries.
+4. Add tests for successful use, invalid input, backwards compatibility, and
+   provider-boundary behavior where relevant.
+5. For render changes, create representative media and inspect the encoded
+   dimensions, duration, frame rate, visual framing, and audible output.
+6. Update the public EDL example or usage documentation whenever users or agents
+   need to author a new field.
+
+Cost and latency are secondary unless the user sets a budget or deadline. Improve
+them only when output quality and reliability remain equal or improve.
+
+## Communication and commits
+
+After code changes, summarize the affected files, the functions or contracts
+added, and what each does in plain language. Keep this technical context compact
+so someone can learn an unfamiliar codebase without reading every diff.
+
+Write simple, readable commit messages. Prefer short lowercase wording without
+punctuation.
+
+## Branch discipline
+
+Several agents work on this repository at once. To keep one agent's progress
+from being overwritten by another:
+
+- One feature per branch, one agent per branch. Never edit a worktree that
+  belongs to another branch; take files from a commit or tag instead.
+- Commit early. Uncommitted work in a worktree has no merge base and no
+  history, so a later sync silently discards it.
+- Hard rules in `SKILL.md` are append-only. New rules get the next number.
+  Removing or renumbering a rule requires an explicit reason in the commit.
+- Procedure prose belongs in `references/<feature>.md`. Edits to `SKILL.md`
+  are limited to rules, helper-index bullets, directory-tree lines, the EDL
+  example, and one-line pointers to the reference files.
+- `tests/test_skill_contract.py` checks that the rules and every referenced
+  path still exist. Run it before committing a `SKILL.md` change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,11 @@ repository as a general product, never as one person's customized clone.
   editorial judgment, factual correctness, synchronization, pacing, and
   production reliability.
 - Design reusable contracts and capabilities. Do not hardcode personal paths,
-  credentials, account ids, prompts, brands, preferences, lane history, or
-  assumptions about one project.
+  credentials, account ids, prompts, brands, preferences, or assumptions
+  about one project.
 - Keep provider-specific behavior behind narrow boundaries. Core EDL validation,
-  rendering, reframing, and QC must remain usable without the localhost GUI or
-  Modal.
+  rendering, reframing, and QC must remain usable from the command line without
+  any optional client or remote runner.
 - Preserve backwards compatibility when practical. If a format must change,
   provide a clear migration path and reject unsupported input with an actionable
   error.
@@ -33,38 +33,13 @@ repository as a general product, never as one person's customized clone.
 - `SKILL.md` defines the agent workflow and public editing contract.
 - `helpers/` contains provider-independent production tools and validation.
 - `skills/` contains focused companion skills and reusable production assets.
-- `gui/` is an optional internal client and remote-execution adapter. It may
-  orchestrate core features but must not become the only place those features
-  exist.
-- `tests/` and `gui/tests/` protect public behavior and adapter behavior
-  respectively.
+- `tests/` protects public behavior. Optional clients or remote runners may
+  orchestrate core features but must never become the only place a feature
+  exists.
 
 Keep decision data explicit in portable project files such as `edit/edl.json`.
 Renderers should consume declared inputs deterministically. UI state, agent
 history, and cloud runtime state must not be required to reproduce an output.
-
-## Experimental GUI harness
-
-The four-lane GUI in `gui/` exists to generate many independent outputs quickly
-so developers can find ugly frames, weak editorial decisions, unsupported
-queries, and renderer failures before video-use users encounter them.
-
-- Use the four parallel Modal lanes for this branch's output-discovery runs.
-  Avoid one-off manual local benchmark renders when the harness can run the same
-  experiment and preserve comparable evidence.
-- Do not assume the public video-use workflow will adopt the GUI, Modal, its lane
-  model, or its run-storage APIs. Promote a finding into `helpers/`, `skills/`,
-  or `SKILL.md` only when the underlying capability is generally useful without
-  the harness.
-- Keep each lane's agent context fresh. Past run traces are evaluation evidence
-  for developers and must not leak into a new lane's creative context.
-- Preserve every run's durable evidence through `gui/run_store.py`: the compact
-  `run_summary.md`, deduplicated `trace.json`, raw Codex protocol when available,
-  complete `render.log`, generated edit handoff, and returned outputs.
-- Prefer `run_summary.md` when an agent needs quick context. Read the raw trace or
-  protocol only to investigate a specific decision, tool call, or failure.
-- Pin valuable successes and representative failures before cleanup. Never
-  delete a pinned run, and never delete an active lane.
 
 ## Change workflow
 

--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -1,3 +1,7 @@
+# color grading helper that builds ffmpeg filter strings and applies them to a video
+# it ships a few named presets and an auto mode that samples frame stats to pick a small corrective eq
+# render py imports get_preset and auto_grade_for_clip and the cli wraps the same functions
+
 """Apply a color grade to a video via ffmpeg filter chain.
 
 Two modes:
@@ -63,6 +67,7 @@ PRESETS: dict[str, str] = {
 }
 
 
+# look up the ffmpeg filter string for a named preset and fail loudly on unknown names
 def get_preset(name: str) -> str:
     """Return the ffmpeg filter string for a preset name. Empty string for 'none'."""
     if name not in PRESETS:
@@ -75,6 +80,7 @@ def get_preset(name: str) -> str:
 # -------- Auto grade (data-driven, per-clip) --------------------------------
 
 
+# run ffmpeg signalstats over a sampled range and average the luma and saturation readings into normalized stats
 def _sample_frame_stats(
     video: Path,
     start: float,
@@ -121,6 +127,7 @@ def _sample_frame_stats(
         sat_avgs: list[float] = []
         bit_depth: int = 8
 
+        # pull the numeric value after the last equals sign on a metadata line
         def _parse_value(line: str) -> float | None:
             try:
                 return float(line.rsplit("=", 1)[1])
@@ -175,6 +182,7 @@ def _sample_frame_stats(
         Path(metadata_path).unlink(missing_ok=True)
 
 
+# analyze a clip range and derive a bounded corrective eq filter with no creative color shift
 def auto_grade_for_clip(
     video: Path,
     start: float = 0.0,
@@ -271,8 +279,10 @@ def auto_grade_for_clip(
     return filter_string, stats
 
 
+# run ffmpeg to write the graded output or stream copy when the filter is empty
 def apply_grade(input_path: Path, output_path: Path, filter_string: str) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    # an empty filter means no grade so copy streams without re encoding
     if not filter_string:
         cmd = [
             "ffmpeg", "-y", "-i", str(input_path),
@@ -291,6 +301,7 @@ def apply_grade(input_path: Path, output_path: Path, filter_string: str) -> None
     subprocess.run(cmd, check=True)
 
 
+# cli entry point that handles preset listing analysis and the normal grade run
 def main() -> None:
     ap = argparse.ArgumentParser(description="Apply a color grade via ffmpeg filter chain")
     ap.add_argument("input", type=Path, nargs="?", help="Input video")

--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -1,7 +1,3 @@
-# color grading helper that builds ffmpeg filter strings and applies them to a video
-# it ships a few named presets and an auto mode that samples frame stats to pick a small corrective eq
-# render py imports get_preset and auto_grade_for_clip and the cli wraps the same functions
-
 """Apply a color grade to a video via ffmpeg filter chain.
 
 Two modes:

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -1,3 +1,7 @@
+# packs scribe word level transcript json files into one phrase level markdown document
+# words are grouped into phrases split on long silences or speaker changes and each phrase carries a start and end stamp
+# the editor sub agent reads the result to pick cuts so it favors compactness over raw detail
+
 """Pack all Scribe transcripts in <edit>/transcripts/ into one readable markdown.
 
 Groups word-level entries into phrase-level lines, breaking on any silence
@@ -21,11 +25,13 @@ import sys
 from pathlib import Path
 
 
+# render seconds as a zero padded fixed width string so stamps line up in columns
 def format_time(seconds: float) -> str:
     """Format a time in seconds as "NNN.NN" with fixed 6-char width for alignment."""
     return f"{seconds:06.2f}"
 
 
+# render a duration as seconds or minutes plus seconds for the section headers
 def format_duration(seconds: float) -> str:
     """Format a duration as "Ms" or "Mm SSs"."""
     if seconds < 60:
@@ -35,6 +41,7 @@ def format_duration(seconds: float) -> str:
     return f"{m}m {s:04.1f}s"
 
 
+# walk scribe word entries and cut them into phrases on silence gaps or speaker changes
 def group_into_phrases(
     words: list[dict],
     silence_threshold: float = 0.5,
@@ -51,6 +58,7 @@ def group_into_phrases(
     current_start: float | None = None
     current_speaker: str | None = None
 
+    # emit the current phrase if it has any visible text then reset the accumulator
     def flush() -> None:
         nonlocal current_words, current_start, current_speaker
         if not current_words:
@@ -61,6 +69,7 @@ def group_into_phrases(
             raw = (w.get("text") or "").strip()
             if not raw:
                 continue
+            # wrap audio events in parentheses unless scribe already did
             if t == "audio_event":
                 if not raw.startswith("("):
                     raw = f"({raw})"
@@ -71,7 +80,9 @@ def group_into_phrases(
             current_speaker = None
             return
         text = " ".join(text_parts)
+        # glue punctuation tokens back onto the preceding word
         text = text.replace(" ,", ",").replace(" .", ".").replace(" ?", "?").replace(" !", "!")
+        # fall back through end then start then phrase start so a missing timestamp cannot break the flush
         end_time = current_words[-1].get("end", current_words[-1].get("start", current_start or 0.0))
         phrases.append({
             "start": current_start,
@@ -122,6 +133,7 @@ def group_into_phrases(
     return phrases
 
 
+# load one transcript json and return its name duration and phrase list
 def pack_one_file(json_path: Path, silence_threshold: float) -> tuple[str, float, list[dict]]:
     """Return (header_name, duration, phrases) for one transcript file."""
     data = json.loads(json_path.read_text())
@@ -134,6 +146,7 @@ def pack_one_file(json_path: Path, silence_threshold: float) -> tuple[str, float
     return json_path.stem, duration, phrases
 
 
+# build the markdown document with a header block and one section per transcript
 def render_markdown(entries: list[tuple[str, float, list[dict]]], silence_threshold: float) -> str:
     lines: list[str] = []
     lines.append("# Packed transcripts")
@@ -162,6 +175,7 @@ def render_markdown(entries: list[tuple[str, float, list[dict]]], silence_thresh
     return "\n".join(lines)
 
 
+# cli entry point that finds transcript json files packs them and writes takes_packed md
 def main() -> None:
     ap = argparse.ArgumentParser(description="Pack Scribe transcripts into takes_packed.md")
     ap.add_argument("--edit-dir", type=Path, required=True, help="Edit directory containing transcripts/")

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -1,7 +1,3 @@
-# packs scribe word level transcript json files into one phrase level markdown document
-# words are grouped into phrases split on long silences or speaker changes and each phrase carries a start and end stamp
-# the editor sub agent reads the result to pick cuts so it favors compactness over raw detail
-
 """Pack all Scribe transcripts in <edit>/transcripts/ into one readable markdown.
 
 Groups word-level entries into phrase-level lines, breaking on any silence

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -1,7 +1,3 @@
-# the ffmpeg render pipeline that turns an edl into a finished video file
-# it extracts graded segments and concatenates them and then composites overlays and subtitles and normalizes loudness
-# it also builds the master srt from transcripts and holds the command line entry point
-
 """Render a video from an EDL.
 
 Implements the HEURISTICS render pipeline in the correct order:

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -1,3 +1,7 @@
+# the ffmpeg render pipeline that turns an edl into a finished video file
+# it extracts graded segments and concatenates them and then composites overlays and subtitles and normalizes loudness
+# it also builds the master srt from transcripts and holds the command line entry point
+
 """Render a video from an EDL.
 
 Implements the HEURISTICS render pipeline in the correct order:
@@ -32,9 +36,13 @@ from pathlib import Path
 try:
     from grade import get_preset, auto_grade_for_clip  # same directory
 except Exception:
+    # fallback that only knows the identity grade when the grade helper is unavailable
+    # fallback that only knows the identity grade when the grade helper is unavailable
     def get_preset(name: str) -> str:
         return ""
 
+    # fallback that skips auto grading when the grade helper is unavailable
+    # fallback that skips auto grading when the grade helper is unavailable
     def auto_grade_for_clip(video, start=0.0, duration=None, verbose=False):  # type: ignore
         return "eq=contrast=1.03:saturation=0.98", {}
 
@@ -59,12 +67,14 @@ SUB_FORCE_STYLE = (
 # -------- Helpers ------------------------------------------------------------
 
 
+# run a command with check and print an abbreviated version unless quiet
 def run(cmd: list[str], quiet: bool = False) -> None:
     if not quiet:
         print(f"  $ {' '.join(str(c) for c in cmd[:6])}{' …' if len(cmd) > 6 else ''}")
     subprocess.run(cmd, check=True)
 
 
+# turn the edl grade field into a filter string or the auto sentinel
 def resolve_grade_filter(grade_field: str | None) -> str:
     """The EDL's 'grade' field can be a preset name, a raw ffmpeg filter, or 'auto'.
 
@@ -85,6 +95,7 @@ def resolve_grade_filter(grade_field: str | None) -> str:
     return grade_field
 
 
+# resolve a path relative to base unless it is already absolute
 def resolve_path(maybe_path: str, base: Path) -> Path:
     """Resolve a path that may be absolute or relative to `base`."""
     p = Path(maybe_path)
@@ -118,6 +129,7 @@ TONEMAP_CHAIN = (
 )
 
 
+# detect pq or hlg transfer metadata on the first video stream
 def is_hdr_source(video: Path) -> bool:
     """Return True if the source uses a PQ or HLG transfer function."""
     try:
@@ -132,6 +144,7 @@ def is_hdr_source(video: Path) -> bool:
         return False
 
 
+# report whether the first video stream is taller than it is wide
 def is_portrait_source(video: Path) -> bool:
     """Return True if the displayed video is portrait, including rotation."""
     try:
@@ -172,6 +185,7 @@ def is_portrait_source(video: Path) -> bool:
         return False
 
 
+# validate an fps argument and return it as a reduced rational string
 def parse_fps(value: str) -> str:
     """Validate and canonicalize an ffmpeg frame rate."""
     text = value.strip()
@@ -198,6 +212,7 @@ def parse_fps(value: str) -> str:
     return f"{rate.numerator}/{rate.denominator}"
 
 
+# read the source frame rate from ffprobe preferring the average rate
 def probe_source_fps(video: Path) -> str | None:
     """Return an ffmpeg-ready source rate, preferring the average frame rate.
 
@@ -216,6 +231,7 @@ def probe_source_fps(video: Path) -> str | None:
         streams = json.loads(out.stdout).get("streams") or []
         if not streams:
             return None
+        # take the first usable rate and skip zero or unparsable values
         for field in ("avg_frame_rate", "r_frame_rate"):
             value = streams[0].get(field)
             if value and value != "0/0":
@@ -231,6 +247,7 @@ def probe_source_fps(video: Path) -> str | None:
 # -------- Per-segment extraction (Rule 2 + Rule 3) --------------------------
 
 
+# encode one edl range as its own mp4 with tone mapping scaling grade and audio fades applied
 def extract_segment(
     source: Path,
     seg_start: float,
@@ -253,12 +270,14 @@ def extract_segment(
     """
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
+    # scale by height for portrait sources so orientation is preserved
     portrait = is_portrait_source(source)
     if draft:
         scale = "scale=-2:1280" if portrait else "scale=1280:-2"
     else:
         scale = "scale=-2:1920" if portrait else "scale=1920:-2"
 
+    # tone map hdr first then scale then grade
     vf_parts: list[str] = []
     if is_hdr_source(source):
         vf_parts.append(TONEMAP_CHAIN)
@@ -300,6 +319,7 @@ def extract_segment(
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
 
+# extract every edl range into graded segment files sharing one output frame rate
 def extract_all_segments(
     edl: dict,
     edit_dir: Path,
@@ -368,10 +388,12 @@ def extract_all_segments(
 # -------- Lossless concat ----------------------------------------------------
 
 
+# join segment files losslessly with the concat demuxer
 def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -> None:
     """Lossless concat via the concat demuxer. No re-encode."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
     concat_list = edit_dir / "_concat.txt"
+    # the concat demuxer reads a text file listing each segment path
     concat_list.write_text("".join(f"file '{p.resolve()}'\n" for p in segment_paths))
 
     cmd = [
@@ -393,6 +415,7 @@ def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -
 PUNCT_BREAK = set(".,!?;:")
 
 
+# format seconds as an srt timestamp with millisecond precision
 def _srt_timestamp(seconds: float) -> str:
     total_ms = int(round(seconds * 1000))
     h, rem = divmod(total_ms, 3600_000)
@@ -401,6 +424,7 @@ def _srt_timestamp(seconds: float) -> str:
     return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
 
 
+# return transcript words that overlap the given source time range
 def _words_in_range(transcript: dict, t_start: float, t_end: float) -> list[dict]:
     out: list[dict] = []
     for w in transcript.get("words", []):
@@ -410,12 +434,14 @@ def _words_in_range(transcript: dict, t_start: float, t_end: float) -> list[dict
         we = w.get("end")
         if ws is None or we is None:
             continue
+        # keep only words that overlap the range
         if we <= t_start or ws >= t_end:
             continue
         out.append(w)
     return out
 
 
+# build an output timeline srt from per source transcripts using two word uppercase chunks
 def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
     """Build an output-timeline SRT from per-source transcripts.
 
@@ -461,6 +487,7 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
             chunks.append(current)
 
         for chunk in chunks:
+            # clamp chunk times to the segment then shift them onto the output timeline
             local_start = max(seg_start, chunk[0].get("start", seg_start))
             local_end = min(seg_end, chunk[-1].get("end", seg_end))
             out_start = max(0.0, local_start - seg_start) + seg_offset
@@ -498,6 +525,7 @@ LOUDNORM_TP = -1.0
 LOUDNORM_LRA = 11.0
 
 
+# run the loudnorm first pass and parse its json measurement from stderr
 def measure_loudness(video_path: Path) -> dict[str, str] | None:
     """Run ffmpeg loudnorm first pass and parse the JSON measurement.
 
@@ -532,6 +560,7 @@ def measure_loudness(video_path: Path) -> dict[str, str] | None:
     return data
 
 
+# normalize audio with two pass loudnorm or a one pass approximation in preview mode
 def apply_loudnorm_two_pass(
     input_path: Path,
     output_path: Path,
@@ -597,6 +626,7 @@ def apply_loudnorm_two_pass(
 # -------- Final compositing (Rule 1 + Rule 4) -------------------------------
 
 
+# composite overlays onto the base and burn subtitles last in one ffmpeg filter graph
 def build_final_composite(
     base_path: Path,
     overlays: list[dict],
@@ -676,6 +706,7 @@ def build_final_composite(
 # -------- Main ---------------------------------------------------------------
 
 
+# command line entry point that validates the edl and runs the full pipeline
 def main() -> None:
     ap = argparse.ArgumentParser(description="Render a video from an EDL")
     ap.add_argument("edl", type=Path, help="Path to edl.json")

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -1,7 +1,3 @@
-# renders a filmstrip and waveform composite png for a time range of a video
-# frames come from ffmpeg the audio envelope is a windowed rms over a temp wav and transcript words and silences are drawn over the ribbon
-# meant as an on demand drill down at cut decisions rather than a bulk index
-
 """Filmstrip + waveform composite PNG for a time range of a video.
 
 The only visual drill-down tool. Given a video and a [start, end] range,

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -54,7 +54,7 @@ def extract_frames(video: Path, start: float, end: float, n: int, dest_dir: Path
             "-i", str(video),
             "-frames:v", "1",
             "-q:v", "4",
-            "-vf", "scale=320:-2",
+            "-vf", "scale=320:-2,format=yuvj420p",
             str(out),
         ]
         subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -1,3 +1,7 @@
+# renders a filmstrip and waveform composite png for a time range of a video
+# frames come from ffmpeg the audio envelope is a windowed rms over a temp wav and transcript words and silences are drawn over the ribbon
+# meant as an on demand drill down at cut decisions rather than a bulk index
+
 """Filmstrip + waveform composite PNG for a time range of a video.
 
 The only visual drill-down tool. Given a video and a [start, end] range,
@@ -34,11 +38,13 @@ from PIL import Image, ImageDraw, ImageFont
 # -------- Frame extraction ---------------------------------------------------
 
 
+# grab n evenly spaced jpeg frames from the range with ffmpeg and return their paths in order
 def extract_frames(video: Path, start: float, end: float, n: int, dest_dir: Path) -> list[Path]:
     """Extract N frames evenly spaced across [start, end]. Returns paths in order."""
     dest_dir.mkdir(parents=True, exist_ok=True)
     if n < 1:
         n = 1
+    # a single frame sits at the midpoint otherwise spread frames so the first and last land on the range edges
     if n == 1:
         times = [(start + end) / 2.0]
     else:
@@ -65,6 +71,7 @@ def extract_frames(video: Path, start: float, end: float, n: int, dest_dir: Path
 # -------- Audio envelope (librosa if available, ffmpeg fallback) ------------
 
 
+# dump the audio range to a mono wav and turn it into a normalized rms envelope of fixed length
 def compute_envelope(video: Path, start: float, end: float, samples: int = 2000) -> np.ndarray:
     """Extract the audio segment and return an RMS envelope of length `samples`.
 
@@ -100,6 +107,7 @@ def compute_envelope(video: Path, start: float, end: float, samples: int = 2000)
         usable = (n // window) * window
         reshaped = pcm[:usable].reshape(-1, window)
         env = np.sqrt(np.mean(reshaped ** 2, axis=1))
+        # pad or trim so the envelope always has exactly samples entries
         if env.size < samples:
             env = np.pad(env, (0, samples - env.size))
         elif env.size > samples:
@@ -115,6 +123,7 @@ def compute_envelope(video: Path, start: float, end: float, samples: int = 2000)
 # -------- Transcript word overlays ------------------------------------------
 
 
+# return transcript word entries that overlap the requested range
 def words_in_range(transcript_path: Path, start: float, end: float) -> list[dict]:
     if not transcript_path.exists():
         return []
@@ -126,12 +135,14 @@ def words_in_range(transcript_path: Path, start: float, end: float) -> list[dict
         we = w.get("end")
         if ws is None or we is None:
             continue
+        # skip tokens that end before the range or begin after it
         if we <= start or ws >= end:
             continue
         out.append(w)
     return out
 
 
+# scan kept tokens for gaps of at least threshold seconds and return them as time pairs
 def find_silences(words: list[dict], start: float, end: float, threshold: float = 0.4) -> list[tuple[float, float]]:
     """Find gaps >= threshold seconds inside [start, end] between kept tokens."""
     gaps: list[tuple[float, float]] = []
@@ -143,6 +154,7 @@ def find_silences(words: list[dict], start: float, end: float, threshold: float 
         if ws - prev_end >= threshold:
             gaps.append((prev_end, ws))
         prev_end = max(prev_end, w.get("end", ws))
+    # also report a trailing gap between the last token and the range end
     if end - prev_end >= threshold:
         gaps.append((prev_end, end))
     return gaps
@@ -160,6 +172,7 @@ FONT_CANDIDATES = [
 ]
 
 
+# try the known monospace and system font paths and fall back to the pillow default
 def load_font(size: int) -> ImageFont.ImageFont:
     for fp in FONT_CANDIDATES:
         if Path(fp).exists():
@@ -181,6 +194,7 @@ SILENCE = (50, 80, 120, 120)  # muted blue, semi-transparent
 WAVE = (140, 180, 255)
 
 
+# draw the full composite of header filmstrip silence bands waveform word labels and time ruler then save it
 def render_timeline(
     video: Path,
     start: float,
@@ -235,6 +249,7 @@ def render_timeline(
         # Filmstrip
         x = 50
         strip_width = canvas_width - 100
+        # paste frames at full size when they fit otherwise scale the whole strip down to the canvas width
         if total_frame_w <= strip_width:
             cursor = 50
             for img in imgs:
@@ -256,6 +271,7 @@ def render_timeline(
         strip_x1 = 50 + draw_width
         strip_span = strip_x1 - strip_x0
 
+        # map a timestamp inside the range onto a pixel column of the strip
         def time_to_x(t: float) -> int:
             frac = (t - start) / max(1e-6, (end - start))
             return int(strip_x0 + frac * strip_span)
@@ -277,6 +293,7 @@ def render_timeline(
         max_amp = wave_h // 2 - 8
         points_top: list[tuple[int, int]] = []
         points_bot: list[tuple[int, int]] = []
+        # mirror the envelope above and below the midline to draw a symmetric waveform
         for i, v in enumerate(env):
             xi = strip_x0 + int(i * strip_span / max(1, len(env) - 1))
             a = int(v * max_amp)
@@ -299,6 +316,7 @@ def render_timeline(
             text = (w.get("text") or "").strip()
             if not text or ws is None or we is None:
                 continue
+            # skip very short words and labels that would land within 28 px of the previous one
             if (we - ws) < 0.05:
                 continue
             cx = (time_to_x(ws) + time_to_x(we)) // 2
@@ -330,6 +348,7 @@ def render_timeline(
         print(f"saved: {out_path}  ({out_path.stat().st_size // 1024} KB)")
 
 
+# cli entry point that validates the range resolves the transcript and output paths and renders the png
 def main() -> None:
     ap = argparse.ArgumentParser(description="Filmstrip + waveform composite for a video range")
     ap.add_argument("video", type=Path, nargs="?", help="Source video")
@@ -372,6 +391,7 @@ def main() -> None:
         if auto.exists():
             transcript = auto
 
+    # default the output into the verify folder under the edit directory with the range in the file name
     out_path = args.output
     if out_path is None:
         out_dir = video.parent / "edit" / "verify"

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -1,3 +1,7 @@
+# transcribes a single video with elevenlabs scribe and caches the response as json
+# audio is extracted to a mono 16khz wav with ffmpeg then uploaded with diarization audio events and word timestamps
+# transcribe_batch imports load_api_key and transcribe_one to fan the same work out across files
+
 """Transcribe a video with ElevenLabs Scribe.
 
 Extracts mono 16kHz audio via ffmpeg, uploads to Scribe with verbatim +
@@ -33,9 +37,12 @@ import requests
 SCRIBE_URL = "https://api.elevenlabs.io/v1/speech-to-text"
 
 
+# read the elevenlabs api key from a dotenv file or the environment and exit if neither has it
 def load_api_key() -> str:
+    # check the repo root dotenv first then the working directory
     for candidate in [Path(__file__).resolve().parent.parent / ".env", Path(".env")]:
         if candidate.exists():
+            # parse key equals value lines and strip surrounding quotes from the value
             for line in candidate.read_text().splitlines():
                 line = line.strip()
                 if not line or line.startswith("#") or "=" not in line:
@@ -49,6 +56,7 @@ def load_api_key() -> str:
     return v
 
 
+# count the audio streams in a container so multi track recordings can be flagged
 def count_audio_tracks(video_path: Path) -> int:
     """How many audio streams the container holds."""
     out = subprocess.run(
@@ -59,6 +67,7 @@ def count_audio_tracks(video_path: Path) -> int:
     return len([ln for ln in out.stdout.splitlines() if ln.strip()])
 
 
+# measure the peak level of a wav in dbfs so a silent track is caught before upload
 def peak_dbfs(wav_path: Path) -> float:
     """Peak level of a 16-bit PCM wav, in dBFS. -inf for digital silence."""
     peak = 0
@@ -71,6 +80,7 @@ def peak_dbfs(wav_path: Path) -> float:
     return 20 * math.log10(peak / 32768) if peak > 0 else float("-inf")
 
 
+# use ffmpeg to write a mono 16khz pcm wav from the video
 def extract_audio(video_path: Path, dest: Path, audio_track: int = 0) -> None:
     cmd = [
         "ffmpeg", "-y", "-i", str(video_path),
@@ -81,6 +91,7 @@ def extract_audio(video_path: Path, dest: Path, audio_track: int = 0) -> None:
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
+# upload the wav to the scribe endpoint with verbatim settings and return the parsed json
 def call_scribe(
     audio_path: Path,
     api_key: str,
@@ -107,12 +118,14 @@ def call_scribe(
             timeout=1800,
         )
 
+    # any non 200 response is treated as a hard failure with a trimmed body for context
     if resp.status_code != 200:
         raise RuntimeError(f"Scribe returned {resp.status_code}: {resp.text[:500]}")
 
     return resp.json()
 
 
+# resolve where a transcript lands with the track number in the name for anything but track zero
 def transcript_path(edit_dir: Path, video: Path, audio_track: int = 0) -> Path:
     """Where a video's transcript lands.
 
@@ -125,6 +138,7 @@ def transcript_path(edit_dir: Path, video: Path, audio_track: int = 0) -> Path:
     return edit_dir / "transcripts" / f"{video.stem}{suffix}.json"
 
 
+# transcribe one video into the transcripts folder and return the json path reusing a cached file if present
 def transcribe_one(
     video: Path,
     edit_dir: Path,
@@ -189,6 +203,7 @@ def transcribe_one(
     return out_path
 
 
+# cli entry point that resolves the video and edit directory then runs a single transcription
 def main() -> None:
     ap = argparse.ArgumentParser(description="Transcribe a video with ElevenLabs Scribe")
     ap.add_argument("video", type=Path, help="Path to video file")

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -1,7 +1,3 @@
-# transcribes a single video with elevenlabs scribe and caches the response as json
-# audio is extracted to a mono 16khz wav with ffmpeg then uploaded with diarization audio events and word timestamps
-# transcribe_batch imports load_api_key and transcribe_one to fan the same work out across files
-
 """Transcribe a video with ElevenLabs Scribe.
 
 Extracts mono 16kHz audio via ffmpeg, uploads to Scribe with verbatim +

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -1,3 +1,7 @@
+# batch transcribes every video in a directory using a thread pool of scribe workers
+# it reuses transcribe_one so per file caching still applies and only pending sources are uploaded
+# failures are collected and reported at the end with a non zero exit
+
 """Batch-transcribe every video in a directory with 4 parallel workers.
 
 Walks <videos_dir> for common video extensions, runs ElevenLabs Scribe on
@@ -26,6 +30,7 @@ from transcribe import load_api_key, transcribe_one, transcript_path
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
 
 
+# list files in the directory whose suffix is a known video extension in sorted order
 def find_videos(videos_dir: Path) -> list[Path]:
     videos = sorted(
         p for p in videos_dir.iterdir()
@@ -34,6 +39,7 @@ def find_videos(videos_dir: Path) -> list[Path]:
     return videos
 
 
+# cli entry point that splits videos into cached and pending sets then transcribes the pending ones in parallel
 def main() -> None:
     ap = argparse.ArgumentParser(description="Parallel batch transcription of a videos directory")
     ap.add_argument("videos_dir", type=Path, help="Directory containing source videos")

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -1,7 +1,3 @@
-# batch transcribes every video in a directory using a thread pool of scribe workers
-# it reuses transcribe_one so per file caching still applies and only pending sources are uploaded
-# failures are collected and reported at the end with a non zero exit
-
 """Batch-transcribe every video in a directory with 4 parallel workers.
 
 Walks <videos_dir> for common video extensions, runs ElevenLabs Scribe on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "video-use"
 version = "0.1.0"
-description = "Conversation-driven video editor skill for Claude Code"
+description = "Conversation-driven video production framework for coding agents"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
@@ -21,3 +21,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 py-modules = []
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -4,14 +4,16 @@ comments must not carry punctuation so they stay short and readable at a glance
 """
 
 import ast
+import io
 import re
+import tokenize
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKIP_DIRS = {".venv", "venv", "node_modules", "__pycache__", ".git", "media", "edit"}
 PUNCTUATION = re.compile(r"[.,:;()\"'`]")
-DEFINITION = re.compile(r"\s*(async def|def|class) \w")
+DEFINITIONS = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
 
 
 # yield every python file in the repo that is not inside a skipped directory
@@ -30,24 +32,39 @@ def audit(text):
     if first and first[0].startswith("#"):
         problems.append("hash comment header should be a module docstring")
     try:
-        if ast.get_docstring(ast.parse(text)) is None:
-            problems.append("missing module docstring")
+        tree = ast.parse(text)
     except SyntaxError:
         problems.append("file does not parse")
-    for index, line in enumerate(lines):
-        if not DEFINITION.match(line):
+        return problems
+    if ast.get_docstring(tree) is None:
+        problems.append("missing module docstring")
+    comments = real_comments(text)
+    for node in sorted(definitions(tree), key=lambda item: item.lineno):
+        # decorators sit between the comment and the definition so look above the first decorator
+        start = min([node.lineno, *[item.lineno for item in node.decorator_list]])
+        above = start - 1
+        if above not in comments:
+            problems.append(f"line {node.lineno} has no comment above {node.name}")
             continue
-        above = index - 1
-        # decorators sit between the comment and the definition
-        while above >= 0 and lines[above].strip().startswith("@"):
-            above -= 1
-        if above < 0 or not lines[above].strip().startswith("#"):
-            problems.append(f"line {index + 1} has no comment above {line.strip()[:40]}")
-            continue
-        comment = lines[above].strip().lstrip("#").strip()
-        if PUNCTUATION.search(comment):
-            problems.append(f"line {above + 1} comment contains punctuation")
+        if PUNCTUATION.search(comments[above]):
+            problems.append(f"line {above} comment contains punctuation")
     return problems
+
+
+# yield every function and class node in the tree so text inside strings never counts as a definition
+def definitions(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, DEFINITIONS):
+            yield node
+
+
+# map line number to comment text for lines that hold nothing but a real comment token
+def real_comments(text):
+    comments = {}
+    for token in tokenize.generate_tokens(io.StringIO(text).readline):
+        if token.type == tokenize.COMMENT and token.line.strip().startswith("#"):
+            comments[token.start[0]] = token.string.lstrip("#").strip()
+    return comments
 
 
 # one test that scans the whole repo so a single failure lists every offending file

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -43,7 +43,7 @@ def audit(text):
         # decorators sit between the comment and the definition so look above the first decorator
         start = min([node.lineno, *[item.lineno for item in node.decorator_list]])
         above = start - 1
-        if above not in comments:
+        if above not in comments or not comments[above]:
             problems.append(f"line {node.lineno} has no comment above {node.name}")
             continue
         if PUNCTUATION.search(comments[above]):

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -1,0 +1,58 @@
+# guards the comment convention across every python file in the repo
+# each file starts with a plain header block and every def or class has one plain comment line above it
+# comments must not carry punctuation so they stay short and readable at a glance
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {".venv", "venv", "node_modules", "__pycache__", ".git", "media", "edit"}
+PUNCTUATION = re.compile(r"[.,:;()\"'`]")
+DEFINITION = re.compile(r"\s*(async def|def|class) \w")
+
+
+# yield every python file in the repo that is not inside a skipped directory
+def python_files():
+    for path in ROOT.rglob("*.py"):
+        if not any(part in SKIP_DIRS for part in path.relative_to(ROOT).parts):
+            yield path
+
+
+# return the problems found in one file as short strings
+def audit(text):
+    lines = text.splitlines()
+    problems = []
+    first = [line for line in lines[:6] if line.strip() and not line.startswith("#!")]
+    if not first or not first[0].startswith("#"):
+        problems.append("missing header comment block")
+    for index, line in enumerate(lines):
+        if not DEFINITION.match(line):
+            continue
+        above = index - 1
+        # decorators sit between the comment and the definition
+        while above >= 0 and lines[above].strip().startswith("@"):
+            above -= 1
+        if above < 0 or not lines[above].strip().startswith("#"):
+            problems.append(f"line {index + 1} has no comment above {line.strip()[:40]}")
+            continue
+        comment = lines[above].strip().lstrip("#").strip()
+        if PUNCTUATION.search(comment):
+            problems.append(f"line {above + 1} comment contains punctuation")
+    return problems
+
+
+# one test that scans the whole repo so a single failure lists every offending file
+class CommentStyleTests(unittest.TestCase):
+    # every python file must satisfy the header and per definition comment rules
+    def test_every_python_file_follows_the_convention(self):
+        failures = {}
+        for path in python_files():
+            problems = audit(path.read_text(encoding="utf-8"))
+            if problems:
+                failures[str(path.relative_to(ROOT))] = problems[:5]
+        self.assertEqual(failures, {}, "comment convention violations")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -1,7 +1,9 @@
-# guards the comment convention across every python file in the repo
-# each file starts with a plain header block and every def or class has one plain comment line above it
-# comments must not carry punctuation so they stay short and readable at a glance
+"""guards the comment convention across every python file in the repo
+each file opens with a module docstring and every def or class has one plain comment line above it
+comments must not carry punctuation so they stay short and readable at a glance
+"""
 
+import ast
 import re
 import unittest
 from pathlib import Path
@@ -23,9 +25,15 @@ def python_files():
 def audit(text):
     lines = text.splitlines()
     problems = []
+    # the file opens with a docstring and not with a block of hash comments
     first = [line for line in lines[:6] if line.strip() and not line.startswith("#!")]
-    if not first or not first[0].startswith("#"):
-        problems.append("missing header comment block")
+    if first and first[0].startswith("#"):
+        problems.append("hash comment header should be a module docstring")
+    try:
+        if ast.get_docstring(ast.parse(text)) is None:
+            problems.append("missing module docstring")
+    except SyntaxError:
+        problems.append("file does not parse")
     for index, line in enumerate(lines):
         if not DEFINITION.match(line):
             continue

--- a/tests/test_render_fps.py
+++ b/tests/test_render_fps.py
@@ -1,3 +1,7 @@
+# unit tests for the frame rate handling in helpers render py
+# they cover parse_fps canonical forms probe_source_fps ffprobe parsing and the rate resolution in extract_all_segments
+# render py is loaded by file path so the tests do not depend on it being importable as a package
+
 import argparse
 import contextlib
 import importlib.util
@@ -10,6 +14,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 
+# load render py straight from its file path under a private module name
 MODULE_PATH = Path(__file__).parents[1] / "helpers" / "render.py"
 SPEC = importlib.util.spec_from_file_location("video_use_render", MODULE_PATH)
 assert SPEC and SPEC.loader
@@ -17,7 +22,9 @@ render = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(render)
 
 
+# tests for parse_fps which turns user supplied rates into canonical rational strings
 class ParseFpsTests(unittest.TestCase):
+    # integer decimal and rational inputs all canonicalize to the expected fraction
     def test_accepts_integer_decimal_and_rational_rates(self):
         expected = {
             "60": "60/1",
@@ -28,12 +35,14 @@ class ParseFpsTests(unittest.TestCase):
             with self.subTest(value=value):
                 self.assertEqual(render.parse_fps(value), canonical)
 
+    # feeding a canonical rate back through parse_fps returns it unchanged
     def test_canonical_rates_are_idempotent(self):
         for value in ("60", "29.97", "30000/1001"):
             with self.subTest(value=value):
                 canonical = render.parse_fps(value)
                 self.assertEqual(render.parse_fps(canonical), canonical)
 
+    # malformed zero negative or oversized inputs raise an argparse type error
     def test_rejects_invalid_or_non_positive_rates(self):
         for value in (
             "",
@@ -51,7 +60,9 @@ class ParseFpsTests(unittest.TestCase):
                     render.parse_fps(value)
 
 
+# tests for probe_source_fps with ffprobe replaced by canned completed process results
 class ProbeSourceFpsTests(unittest.TestCase):
+    # build a fake ffprobe result whose json carries the given average and nominal rates
     @staticmethod
     def _probe_result(avg: str, nominal: str) -> subprocess.CompletedProcess:
         stdout = json.dumps({
@@ -59,28 +70,34 @@ class ProbeSourceFpsTests(unittest.TestCase):
         })
         return subprocess.CompletedProcess([], 0, stdout=stdout, stderr="")
 
+    # the average frame rate wins when ffprobe reports a usable one
     def test_prefers_average_rate(self):
         result = self._probe_result("30000/1001", "30/1")
         with patch.object(render.subprocess, "run", return_value=result):
             self.assertEqual(render.probe_source_fps(Path("source.mp4")), "30000/1001")
 
+    # a zero average rate falls back to the nominal r_frame_rate
     def test_falls_back_to_nominal_rate(self):
         result = self._probe_result("0/0", "60/1")
         with patch.object(render.subprocess, "run", return_value=result):
             self.assertEqual(render.probe_source_fps(Path("source.mp4")), "60/1")
 
+    # an empty streams list yields none instead of a rate
     def test_returns_none_for_unusable_probe_output(self):
         result = subprocess.CompletedProcess([], 0, stdout='{"streams": []}', stderr="")
         with patch.object(render.subprocess, "run", return_value=result):
             self.assertIsNone(render.probe_source_fps(Path("source.mp4")))
 
+    # an ffprobe process error yields none rather than propagating
     def test_returns_none_when_ffprobe_fails(self):
         error = subprocess.CalledProcessError(1, ["ffprobe"])
         with patch.object(render.subprocess, "run", side_effect=error):
             self.assertIsNone(render.probe_source_fps(Path("source.mp4")))
 
 
+# tests for how extract_all_segments chooses one rate for every segment
 class RenderRateTests(unittest.TestCase):
+    # minimal two source edl with one range per source
     @staticmethod
     def _edl() -> dict:
         return {
@@ -91,6 +108,7 @@ class RenderRateTests(unittest.TestCase):
             ],
         }
 
+    # only the first source is probed and its rate is applied to every segment
     def test_multi_source_render_resolves_one_rate_from_first_source(self):
         edl = self._edl()
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -105,6 +123,7 @@ class RenderRateTests(unittest.TestCase):
         probe.assert_called_once_with((edit_dir / "first.mp4").resolve())
         self.assertEqual([call.kwargs["rate"] for call in extract.call_args_list], ["60/1", "60/1"])
 
+    # an explicit fps argument skips probing and is canonicalized for every segment
     def test_explicit_rate_skips_probe_and_applies_to_every_segment(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             with (
@@ -122,6 +141,7 @@ class RenderRateTests(unittest.TestCase):
             ["30/1", "30/1"],
         )
 
+    # when probing fails every segment falls back to the 24 default
     def test_failed_probe_falls_back_to_24_for_every_segment(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             with (

--- a/tests/test_render_fps.py
+++ b/tests/test_render_fps.py
@@ -1,6 +1,7 @@
-# unit tests for the frame rate handling in helpers render py
-# they cover parse_fps canonical forms probe_source_fps ffprobe parsing and the rate resolution in extract_all_segments
-# render py is loaded by file path so the tests do not depend on it being importable as a package
+"""unit tests for the frame rate handling in helpers render py
+they cover parse_fps canonical forms probe_source_fps ffprobe parsing and the rate resolution in extract_all_segments
+render py is loaded by file path so the tests do not depend on it being importable as a package
+"""
 
 import argparse
 import contextlib

--- a/tests/test_render_orientation.py
+++ b/tests/test_render_orientation.py
@@ -1,3 +1,6 @@
+# tests for portrait detection in the render helper including rotation side data
+# it loads the helper from its file path and patches ffprobe so no real media is needed
+
 import importlib.util
 import json
 import subprocess
@@ -13,7 +16,9 @@ render = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(render)
 
 
+# portrait detection must honor display rotation but ignore plain rotate tags
 class PortraitDetectionTests(unittest.TestCase):
+    # run the detector against a fake ffprobe json stream
     def _is_portrait(self, stream: dict) -> bool:
         result = subprocess.CompletedProcess(
             [], 0, stdout=json.dumps({"streams": [stream]}), stderr=""
@@ -26,12 +31,15 @@ class PortraitDetectionTests(unittest.TestCase):
         self.assertNotIn("stream_tags=rotate", show_entries)
         return portrait
 
+    # taller than wide with no rotation is portrait
     def test_native_portrait_dimensions(self):
         self.assertTrue(self._is_portrait({"width": 1080, "height": 1920}))
 
+    # wider than tall with no rotation is landscape
     def test_native_landscape_dimensions(self):
         self.assertFalse(self._is_portrait({"width": 1920, "height": 1080}))
 
+    # a quarter turn in display side data flips a coded landscape into portrait
     def test_side_data_rotation_turns_coded_landscape_into_portrait(self):
         stream = {
             "width": 1920,
@@ -40,10 +48,12 @@ class PortraitDetectionTests(unittest.TestCase):
         }
         self.assertTrue(self._is_portrait(stream))
 
+    # a rotate tag without side data does not change the answer
     def test_plain_rotation_tag_without_side_data_is_ignored(self):
         stream = {"width": 1920, "height": 1080, "tags": {"rotate": "270"}}
         self.assertFalse(self._is_portrait(stream))
 
+    # a quarter turn can also flip a coded portrait into landscape
     def test_rotation_can_turn_coded_portrait_into_landscape(self):
         stream = {
             "width": 1080,
@@ -52,6 +62,7 @@ class PortraitDetectionTests(unittest.TestCase):
         }
         self.assertFalse(self._is_portrait(stream))
 
+    # unreadable probe output falls back to landscape
     def test_invalid_probe_output_falls_back_to_landscape(self):
         result = subprocess.CompletedProcess([], 0, stdout="not json", stderr="")
         with patch.object(render.subprocess, "run", return_value=result):

--- a/tests/test_render_orientation.py
+++ b/tests/test_render_orientation.py
@@ -1,5 +1,6 @@
-# tests for portrait detection in the render helper including rotation side data
-# it loads the helper from its file path and patches ffprobe so no real media is needed
+"""tests for portrait detection in the render helper including rotation side data
+it loads the helper from its file path and patches ffprobe so no real media is needed
+"""
 
 import importlib.util
 import json

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -1,3 +1,7 @@
+# tests that guard the public editing contract documented in skill md
+# they check that the numbered hard rules stay present and in order and that every referenced helper or reference path exists
+# the hard rules list is append only so new rules go at the end
+
 """Guard the public editing contract in SKILL.md.
 
 Two failure modes this protects against when several agents edit the file:
@@ -28,21 +32,28 @@ HARD_RULES = [
     "All session outputs in `<videos_dir>/edit/`.",
 ]
 
+# matches backticked paths under references helpers or skills
 PATH_PATTERN = re.compile(r"`((?:references|helpers|skills)/[A-Za-z0-9_./-]+)`")
 
 
+# slice out the body of the hard rules section up to the next second level heading
 def hard_rules_section(text: str) -> str:
+    # dotall plus multiline so the lazy group spans lines and the heading anchors match at line starts
     match = re.search(r"^## Hard Rules.*?$(.*?)^## ", text, re.S | re.M)
     assert match, "SKILL.md must contain a '## Hard Rules' section"
     return match.group(1)
 
 
+# test case that reads skill md once per test and checks its contract
 class SkillContractTests(unittest.TestCase):
+    # load the skill md text for each test
     def setUp(self) -> None:
         self.text = SKILL.read_text(encoding="utf-8")
 
+    # numbered bold rule titles must be consecutive and each expected rule must still sit at its index
     def test_hard_rules_are_present_in_order(self):
         section = hard_rules_section(self.text)
+        # capture the number and bold title of each numbered list item
         items = re.findall(r"^(\d+)\. \*\*(.+?)\*\*", section, re.M)
         numbers = [int(number) for number, _ in items]
         self.assertEqual(numbers, list(range(1, len(numbers) + 1)), "rules must be numbered consecutively")
@@ -50,6 +61,7 @@ class SkillContractTests(unittest.TestCase):
         for index, expected in enumerate(HARD_RULES):
             self.assertIn(expected, items[index][1], f"rule {index + 1} changed or moved")
 
+    # every backticked helper or reference path in skill md must exist on disk
     def test_referenced_paths_exist(self):
         missing = sorted(
             path

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -1,7 +1,3 @@
-# tests that guard the public editing contract documented in skill md
-# they check that the numbered hard rules stay present and in order and that every referenced helper or reference path exists
-# the hard rules list is append only so new rules go at the end
-
 """Guard the public editing contract in SKILL.md.
 
 Two failure modes this protects against when several agents edit the file:

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -1,0 +1,63 @@
+"""Guard the public editing contract in SKILL.md.
+
+Two failure modes this protects against when several agents edit the file:
+a hard rule silently disappears or gets renumbered, and a helper or reference
+path is documented but no longer exists in the tree.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "SKILL.md"
+
+# Append-only. Add new rules to the end of this list when SKILL.md gains one.
+HARD_RULES = [
+    "Subtitles are applied LAST in the filter chain",
+    "Per-segment extract",
+    "30ms audio fades at every segment boundary",
+    "Overlays use `setpts=PTS-STARTPTS+T/TB`",
+    "Master SRT uses output-timeline offsets",
+    "Never cut inside a word.",
+    "Pad every cut edge.",
+    "Word-level verbatim ASR only.",
+    "Cache transcripts per source.",
+    "Parallel sub-agents for multiple animations.",
+    "Strategy confirmation before execution.",
+    "All session outputs in `<videos_dir>/edit/`.",
+]
+
+PATH_PATTERN = re.compile(r"`((?:references|helpers|skills)/[A-Za-z0-9_./-]+)`")
+
+
+def hard_rules_section(text: str) -> str:
+    match = re.search(r"^## Hard Rules.*?$(.*?)^## ", text, re.S | re.M)
+    assert match, "SKILL.md must contain a '## Hard Rules' section"
+    return match.group(1)
+
+
+class SkillContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.text = SKILL.read_text(encoding="utf-8")
+
+    def test_hard_rules_are_present_in_order(self):
+        section = hard_rules_section(self.text)
+        items = re.findall(r"^(\d+)\. \*\*(.+?)\*\*", section, re.M)
+        numbers = [int(number) for number, _ in items]
+        self.assertEqual(numbers, list(range(1, len(numbers) + 1)), "rules must be numbered consecutively")
+        self.assertGreaterEqual(len(items), len(HARD_RULES), "a hard rule was removed")
+        for index, expected in enumerate(HARD_RULES):
+            self.assertIn(expected, items[index][1], f"rule {index + 1} changed or moved")
+
+    def test_referenced_paths_exist(self):
+        missing = sorted(
+            path
+            for path in set(PATH_PATTERN.findall(self.text))
+            if not (ROOT / path).exists()
+        )
+        self.assertEqual(missing, [], "SKILL.md names paths that do not exist")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -30,6 +30,8 @@ HARD_RULES = [
 
 # matches backticked paths under references helpers or skills
 PATH_PATTERN = re.compile(r"`((?:references|helpers|skills)/[A-Za-z0-9_./-]+)`")
+# matches a bare helper script name at the start of a backticked command
+HELPER_PATTERN = re.compile(r"`([A-Za-z0-9_]+\.py)\b")
 
 
 # slice out the body of the hard rules section up to the next second level heading
@@ -65,6 +67,15 @@ class SkillContractTests(unittest.TestCase):
             if not (ROOT / path).exists()
         )
         self.assertEqual(missing, [], "SKILL.md names paths that do not exist")
+
+    # every bare helper script named in a backticked command must exist under helpers
+    def test_bare_helper_names_exist(self):
+        missing = sorted(
+            name
+            for name in set(HELPER_PATTERN.findall(self.text))
+            if not (ROOT / "helpers" / name).exists()
+        )
+        self.assertEqual(missing, [], "SKILL.md names helper scripts that do not exist")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds AGENTS.md so coding agents know the repo's rules, puts a short plain comment above every function in the existing helpers, and adds two tests: one that keeps the comment convention, one that keeps SKILL.md's numbered hard rules in order and checks every path it references exists. Also a pytest path setting so plain `pytest` works, and a one-line fix in the timeline PNG export.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds repo guidance and contract guards so concurrent agents can work safely without silently breaking the public editing rules. It also standardizes Python definition comments and fixes timeline PNG extraction compatibility.

- `AGENTS.md` documents product principles, architecture boundaries, workflow, and branch discipline.
- Every Python file now requires a module docstring and plain comment text above each function or class, enforced by `tests/test_comment_style.py`.
- `tests/test_skill_contract.py` verifies numbered hard rules stay in order and every referenced path or helper script exists.
- Adds a pytest `pythonpath` setting so plain `pytest` works from the repo root.
- Timeline PNG extraction now forces the `yuvj420p` pixel format.

<sup>Written for commit b48e6031f135dfa58b38305fe0ef6b9e9c5dd447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

