### PR TITLE
edl v2 with deliverables, overlay layouts, protected regions, and caption provenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,8 @@ from being overwritten by another:
   history, so a later sync silently discards it.
 - Hard rules in `SKILL.md` are append-only. New rules get the next number.
   Removing or renumbering a rule requires an explicit reason in the commit.
-- Procedure prose belongs in `references/<feature>.md`. Edits to `SKILL.md`
+- Procedure prose belongs in `references/<feature>.md` at the repository root;
+  create that folder with the first reference file. Edits to `SKILL.md`
   are limited to rules, helper-index bullets, directory-tree lines, the EDL
   example, and one-line pointers to the reference files.
 - `tests/test_skill_contract.py` checks that the rules and every referenced

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# video-use repository context
+
+video-use is a public, conversation-driven video production framework. Changes
+made here may be packaged into the skill and reused by people with different
+machines, media, workflows, providers, brands, and output goals. Treat the
+repository as a general product, never as one person's customized clone.
+
+## Product principles
+
+- The delivered video is the product. Prioritize visual and audio quality,
+  editorial judgment, factual correctness, synchronization, pacing, and
+  production reliability.
+- Design reusable contracts and capabilities. Do not hardcode personal paths,
+  credentials, account ids, prompts, brands, preferences, lane history, or
+  assumptions about one project.
+- Keep provider-specific behavior behind narrow boundaries. Core EDL validation,
+  rendering, reframing, and QC must remain usable without the localhost GUI or
+  Modal.
+- Preserve backwards compatibility when practical. If a format must change,
+  provide a clear migration path and reject unsupported input with an actionable
+  error.
+- Never silently downgrade a requested feature. A missing source, track, model,
+  codec, or dependency should fail before expensive work begins and explain what
+  is required.
+- Defaults should be safe and broadly useful, while explicit project or user
+  requirements always win.
+- Keep credentials out of source, logs, fixtures, prompts, and generated
+  artifacts. Configuration belongs in environment variables or provider secret
+  stores.
+
+## Architecture boundaries
+
+- `SKILL.md` defines the agent workflow and public editing contract.
+- `helpers/` contains provider-independent production tools and validation.
+- `skills/` contains focused companion skills and reusable production assets.
+- `gui/` is an optional internal client and remote-execution adapter. It may
+  orchestrate core features but must not become the only place those features
+  exist.
+- `tests/` and `gui/tests/` protect public behavior and adapter behavior
+  respectively.
+
+Keep decision data explicit in portable project files such as `edit/edl.json`.
+Renderers should consume declared inputs deterministically. UI state, agent
+history, and cloud runtime state must not be required to reproduce an output.
+
+## Experimental GUI harness
+
+The four-lane GUI in `gui/` exists to generate many independent outputs quickly
+so developers can find ugly frames, weak editorial decisions, unsupported
+queries, and renderer failures before video-use users encounter them.
+
+- Use the four parallel Modal lanes for this branch's output-discovery runs.
+  Avoid one-off manual local benchmark renders when the harness can run the same
+  experiment and preserve comparable evidence.
+- Do not assume the public video-use workflow will adopt the GUI, Modal, its lane
+  model, or its run-storage APIs. Promote a finding into `helpers/`, `skills/`,
+  or `SKILL.md` only when the underlying capability is generally useful without
+  the harness.
+- Keep each lane's agent context fresh. Past run traces are evaluation evidence
+  for developers and must not leak into a new lane's creative context.
+- Preserve every run's durable evidence through `gui/run_store.py`: the compact
+  `run_summary.md`, deduplicated `trace.json`, raw Codex protocol when available,
+  complete `render.log`, generated edit handoff, and returned outputs.
+- Prefer `run_summary.md` when an agent needs quick context. Read the raw trace or
+  protocol only to investigate a specific decision, tool call, or failure.
+- Pin valuable successes and representative failures before cleanup. Never
+  delete a pinned run, and never delete an active lane.
+
+## Change workflow
+
+1. Identify whether a change belongs to the public editing contract, a reusable
+   helper, a focused skill, or an optional adapter.
+2. Implement the smallest complete general capability at the lowest reusable
+   layer. Wire adapters to that capability instead of duplicating it.
+3. Validate inputs locally before uploads or paid compute. Validate again at
+   remote execution boundaries.
+4. Add tests for successful use, invalid input, backwards compatibility, and
+   provider-boundary behavior where relevant.
+5. For render changes, create representative media and inspect the encoded
+   dimensions, duration, frame rate, visual framing, and audible output.
+6. Update the public EDL example or usage documentation whenever users or agents
+   need to author a new field.
+
+Cost and latency are secondary unless the user sets a budget or deadline. Improve
+them only when output quality and reliability remain equal or improve.
+
+## Communication and commits
+
+After code changes, summarize the affected files, the functions or contracts
+added, and what each does in plain language. Keep this technical context compact
+so someone can learn an unfamiliar codebase without reading every diff.
+
+Write simple, readable commit messages. Prefer short lowercase wording without
+punctuation.
+
+## Branch discipline
+
+Several agents work on this repository at once. To keep one agent's progress
+from being overwritten by another:
+
+- One feature per branch, one agent per branch. Never edit a worktree that
+  belongs to another branch; take files from a commit or tag instead.
+- Commit early. Uncommitted work in a worktree has no merge base and no
+  history, so a later sync silently discards it.
+- Hard rules in `SKILL.md` are append-only. New rules get the next number.
+  Removing or renumbering a rule requires an explicit reason in the commit.
+- Procedure prose belongs in `references/<feature>.md`. Edits to `SKILL.md`
+  are limited to rules, helper-index bullets, directory-tree lines, the EDL
+  example, and one-line pointers to the reference files.
+- `tests/test_skill_contract.py` checks that the rules and every referenced
+  path still exist. Run it before committing a `SKILL.md` change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,11 @@ repository as a general product, never as one person's customized clone.
   editorial judgment, factual correctness, synchronization, pacing, and
   production reliability.
 - Design reusable contracts and capabilities. Do not hardcode personal paths,
-  credentials, account ids, prompts, brands, preferences, lane history, or
-  assumptions about one project.
+  credentials, account ids, prompts, brands, preferences, or assumptions
+  about one project.
 - Keep provider-specific behavior behind narrow boundaries. Core EDL validation,
-  rendering, reframing, and QC must remain usable without the localhost GUI or
-  Modal.
+  rendering, reframing, and QC must remain usable from the command line without
+  any optional client or remote runner.
 - Preserve backwards compatibility when practical. If a format must change,
   provide a clear migration path and reject unsupported input with an actionable
   error.
@@ -33,38 +33,13 @@ repository as a general product, never as one person's customized clone.
 - `SKILL.md` defines the agent workflow and public editing contract.
 - `helpers/` contains provider-independent production tools and validation.
 - `skills/` contains focused companion skills and reusable production assets.
-- `gui/` is an optional internal client and remote-execution adapter. It may
-  orchestrate core features but must not become the only place those features
-  exist.
-- `tests/` and `gui/tests/` protect public behavior and adapter behavior
-  respectively.
+- `tests/` protects public behavior. Optional clients or remote runners may
+  orchestrate core features but must never become the only place a feature
+  exists.
 
 Keep decision data explicit in portable project files such as `edit/edl.json`.
 Renderers should consume declared inputs deterministically. UI state, agent
 history, and cloud runtime state must not be required to reproduce an output.
-
-## Experimental GUI harness
-
-The four-lane GUI in `gui/` exists to generate many independent outputs quickly
-so developers can find ugly frames, weak editorial decisions, unsupported
-queries, and renderer failures before video-use users encounter them.
-
-- Use the four parallel Modal lanes for this branch's output-discovery runs.
-  Avoid one-off manual local benchmark renders when the harness can run the same
-  experiment and preserve comparable evidence.
-- Do not assume the public video-use workflow will adopt the GUI, Modal, its lane
-  model, or its run-storage APIs. Promote a finding into `helpers/`, `skills/`,
-  or `SKILL.md` only when the underlying capability is generally useful without
-  the harness.
-- Keep each lane's agent context fresh. Past run traces are evaluation evidence
-  for developers and must not leak into a new lane's creative context.
-- Preserve every run's durable evidence through `gui/run_store.py`: the compact
-  `run_summary.md`, deduplicated `trace.json`, raw Codex protocol when available,
-  complete `render.log`, generated edit handoff, and returned outputs.
-- Prefer `run_summary.md` when an agent needs quick context. Read the raw trace or
-  protocol only to investigate a specific decision, tool call, or failure.
-- Pin valuable successes and representative failures before cleanup. Never
-  delete a pinned run, and never delete an active lane.
 
 ## Change workflow
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,6 +31,7 @@ These are the things where deviation produces silent failures or broken output. 
 10. **Parallel sub-agents for multiple animations.** Never sequential. Spawn N at once via the `Agent` tool; total wall time ≈ slowest one.
 11. **Strategy confirmation before execution.** Never touch the cut until the user has approved the plain-English plan.
 12. **All session outputs in `<videos_dir>/edit/`.** Never write inside the `video-use/` project directory.
+13. **Captions transcribe audible speech only.** Every cue must come from timestamped human or generated speech. Music/SFX-only and silent videos have no subtitle track, no `captions` block, and no baked caption rail. Marketing copy is designed scene typography, never a fabricated transcript.
 
 Everything else in this document is a worked example. Deviate whenever the material calls for it.
 
@@ -48,7 +49,7 @@ The skill lives in `video-use/`. User footage lives wherever they put it. All se
     ├── transcripts/<name>.json  ← cached raw Scribe JSON
     ├── animations/slot_<id>/    ← per-animation source + render + reasoning
     ├── clips_graded/            ← per-segment extracts with grade + fades
-    ├── master.srt               ← output-timeline subtitles
+    ├── master.srt/master.ass    ← output-timeline subtitles
     ├── downloads/               ← yt-dlp outputs
     ├── verify/                  ← debug frames / timeline PNGs
     ├── preview.mp4
@@ -60,7 +61,8 @@ The skill lives in `video-use/`. User footage lives wherever they put it. All se
 First-time install lives in `install.md` (clone, deps, ffmpeg, skill registration, API key). Don't re-run it every session; on cold start just verify:
 
 - `ELEVENLABS_API_KEY` resolves — either in the environment or in `.env` at the video-use repo root. If missing, ask the user to paste one and write it to `.env` (never to the user's `<videos_dir>`).
-- `ffmpeg` + `ffprobe` on PATH.
+- `ffmpeg` + `ffprobe` on PATH. Caption burn-in requires libass; on macOS,
+  `render.py` automatically falls back to Homebrew's `ffmpeg-full` keg.
 - Python deps installed (`uv sync` or `pip install -e .` inside the repo).
 - Node.js + npm available if the session needs HyperFrames or Remotion slots. HyperFrames currently requires Node.js 22+.
 - `yt-dlp`, HyperFrames, Remotion, Manim installed only on first use.
@@ -75,7 +77,8 @@ Helpers (`helpers/transcribe.py`, `helpers/render.py`, etc.) live alongside this
 - **`transcribe_batch.py <videos_dir>`** — 4-worker parallel transcription. Use for multi-take.
 - **`pack_transcripts.py --edit-dir <dir>`** — `transcripts/*.json` → `takes_packed.md` (phrase-level, break on silence ≥ 0.5s).
 - **`timeline_view.py <video> <start> <end>`** — filmstrip + waveform PNG. On-demand visual drill-down. **Not a scan tool** — use it at decision points, not constantly.
-- **`render.py <edl.json> -o <out>`** — per-segment extract → concat → overlays (PTS-shifted) → subtitles LAST. `--preview` for 720p fast. `--build-subtitles` to generate master.srt inline.
+- **`captions.py <alignment.json> -o master.ass`** — convert ElevenLabs character timestamps or generic word timestamps into compact captions inside a bottom safe rail.
+- **`render.py <edl.json> -o <out>`** — per-segment extract → concat → overlays (PTS-shifted) → subtitles LAST. `--preview` for an evaluable 1080p render. `--all-deliverables` renders every declared aspect/loudness target. `--preflight-overlays` checks overlay placement before a full render. `--build-subtitles` generates master.srt inline.
 - **`grade.py <in> -o <out>`** — ffmpeg filter chain grade. Presets + `--filter '<raw>'` for custom.
 
 For animations, create `<edit>/animations/slot_<id>/` with `Bash` and spawn a sub-agent via the `Agent` tool.
@@ -93,6 +96,7 @@ For animations, create `<edit>/animations/slot_<id>/` with `Bash` and spawn a su
    - Waveform spike at the boundary (audio pop that slipped past the 30ms fade)
    - Subtitle hidden behind an overlay (Rule 1 violation)
    - Overlay misaligned or showing wrong frames (Rule 4 violation)
+   - Captions without matching audible words, or speech captions with missing words
 
    Also sample: first 2s, last 2s, and 2–3 mid-points — check grade consistency, subtitle readability, overall coherence. Run `ffprobe` on the output to verify duration matches the EDL expectation.
 
@@ -176,6 +180,15 @@ For anything else — portraiture, nature, product, music video, documentary —
 Hard rules: apply **per-segment during extraction** (not post-concat, which re-encodes twice). Never go aggressive without testing skin tones.
 
 ## Subtitles (when requested)
+
+First verify that the final audio contains audible speech and that timestamped
+transcript or alignment JSON exists. Subtitle text must be derived from those
+spoken words. Never invent caption sentences to summarize a music-only video.
+When captions are used, EDL version 2 requires `captions.provenance`: use
+`source_transcript` for recorded speech, `narration_alignment` for generated
+voiceover, or `provided_transcript` for a transcript supplied with the project.
+For generated narration, convert the alignment with `helpers/captions.py`, which
+writes `.ass` cues inside the bottom caption rail declared as `captions.safe_region`.
 
 Subtitles have three dimensions worth reasoning about: **chunking** (1/2/3/sentence per line), **case** (UPPER/Title/Natural), and **placement** (margin from bottom). The right combo depends on content.
 
@@ -269,7 +282,7 @@ Match the source unless the user asked for something specific. Common targets: `
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "sources": {"C0103": "/abs/path/C0103.MP4", "C0108": "/abs/path/C0108.MP4"},
   "ranges": [
     {"source": "C0103", "start": 2.42, "end": 6.85,
@@ -279,14 +292,41 @@ Match the source unless the user asked for something specific. Common targets: `
   ],
   "grade": "warm_cinematic",
   "overlays": [
-    {"file": "edit/animations/slot_1/render.mp4", "start_in_output": 0.0, "duration": 5.0}
+    {"id": "slot_1", "file": "animations/slot_1/render.mp4",
+     "start_in_output": 0.0, "duration": 5.0, "composition": "cutaway", "fit": "cover"},
+    {"id": "illustration_02", "file": "animations/slot_2/render.mp4",
+     "start_in_output": 12.0, "duration": 4.0,
+     "rect": {"x": 0.04, "y": 0.10, "width": 0.44, "height": 0.66}}
   ],
-  "subtitles": "edit/master.srt",
+  "protected_regions": [
+    {"owner": "base_matrix", "start_in_output": 30.0, "duration": 8.0,
+     "rect": {"x": 0.08, "y": 0.18, "width": 0.84, "height": 0.56}}
+  ],
+  "subtitles": "master.ass",
+  "captions": {
+    "provenance": {
+      "kind": "source_transcript",
+      "files": ["transcripts/C0103.json", "transcripts/C0108.json"]
+    },
+    "safe_region": {"x": 0.0, "y": 0.84, "width": 1.0, "height": 0.16}
+  },
   "total_duration_s": 87.4
 }
 ```
 
-`grade` is a preset name or raw ffmpeg filter. `overlays` are rendered animation clips. `subtitles` is optional and applied LAST.
+`grade` is a preset name or raw ffmpeg filter. Relative `file` and `subtitles`
+paths resolve from the EDL's directory. Overlay and protected-region rectangles
+use normalized frame coordinates; entries without `composition`, `layout`, or
+`rect` keep legacy full-frame behavior, but new explainer overlays should declare
+a composition. `.ass` subtitle styles are preserved; SRT receives the default
+force style. Subtitles are always applied LAST. Version 2 rejects subtitle or
+caption declarations without timestamped speech evidence. Version 1 remains
+renderable for legacy projects, but new agent-authored handoffs must use
+version 2.
+
+Read `references/overlays.md` for compositions, layouts, protected regions, and
+the overlay preflight gate. Read `references/deliverables.md` for multi-format
+outputs, reframe tracks, and per-deliverable loudness targets.
 
 ## Memory — `project.md`
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -49,7 +49,7 @@ The skill lives in `video-use/`. User footage lives wherever they put it. All se
     ├── transcripts/<name>.json  ← cached raw Scribe JSON
     ├── animations/slot_<id>/    ← per-animation source + render + reasoning
     ├── clips_graded/            ← per-segment extracts with grade + fades
-    ├── master.srt/master.ass    ← output-timeline subtitles
+    ├── master.srt | master.ass  ← output-timeline subtitles
     ├── downloads/               ← yt-dlp outputs
     ├── verify/                  ← debug frames / timeline PNGs
     ├── preview.mp4

--- a/helpers/captions.py
+++ b/helpers/captions.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 from pathlib import Path
 
@@ -21,6 +22,9 @@ PUNCTUATION_BREAKS = ".?!;:"
 
 # normalize one raw word entry into text start and end and drop entries without usable timing
 def _as_word(item: dict) -> dict[str, float | str] | None:
+    # scribe labels sound effects and music as audio events and those are never spoken words
+    if item.get("type") not in (None, "word"):
+        return None
     text = str(item.get("text") or item.get("word") or "").strip()
     if not text:
         return None
@@ -28,6 +32,8 @@ def _as_word(item: dict) -> dict[str, float | str] | None:
         start = float(item["start"])
         end = float(item["end"])
     except (KeyError, TypeError, ValueError):
+        return None
+    if not math.isfinite(start) or not math.isfinite(end) or start < 0:
         return None
     if end <= start:
         end = start + 0.08

--- a/helpers/captions.py
+++ b/helpers/captions.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python3
-# build caption safe ASS subtitle files from word timestamps or elevenlabs character alignment
-# it groups words into short readable cues and writes them into a bottom rail that matches the edl safe region
-# the command line entry point reads an alignment json file and writes one ASS file
-
 """Turn word or ElevenLabs character timestamps into caption-safe ASS subtitles.
 
 The generated captions sit inside a dedicated bottom rail. Use the same rail in
@@ -124,7 +120,7 @@ def chunk_words(
 
 
 # format seconds as an ASS timestamp with centisecond precision
-def _ass_time(seconds: float) -> str:
+def _substation_time(seconds: float) -> str:
     centiseconds = max(0, int(round(seconds * 100)))
     hours, remainder = divmod(centiseconds, 360_000)
     minutes, remainder = divmod(remainder, 6_000)
@@ -133,17 +129,17 @@ def _ass_time(seconds: float) -> str:
 
 
 # escape backslashes and braces so text is not read as ASS override tags
-def _ass_escape(text: str) -> str:
+def _substation_escape(text: str) -> str:
     return text.replace("\\", r"\\").replace("{", r"\{").replace("}", r"\}")
 
 
 # split long cue text into two balanced lines using the ASS line break
 def _wrap_two_lines(text: str, max_line_characters: int = 30) -> str:
     if len(text) <= max_line_characters:
-        return _ass_escape(text)
+        return _substation_escape(text)
     words = text.split()
     if len(words) < 2:
-        return _ass_escape(text)
+        return _substation_escape(text)
     # try every split point and pick the one with the shortest longest line and the smallest imbalance
     candidates = []
     for index in range(1, len(words)):
@@ -151,11 +147,11 @@ def _wrap_two_lines(text: str, max_line_characters: int = 30) -> str:
         right = " ".join(words[index:])
         candidates.append((max(len(left), len(right)), abs(len(left) - len(right)), left, right))
     _, _, left, right = min(candidates)
-    return f"{_ass_escape(left)}\\N{_ass_escape(right)}"
+    return f"{_substation_escape(left)}\\N{_substation_escape(right)}"
 
 
 # write cues into an ASS file with a caption style that sits inside the bottom safe rail
-def write_ass(
+def write_substation(
     cues: list[tuple[float, float, str]],
     output: Path,
     *,
@@ -188,7 +184,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         if end <= start:
             end = start + 0.25
         events.append(
-            f"Dialogue: 0,{_ass_time(start)},{_ass_time(end)},Caption,,0,0,0,,"
+            f"Dialogue: 0,{_substation_time(start)},{_substation_time(end)},Caption,,0,0,0,,"
             f"{_wrap_two_lines(text)}"
         )
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -216,7 +212,7 @@ def main() -> None:
         max_words=max(1, args.max_words),
         max_characters=max(12, args.max_characters),
     )
-    write_ass(
+    write_substation(
         cues,
         args.output,
         width=args.width,

--- a/helpers/captions.py
+++ b/helpers/captions.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Turn word or ElevenLabs character timestamps into caption-safe ASS subtitles.
+
+The generated captions sit inside a dedicated bottom rail. Use the same rail in
+the EDL's ``captions.safe_region`` so render.py can reject colliding overlays.
+
+Usage:
+    python helpers/captions.py alignment.json -o master.ass
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+PUNCTUATION_BREAKS = ".?!;:"
+
+
+def _as_word(item: dict) -> dict[str, float | str] | None:
+    text = str(item.get("text") or item.get("word") or "").strip()
+    if not text:
+        return None
+    try:
+        start = float(item["start"])
+        end = float(item["end"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if end <= start:
+        end = start + 0.08
+    return {"text": text, "start": start, "end": end}
+
+
+def _words_from_char_alignment(alignment: dict) -> list[dict[str, float | str]]:
+    characters = alignment.get("characters") or []
+    starts = alignment.get("character_start_times_seconds") or []
+    ends = alignment.get("character_end_times_seconds") or []
+    if not (len(characters) == len(starts) == len(ends)):
+        raise ValueError("ElevenLabs character alignment arrays have different lengths")
+
+    words: list[dict[str, float | str]] = []
+    buffer: list[str] = []
+    word_start: float | None = None
+    word_end: float | None = None
+
+    def flush() -> None:
+        nonlocal buffer, word_start, word_end
+        text = "".join(buffer).strip()
+        if text and word_start is not None and word_end is not None:
+            words.append({"text": text, "start": word_start, "end": word_end})
+        buffer = []
+        word_start = None
+        word_end = None
+
+    for char, start, end in zip(characters, starts, ends):
+        if str(char).isspace():
+            flush()
+            continue
+        if word_start is None:
+            word_start = float(start)
+        buffer.append(str(char))
+        word_end = float(end)
+    flush()
+    return words
+
+
+def load_words(payload: dict) -> list[dict[str, float | str]]:
+    """Read a generic word list or an ElevenLabs timestamp response."""
+    for key in ("normalized_alignment", "alignment"):
+        alignment = payload.get(key)
+        if isinstance(alignment, dict) and alignment.get("characters") is not None:
+            words = _words_from_char_alignment(alignment)
+            if words:
+                return words
+
+    raw_words = payload.get("words")
+    if isinstance(raw_words, list):
+        words = [word for item in raw_words if isinstance(item, dict) if (word := _as_word(item))]
+        if words:
+            return words
+    raise ValueError("expected ElevenLabs alignment data or a words array")
+
+
+def chunk_words(
+    words: list[dict[str, float | str]],
+    *,
+    max_words: int = 6,
+    max_characters: int = 44,
+) -> list[tuple[float, float, str]]:
+    """Create short, readable cues with punctuation-aware boundaries."""
+    cues: list[tuple[float, float, str]] = []
+    current: list[dict[str, float | str]] = []
+
+    def flush() -> None:
+        nonlocal current
+        if not current:
+            return
+        text = re.sub(r"\s+", " ", " ".join(str(word["text"]) for word in current)).strip()
+        cues.append((float(current[0]["start"]), float(current[-1]["end"]), text))
+        current = []
+
+    for word in words:
+        proposed = " ".join(str(item["text"]) for item in [*current, word])
+        if current and (len(current) >= max_words or len(proposed) > max_characters):
+            flush()
+        current.append(word)
+        if str(word["text"])[-1:] in PUNCTUATION_BREAKS:
+            flush()
+    flush()
+    return cues
+
+
+def _ass_time(seconds: float) -> str:
+    centiseconds = max(0, int(round(seconds * 100)))
+    hours, remainder = divmod(centiseconds, 360_000)
+    minutes, remainder = divmod(remainder, 6_000)
+    secs, cs = divmod(remainder, 100)
+    return f"{hours}:{minutes:02d}:{secs:02d}.{cs:02d}"
+
+
+def _ass_escape(text: str) -> str:
+    return text.replace("\\", r"\\").replace("{", r"\{").replace("}", r"\}")
+
+
+def _wrap_two_lines(text: str, max_line_characters: int = 30) -> str:
+    if len(text) <= max_line_characters:
+        return _ass_escape(text)
+    words = text.split()
+    if len(words) < 2:
+        return _ass_escape(text)
+    candidates = []
+    for index in range(1, len(words)):
+        left = " ".join(words[:index])
+        right = " ".join(words[index:])
+        candidates.append((max(len(left), len(right)), abs(len(left) - len(right)), left, right))
+    _, _, left, right = min(candidates)
+    return f"{_ass_escape(left)}\\N{_ass_escape(right)}"
+
+
+def write_ass(
+    cues: list[tuple[float, float, str]],
+    output: Path,
+    *,
+    width: int = 1920,
+    height: int = 1080,
+    safe_bottom: float = 0.16,
+    font: str = "Helvetica",
+    font_size: int = 42,
+) -> None:
+    if not 0.10 <= safe_bottom <= 0.35:
+        raise ValueError("safe_bottom must be between 0.10 and 0.35")
+    margin_v = max(28, int(height * safe_bottom * 0.22))
+    header = f"""[Script Info]
+ScriptType: v4.00+
+PlayResX: {width}
+PlayResY: {height}
+ScaledBorderAndShadow: yes
+WrapStyle: 2
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Caption,{font},{font_size},&H00FFFFFF,&H00FFFFFF,&H00101827,&HC0111728,-1,0,0,0,100,100,0,0,3,2,0,2,72,72,{margin_v},1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+    events = []
+    for start, end, text in cues:
+        if end <= start:
+            end = start + 0.25
+        events.append(
+            f"Dialogue: 0,{_ass_time(start)},{_ass_time(end)},Caption,,0,0,0,,"
+            f"{_wrap_two_lines(text)}"
+        )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(header + "\n".join(events) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("alignment", type=Path, help="ElevenLabs response or generic words JSON")
+    parser.add_argument("-o", "--output", type=Path, required=True, help="Output .ass path")
+    parser.add_argument("--max-words", type=int, default=6)
+    parser.add_argument("--max-characters", type=int, default=44)
+    parser.add_argument("--width", type=int, default=1920)
+    parser.add_argument("--height", type=int, default=1080)
+    parser.add_argument("--safe-bottom", type=float, default=0.16)
+    parser.add_argument("--font", default="Helvetica")
+    parser.add_argument("--font-size", type=int, default=42)
+    args = parser.parse_args()
+
+    payload = json.loads(args.alignment.read_text())
+    words = load_words(payload)
+    cues = chunk_words(
+        words,
+        max_words=max(1, args.max_words),
+        max_characters=max(12, args.max_characters),
+    )
+    write_ass(
+        cues,
+        args.output,
+        width=args.width,
+        height=args.height,
+        safe_bottom=args.safe_bottom,
+        font=args.font,
+        font_size=args.font_size,
+    )
+    print(f"captions → {args.output} ({len(cues)} cues)")
+
+
+if __name__ == "__main__":
+    main()

--- a/helpers/captions.py
+++ b/helpers/captions.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# build caption safe ass subtitle files from word timestamps or elevenlabs character alignment
+# it groups words into short readable cues and writes them into a bottom rail that matches the edl safe region
+# the command line entry point reads an alignment json file and writes one ass file
+
 """Turn word or ElevenLabs character timestamps into caption-safe ASS subtitles.
 
 The generated captions sit inside a dedicated bottom rail. Use the same rail in
@@ -19,6 +23,7 @@ from pathlib import Path
 PUNCTUATION_BREAKS = ".?!;:"
 
 
+# normalize one raw word entry into text start and end and drop entries without usable timing
 def _as_word(item: dict) -> dict[str, float | str] | None:
     text = str(item.get("text") or item.get("word") or "").strip()
     if not text:
@@ -33,6 +38,7 @@ def _as_word(item: dict) -> dict[str, float | str] | None:
     return {"text": text, "start": start, "end": end}
 
 
+# rebuild words from elevenlabs per character timings by splitting on whitespace
 def _words_from_char_alignment(alignment: dict) -> list[dict[str, float | str]]:
     characters = alignment.get("characters") or []
     starts = alignment.get("character_start_times_seconds") or []
@@ -45,6 +51,7 @@ def _words_from_char_alignment(alignment: dict) -> list[dict[str, float | str]]:
     word_start: float | None = None
     word_end: float | None = None
 
+    # emit the buffered characters as one word and reset the buffer
     def flush() -> None:
         nonlocal buffer, word_start, word_end
         text = "".join(buffer).strip()
@@ -66,6 +73,7 @@ def _words_from_char_alignment(alignment: dict) -> list[dict[str, float | str]]:
     return words
 
 
+# accept either an elevenlabs alignment payload or a plain words array and return timed words
 def load_words(payload: dict) -> list[dict[str, float | str]]:
     """Read a generic word list or an ElevenLabs timestamp response."""
     for key in ("normalized_alignment", "alignment"):
@@ -83,6 +91,7 @@ def load_words(payload: dict) -> list[dict[str, float | str]]:
     raise ValueError("expected ElevenLabs alignment data or a words array")
 
 
+# group timed words into short cues that break on punctuation and word or character limits
 def chunk_words(
     words: list[dict[str, float | str]],
     *,
@@ -93,6 +102,7 @@ def chunk_words(
     cues: list[tuple[float, float, str]] = []
     current: list[dict[str, float | str]] = []
 
+    # turn the current word group into one cue and start a new group
     def flush() -> None:
         nonlocal current
         if not current:
@@ -103,6 +113,7 @@ def chunk_words(
 
     for word in words:
         proposed = " ".join(str(item["text"]) for item in [*current, word])
+        # flush before adding this word when the group would exceed the word or character limit
         if current and (len(current) >= max_words or len(proposed) > max_characters):
             flush()
         current.append(word)
@@ -112,6 +123,7 @@ def chunk_words(
     return cues
 
 
+# format seconds as an ass timestamp with centisecond precision
 def _ass_time(seconds: float) -> str:
     centiseconds = max(0, int(round(seconds * 100)))
     hours, remainder = divmod(centiseconds, 360_000)
@@ -120,16 +132,19 @@ def _ass_time(seconds: float) -> str:
     return f"{hours}:{minutes:02d}:{secs:02d}.{cs:02d}"
 
 
+# escape backslashes and braces so text is not read as ass override tags
 def _ass_escape(text: str) -> str:
     return text.replace("\\", r"\\").replace("{", r"\{").replace("}", r"\}")
 
 
+# split long cue text into two balanced lines using the ass line break
 def _wrap_two_lines(text: str, max_line_characters: int = 30) -> str:
     if len(text) <= max_line_characters:
         return _ass_escape(text)
     words = text.split()
     if len(words) < 2:
         return _ass_escape(text)
+    # try every split point and pick the one with the shortest longest line and the smallest imbalance
     candidates = []
     for index in range(1, len(words)):
         left = " ".join(words[:index])
@@ -139,6 +154,7 @@ def _wrap_two_lines(text: str, max_line_characters: int = 30) -> str:
     return f"{_ass_escape(left)}\\N{_ass_escape(right)}"
 
 
+# write cues into an ass file with a caption style that sits inside the bottom safe rail
 def write_ass(
     cues: list[tuple[float, float, str]],
     output: Path,
@@ -151,6 +167,7 @@ def write_ass(
 ) -> None:
     if not 0.10 <= safe_bottom <= 0.35:
         raise ValueError("safe_bottom must be between 0.10 and 0.35")
+    # scale the vertical margin with the safe rail while keeping a floor of 28 pixels
     margin_v = max(28, int(height * safe_bottom * 0.22))
     header = f"""[Script Info]
 ScriptType: v4.00+
@@ -178,6 +195,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
     output.write_text(header + "\n".join(events) + "\n")
 
 
+# command line entry point that reads alignment json and writes an ass file
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("alignment", type=Path, help="ElevenLabs response or generic words JSON")

--- a/helpers/captions.py
+++ b/helpers/captions.py
@@ -188,7 +188,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             f"{_wrap_two_lines(text)}"
         )
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(header + "\n".join(events) + "\n")
+    output.write_text(header + "\n".join(events) + "\n", encoding="utf-8")
 
 
 # command line entry point that reads alignment json and writes an ASS file

--- a/helpers/captions.py
+++ b/helpers/captions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-# build caption safe ass subtitle files from word timestamps or elevenlabs character alignment
+# build caption safe ASS subtitle files from word timestamps or elevenlabs character alignment
 # it groups words into short readable cues and writes them into a bottom rail that matches the edl safe region
-# the command line entry point reads an alignment json file and writes one ass file
+# the command line entry point reads an alignment json file and writes one ASS file
 
 """Turn word or ElevenLabs character timestamps into caption-safe ASS subtitles.
 
@@ -123,7 +123,7 @@ def chunk_words(
     return cues
 
 
-# format seconds as an ass timestamp with centisecond precision
+# format seconds as an ASS timestamp with centisecond precision
 def _ass_time(seconds: float) -> str:
     centiseconds = max(0, int(round(seconds * 100)))
     hours, remainder = divmod(centiseconds, 360_000)
@@ -132,12 +132,12 @@ def _ass_time(seconds: float) -> str:
     return f"{hours}:{minutes:02d}:{secs:02d}.{cs:02d}"
 
 
-# escape backslashes and braces so text is not read as ass override tags
+# escape backslashes and braces so text is not read as ASS override tags
 def _ass_escape(text: str) -> str:
     return text.replace("\\", r"\\").replace("{", r"\{").replace("}", r"\}")
 
 
-# split long cue text into two balanced lines using the ass line break
+# split long cue text into two balanced lines using the ASS line break
 def _wrap_two_lines(text: str, max_line_characters: int = 30) -> str:
     if len(text) <= max_line_characters:
         return _ass_escape(text)
@@ -154,7 +154,7 @@ def _wrap_two_lines(text: str, max_line_characters: int = 30) -> str:
     return f"{_ass_escape(left)}\\N{_ass_escape(right)}"
 
 
-# write cues into an ass file with a caption style that sits inside the bottom safe rail
+# write cues into an ASS file with a caption style that sits inside the bottom safe rail
 def write_ass(
     cues: list[tuple[float, float, str]],
     output: Path,
@@ -195,7 +195,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
     output.write_text(header + "\n".join(events) + "\n")
 
 
-# command line entry point that reads alignment json and writes an ass file
+# command line entry point that reads alignment json and writes an ASS file
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("alignment", type=Path, help="ElevenLabs response or generic words JSON")

--- a/helpers/edl.py
+++ b/helpers/edl.py
@@ -1,3 +1,7 @@
+# validation and normalization for the public edl contract
+# it checks sources ranges caption provenance and deliverable targets before anything expensive runs
+# nothing here imports the renderer or the gui so remote workers can reuse it
+
 """Validation and normalization for the public video-use EDL contract.
 
 This module deliberately has no renderer or GUI dependencies. Local tools,
@@ -15,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 
+# error type raised when an edl cannot be rendered deterministically
 class EDLValidationError(ValueError):
     """Raised when an EDL cannot produce a deterministic video output."""
 
@@ -28,11 +33,13 @@ _CAPTION_PROVENANCE_KINDS = {
 }
 
 
+# resolve a path relative to the edit directory unless it is already absolute
 def _resolve_path(value: str, edit_dir: Path) -> Path:
     path = Path(value).expanduser()
     return path.resolve() if path.is_absolute() else (edit_dir / path).resolve()
 
 
+# coerce a value to float and raise a validation error with the field label on failure
 def _number(value: Any, label: str) -> float:
     try:
         result = float(value)
@@ -41,6 +48,7 @@ def _number(value: Any, label: str) -> float:
     return result
 
 
+# check whether transcript or alignment json contains at least one word with valid timing
 def _has_timed_speech(payload: Any) -> bool:
     """Return whether JSON evidence contains at least one timestamped word."""
 
@@ -60,6 +68,7 @@ def _has_timed_speech(payload: Any) -> bool:
             if text and end > start >= 0:
                 return True
 
+    # fall back to elevenlabs character alignment when no words array has timing
     for key in ("normalized_alignment", "alignment"):
         alignment = payload.get(key)
         if not isinstance(alignment, dict):
@@ -84,6 +93,7 @@ def _has_timed_speech(payload: Any) -> bool:
     return False
 
 
+# collect problems with the captions block such as missing provenance or evidence without spoken words
 def _caption_contract_problems(
     edl: dict[str, Any],
     edit_dir: Path,
@@ -137,6 +147,7 @@ def _caption_contract_problems(
         if evidence_path.suffix.casefold() != ".json":
             problems.append(f"{label} must reference timestamped JSON evidence")
             continue
+        # the rendered subtitle file cannot vouch for itself
         if subtitle_path is not None and evidence_path == subtitle_path:
             problems.append(f"{label} cannot reuse the rendered subtitle file as evidence")
             continue
@@ -160,9 +171,11 @@ def _caption_contract_problems(
     return problems
 
 
+# read width and height from explicit fields or a resolution string and enforce even sizes
 def _dimensions(item: dict[str, Any], label: str) -> tuple[int, int]:
     width = item.get("width")
     height = item.get("height")
+    # accept a resolution string such as 1080x1920 when explicit fields are missing
     if width is None or height is None:
         match = _RESOLUTION.fullmatch(str(item.get("resolution") or ""))
         if match:
@@ -180,6 +193,7 @@ def _dimensions(item: dict[str, Any], label: str) -> tuple[int, int]:
     return width_i, height_i
 
 
+# parse an fps value into a canonical ffmpeg rational string
 def _frame_rate(value: Any, label: str) -> str:
     text = str(value)
     try:
@@ -191,6 +205,7 @@ def _frame_rate(value: Any, label: str) -> str:
     return f"{rate.numerator}/{rate.denominator}"
 
 
+# read loudness targets from several accepted aliases and validate their ranges
 def _loudness(item: dict[str, Any], label: str) -> dict[str, float]:
     raw = item.get("loudness")
     audio = item.get("audio") if isinstance(item.get("audio"), dict) else {}
@@ -228,14 +243,17 @@ def _loudness(item: dict[str, Any], label: str) -> dict[str, float]:
     }
 
 
+# resolve the reframe settings for one deliverable from its own block or the shared edl block
 def _reframe_for(edl: dict[str, Any], item: dict[str, Any], deliverable_id: str) -> dict[str, Any]:
     raw = item.get("reframe")
     if raw is None:
+        # a shared reframe block without a mode is keyed by deliverable id
         shared = edl.get("reframe")
         if isinstance(shared, dict) and "mode" not in shared:
             raw = shared.get(deliverable_id)
         else:
             raw = shared
+    # a reframe_track alias on the deliverable selects a named track
     if raw is not None and item.get("reframe_track"):
         raw = copy.deepcopy(raw)
         if isinstance(raw, dict):
@@ -247,6 +265,7 @@ def _reframe_for(edl: dict[str, Any], item: dict[str, Any], deliverable_id: str)
     if not isinstance(raw, dict):
         raise EDLValidationError(f"deliverable '{deliverable_id}' reframe must be an object")
     result = copy.deepcopy(raw)
+    # map legacy mode and asset aliases onto the canonical names
     mode = str(result.get("mode") or result.get("strategy") or "cover").casefold()
     if mode == "center":
         mode = "cover"
@@ -276,6 +295,7 @@ def _reframe_for(edl: dict[str, Any], item: dict[str, Any], deliverable_id: str)
     return result
 
 
+# turn the deliverables list or object into validated entries with canonical fields and output paths
 def normalize_deliverables(
     edl: dict[str, Any],
     edit_dir: Path,
@@ -338,6 +358,7 @@ def normalize_deliverables(
         if sample_rate != 48_000:
             raise EDLValidationError(f"{label} currently supports only 48000 Hz audio")
         declared_file = str(item.get("file") or f"deliverables/{deliverable_id}.mp4")
+        # an output directory override replaces the declared file name
         output_path = (
             (output_dir / f"{deliverable_id}.mp4").resolve()
             if output_dir is not None
@@ -363,6 +384,7 @@ def normalize_deliverables(
     return normalized
 
 
+# load just enough of a track reference to tell whether the named track has keyframes
 def _track_keyframes(reframe: dict[str, Any], edit_dir: Path) -> list[Any] | None:
     """Read enough of a track reference to reject missing or empty named tracks."""
     raw = reframe.get("keyframes")
@@ -375,6 +397,7 @@ def _track_keyframes(reframe: dict[str, Any], edit_dir: Path) -> list[Any] | Non
         return None
     track_path = _resolve_path(track_value, edit_dir)
     payload = json.loads(track_path.read_text(encoding="utf-8"))
+    # named track files need a track_id to pick one track
     if isinstance(payload, dict) and isinstance(payload.get("tracks"), dict):
         track_id = reframe.get("track_id")
         return payload["tracks"].get(str(track_id)) if track_id else None
@@ -385,6 +408,7 @@ def _track_keyframes(reframe: dict[str, Any], edit_dir: Path) -> list[Any] | Non
     return raw if isinstance(raw, list) else None
 
 
+# run every structural check on an edl and raise one error listing all problems
 def validate_edl(
     edl: dict[str, Any],
     edit_dir: Path,
@@ -405,6 +429,7 @@ def validate_edl(
         version = 0
     if version < 1:
         problems.append("version must be a positive integer")
+    # version two and newer enforce caption provenance unless the caller overrides
     strict_captions = (
         version >= 2
         if require_caption_provenance is None
@@ -466,6 +491,7 @@ def validate_edl(
         for deliverable in deliverables:
             reframe = deliverable["reframe"]
             track_value = reframe.get("track_file") or reframe.get("track")
+            # tracked deliverables must point at readable non empty keyframes
             if check_files and reframe["mode"] == "track":
                 if isinstance(track_value, str) and not _resolve_path(
                     track_value, edit_dir

--- a/helpers/edl.py
+++ b/helpers/edl.py
@@ -1,11 +1,11 @@
 # validation and normalization for the public edl contract
 # it checks sources ranges caption provenance and deliverable targets before anything expensive runs
-# nothing here imports the renderer or the gui so remote workers can reuse it
+# nothing here imports the renderer so any tool can validate an edit before rendering
 
 """Validation and normalization for the public video-use EDL contract.
 
-This module deliberately has no renderer or GUI dependencies. Local tools,
-remote workers, and third-party integrations can all reject an incomplete edit
+This module deliberately has no renderer dependencies. Local tools and
+third-party integrations can all reject an incomplete edit
 before spending time uploading media or starting an ffmpeg render.
 """
 

--- a/helpers/edl.py
+++ b/helpers/edl.py
@@ -378,6 +378,14 @@ def normalize_deliverables(
             }
         )
         normalized.append(item)
+    # two deliverables writing the same file would silently overwrite each other
+    seen: dict[Path, str] = {}
+    for item in normalized:
+        previous = seen.setdefault(item["output_path"], item["id"])
+        if previous != item["id"]:
+            raise EDLValidationError(
+                f"deliverables '{previous}' and '{item['id']}' resolve to the same output file"
+            )
     return normalized
 
 
@@ -423,10 +431,14 @@ def validate_edl(
     # a non object root cannot be inspected so it is reported instead of crashing below
     if not isinstance(edl, dict):
         raise EDLValidationError("EDL is not renderable:\n- edl must be a JSON object")
-    try:
-        version = int(edl.get("version", 1))
-    except (TypeError, ValueError):
+    raw_version = edl.get("version", 1)
+    # a fractional version is malformed rather than a legacy version so it must not truncate
+    if isinstance(raw_version, bool) or not (
+        isinstance(raw_version, int) or (isinstance(raw_version, float) and raw_version.is_integer())
+    ):
         version = 0
+    else:
+        version = int(raw_version)
     if version < 1:
         problems.append("version must be a positive integer")
     # version two and newer enforce caption provenance unless the caller overrides
@@ -476,7 +488,8 @@ def validate_edl(
             problems.append(f"range {index} must be an object")
             continue
         source_id = value.get("source")
-        if source_id not in sources:
+        # only a string can name a source so anything else is reported instead of crashing the lookup
+        if not isinstance(source_id, str) or source_id not in sources:
             problems.append(f"range {index} references unknown source '{source_id}'")
         try:
             start = float(value["start"])

--- a/helpers/edl.py
+++ b/helpers/edl.py
@@ -1,0 +1,496 @@
+"""Validation and normalization for the public video-use EDL contract.
+
+This module deliberately has no renderer or GUI dependencies. Local tools,
+remote workers, and third-party integrations can all reject an incomplete edit
+before spending time uploading media or starting an ffmpeg render.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+
+class EDLValidationError(ValueError):
+    """Raised when an EDL cannot produce a deterministic video output."""
+
+
+_DELIVERABLE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*")
+_RESOLUTION = re.compile(r"\s*(\d+)\s*[xX×]\s*(\d+)\s*")
+_CAPTION_PROVENANCE_KINDS = {
+    "source_transcript",
+    "narration_alignment",
+    "provided_transcript",
+}
+
+
+def _resolve_path(value: str, edit_dir: Path) -> Path:
+    path = Path(value).expanduser()
+    return path.resolve() if path.is_absolute() else (edit_dir / path).resolve()
+
+
+def _number(value: Any, label: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise EDLValidationError(f"{label} must be numeric") from exc
+    return result
+
+
+def _has_timed_speech(payload: Any) -> bool:
+    """Return whether JSON evidence contains at least one timestamped word."""
+
+    if not isinstance(payload, dict):
+        return False
+    raw_words = payload.get("words")
+    if isinstance(raw_words, list):
+        for item in raw_words:
+            if not isinstance(item, dict) or item.get("type") not in (None, "word"):
+                continue
+            text = str(item.get("text") or item.get("word") or "").strip()
+            try:
+                start = float(item["start"])
+                end = float(item["end"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if text and end > start >= 0:
+                return True
+
+    for key in ("normalized_alignment", "alignment"):
+        alignment = payload.get(key)
+        if not isinstance(alignment, dict):
+            continue
+        characters = alignment.get("characters")
+        starts = alignment.get("character_start_times_seconds")
+        ends = alignment.get("character_end_times_seconds")
+        if not all(isinstance(value, list) for value in (characters, starts, ends)):
+            continue
+        if not (len(characters) == len(starts) == len(ends)):
+            continue
+        for character, start_value, end_value in zip(characters, starts, ends):
+            if not str(character).strip():
+                continue
+            try:
+                start = float(start_value)
+                end = float(end_value)
+            except (TypeError, ValueError):
+                continue
+            if end > start >= 0:
+                return True
+    return False
+
+
+def _caption_contract_problems(
+    edl: dict[str, Any],
+    edit_dir: Path,
+    *,
+    check_files: bool,
+) -> list[str]:
+    """Validate that captions are backed by timestamped audible speech."""
+
+    subtitles = edl.get("subtitles")
+    captions = edl.get("captions")
+    if not subtitles and captions is None:
+        return []
+
+    problems: list[str] = []
+    if subtitles is not None and (not isinstance(subtitles, str) or not subtitles.strip()):
+        problems.append("subtitles must be a non-empty file path")
+        subtitles = None
+    if not isinstance(captions, dict):
+        problems.append(
+            "subtitles require a captions object with captions.provenance backed by "
+            "timestamped audible speech"
+        )
+        return problems
+
+    provenance = captions.get("provenance")
+    if not isinstance(provenance, dict):
+        problems.append(
+            "captions.provenance is required; captions may only represent audible speech"
+        )
+        return problems
+
+    kind = str(provenance.get("kind") or "")
+    if kind not in _CAPTION_PROVENANCE_KINDS:
+        choices = ", ".join(sorted(_CAPTION_PROVENANCE_KINDS))
+        problems.append(f"captions.provenance.kind must be one of: {choices}")
+
+    raw_files = provenance.get("files")
+    if not isinstance(raw_files, list) or not raw_files:
+        problems.append(
+            "captions.provenance.files must list timestamped transcript or alignment JSON"
+        )
+        return problems
+
+    subtitle_path = _resolve_path(subtitles, edit_dir) if isinstance(subtitles, str) else None
+    for index, value in enumerate(raw_files):
+        label = f"captions.provenance.files[{index}]"
+        if not isinstance(value, str) or not value.strip():
+            problems.append(f"{label} must be a non-empty JSON file path")
+            continue
+        evidence_path = _resolve_path(value, edit_dir)
+        if evidence_path.suffix.casefold() != ".json":
+            problems.append(f"{label} must reference timestamped JSON evidence")
+            continue
+        if subtitle_path is not None and evidence_path == subtitle_path:
+            problems.append(f"{label} cannot reuse the rendered subtitle file as evidence")
+            continue
+        if not check_files:
+            continue
+        if not evidence_path.is_file():
+            problems.append(f"caption evidence file does not exist: {evidence_path}")
+            continue
+        try:
+            payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            problems.append(f"caption evidence could not be read: {evidence_path}: {exc}")
+            continue
+        if not _has_timed_speech(payload):
+            problems.append(
+                f"caption evidence contains no timestamped spoken words: {evidence_path}"
+            )
+
+    if check_files and subtitle_path is not None and not subtitle_path.is_file():
+        problems.append(f"subtitles file does not exist: {subtitle_path}")
+    return problems
+
+
+def _dimensions(item: dict[str, Any], label: str) -> tuple[int, int]:
+    width = item.get("width")
+    height = item.get("height")
+    if width is None or height is None:
+        match = _RESOLUTION.fullmatch(str(item.get("resolution") or ""))
+        if match:
+            width, height = match.groups()
+    try:
+        width_i, height_i = int(width), int(height)
+    except (TypeError, ValueError) as exc:
+        raise EDLValidationError(
+            f"{label} requires width and height or a resolution such as 1080x1920"
+        ) from exc
+    if width_i < 2 or height_i < 2 or width_i > 8192 or height_i > 8192:
+        raise EDLValidationError(f"{label} dimensions must be between 2 and 8192 pixels")
+    if width_i % 2 or height_i % 2:
+        raise EDLValidationError(f"{label} width and height must be even for yuv420p output")
+    return width_i, height_i
+
+
+def _frame_rate(value: Any, label: str) -> str:
+    text = str(value)
+    try:
+        rate = Fraction(text)
+    except (ValueError, ZeroDivisionError) as exc:
+        raise EDLValidationError(f"{label} fps must be a positive number or rational") from exc
+    if rate <= 0 or rate.numerator > 2_147_483_647 or rate.denominator > 2_147_483_647:
+        raise EDLValidationError(f"{label} fps must be a positive ffmpeg-compatible rate")
+    return f"{rate.numerator}/{rate.denominator}"
+
+
+def _loudness(item: dict[str, Any], label: str) -> dict[str, float]:
+    raw = item.get("loudness")
+    audio = item.get("audio") if isinstance(item.get("audio"), dict) else {}
+    if raw is None:
+        raw = audio
+    if isinstance(raw, (int, float)):
+        raw = {"integrated_lufs": raw}
+    if not isinstance(raw, dict):
+        raise EDLValidationError(f"{label} loudness must be an object or LUFS number")
+    integrated = _number(
+        raw.get(
+            "integrated_lufs",
+            raw.get(
+                "integrated_loudness_lufs",
+                item.get("loudness_lufs", item.get("target_lufs", -14.0)),
+            ),
+        ),
+        f"{label} integrated_lufs",
+    )
+    true_peak = _number(
+        raw.get("true_peak_dbtp", item.get("true_peak_dbtp", -1.0)),
+        f"{label} true_peak_dbtp",
+    )
+    lra = _number(raw.get("lra", raw.get("loudness_range_lu", 11.0)), f"{label} lra")
+    if not -70.0 <= integrated <= -5.0:
+        raise EDLValidationError(f"{label} integrated_lufs must be between -70 and -5")
+    if not -9.0 <= true_peak <= 0.0:
+        raise EDLValidationError(f"{label} true_peak_dbtp must be between -9 and 0")
+    if not 1.0 <= lra <= 50.0:
+        raise EDLValidationError(f"{label} lra must be between 1 and 50")
+    return {
+        "integrated_lufs": integrated,
+        "true_peak_dbtp": true_peak,
+        "lra": lra,
+    }
+
+
+def _reframe_for(edl: dict[str, Any], item: dict[str, Any], deliverable_id: str) -> dict[str, Any]:
+    raw = item.get("reframe")
+    if raw is None:
+        shared = edl.get("reframe")
+        if isinstance(shared, dict) and "mode" not in shared:
+            raw = shared.get(deliverable_id)
+        else:
+            raw = shared
+    if raw is not None and item.get("reframe_track"):
+        raw = copy.deepcopy(raw)
+        if isinstance(raw, dict):
+            raw["track_id"] = item["reframe_track"]
+    if raw is None:
+        raw = {"mode": "cover"}
+    if isinstance(raw, str):
+        raw = {"mode": raw}
+    if not isinstance(raw, dict):
+        raise EDLValidationError(f"deliverable '{deliverable_id}' reframe must be an object")
+    result = copy.deepcopy(raw)
+    mode = str(result.get("mode") or result.get("strategy") or "cover").casefold()
+    if mode == "center":
+        mode = "cover"
+    if mode in {"tracked", "tracked_subject", "subject_tracking", "smart_crop"}:
+        mode = "track"
+    if result.get("tracking_asset") and not (result.get("track") or result.get("track_file")):
+        result["track_file"] = result["tracking_asset"]
+    if mode not in {"cover", "contain", "track"}:
+        raise EDLValidationError(
+            f"deliverable '{deliverable_id}' reframe mode must be cover, contain, or track"
+        )
+    result["mode"] = mode
+    interpolation = str(result.get("interpolation") or "linear").casefold()
+    if interpolation not in {"linear", "smooth", "hold"}:
+        raise EDLValidationError(
+            f"deliverable '{deliverable_id}' reframe interpolation must be "
+            "linear, smooth, or hold"
+        )
+    result["interpolation"] = interpolation
+    if mode == "track" and not (
+        result.get("keyframes") or result.get("track") or result.get("track_file")
+    ):
+        raise EDLValidationError(
+            f"deliverable '{deliverable_id}' requests tracked reframing but has no "
+            "keyframes or track file"
+        )
+    return result
+
+
+def normalize_deliverables(
+    edl: dict[str, Any],
+    edit_dir: Path,
+    *,
+    output_dir: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Return validated deliverables in one canonical list representation.
+
+    Both a list and an id-keyed object are accepted so older agent-authored
+    EDLs remain easy to migrate. The returned dictionaries contain canonical
+    dimensions, fps, loudness, reframe settings, and an absolute ``output_path``.
+    """
+    raw = edl.get("deliverables")
+    if not raw:
+        return []
+    if isinstance(raw, dict):
+        entries: list[dict[str, Any]] = []
+        for deliverable_id, value in raw.items():
+            if not isinstance(value, dict):
+                raise EDLValidationError(
+                    f"deliverable '{deliverable_id}' must be an object"
+                )
+            entries.append({"id": str(deliverable_id), **value})
+    elif isinstance(raw, list):
+        entries = raw
+    else:
+        raise EDLValidationError("deliverables must be a list or id-keyed object")
+
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, value in enumerate(entries):
+        if not isinstance(value, dict):
+            raise EDLValidationError(f"deliverable {index} must be an object")
+        item = copy.deepcopy(value)
+        deliverable_id = str(item.get("id") or item.get("name") or "")
+        label = f"deliverable '{deliverable_id or index}'"
+        if not _DELIVERABLE_ID.fullmatch(deliverable_id):
+            raise EDLValidationError(
+                f"{label} id must contain only letters, numbers, underscores, or hyphens"
+            )
+        if deliverable_id in seen:
+            raise EDLValidationError(f"duplicate deliverable id '{deliverable_id}'")
+        seen.add(deliverable_id)
+        width, height = _dimensions(item, label)
+        fps = _frame_rate(item.get("fps", "30"), label)
+        video_codec = str(item.get("video_codec") or "h264").casefold()
+        if video_codec not in {"h264", "libx264", "avc"}:
+            raise EDLValidationError(f"{label} currently supports only H.264 video")
+        pixel_format = str(item.get("pixel_format") or "yuv420p").casefold()
+        if pixel_format != "yuv420p":
+            raise EDLValidationError(f"{label} currently supports only yuv420p output")
+        audio = item.get("audio") if isinstance(item.get("audio"), dict) else {}
+        audio_codec = str(audio.get("codec") or "aac").casefold()
+        if audio_codec != "aac":
+            raise EDLValidationError(f"{label} currently supports only AAC audio")
+        try:
+            sample_rate = int(audio.get("sample_rate_hz", 48_000))
+        except (TypeError, ValueError) as exc:
+            raise EDLValidationError(f"{label} audio sample_rate_hz must be an integer") from exc
+        if sample_rate != 48_000:
+            raise EDLValidationError(f"{label} currently supports only 48000 Hz audio")
+        declared_file = str(item.get("file") or f"deliverables/{deliverable_id}.mp4")
+        output_path = (
+            (output_dir / f"{deliverable_id}.mp4").resolve()
+            if output_dir is not None
+            else _resolve_path(declared_file, edit_dir)
+        )
+        if output_path.suffix.casefold() != ".mp4":
+            raise EDLValidationError(f"{label} file must use the .mp4 extension")
+        item.update(
+            {
+                "id": deliverable_id,
+                "width": width,
+                "height": height,
+                "fps": fps,
+                "video_codec": "h264",
+                "pixel_format": "yuv420p",
+                "file": declared_file,
+                "output_path": output_path,
+                "loudness": _loudness(item, label),
+                "reframe": _reframe_for(edl, item, deliverable_id),
+            }
+        )
+        normalized.append(item)
+    return normalized
+
+
+def _track_keyframes(reframe: dict[str, Any], edit_dir: Path) -> list[Any] | None:
+    """Read enough of a track reference to reject missing or empty named tracks."""
+    raw = reframe.get("keyframes")
+    if raw is None and isinstance(reframe.get("track"), list):
+        raw = reframe["track"]
+    if raw is not None:
+        return raw if isinstance(raw, list) else None
+    track_value = reframe.get("track_file") or reframe.get("track")
+    if not isinstance(track_value, str):
+        return None
+    track_path = _resolve_path(track_value, edit_dir)
+    payload = json.loads(track_path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict) and isinstance(payload.get("tracks"), dict):
+        track_id = reframe.get("track_id")
+        return payload["tracks"].get(str(track_id)) if track_id else None
+    if isinstance(payload, dict):
+        raw = payload.get("keyframes")
+    else:
+        raw = payload
+    return raw if isinstance(raw, list) else None
+
+
+def validate_edl(
+    edl: dict[str, Any],
+    edit_dir: Path,
+    *,
+    check_files: bool = True,
+    require_caption_provenance: bool | None = None,
+) -> None:
+    """Reject blocked, incomplete, or internally inconsistent edit decisions.
+
+    EDL version 2 and newer require timestamped speech evidence for captions.
+    Callers accepting freshly agent-authored handoffs may opt into the same
+    strict check for legacy-version EDLs with ``require_caption_provenance``.
+    """
+    problems: list[str] = []
+    try:
+        version = int(edl.get("version", 1))
+    except (TypeError, ValueError):
+        version = 0
+    if version < 1:
+        problems.append("version must be a positive integer")
+    strict_captions = (
+        version >= 2
+        if require_caption_provenance is None
+        else require_caption_provenance
+    )
+    if strict_captions:
+        problems.extend(
+            _caption_contract_problems(edl, edit_dir, check_files=check_files)
+        )
+    status = str(edl.get("status") or "").casefold()
+    if status.startswith("blocked") or status in {"not_ready", "incomplete"}:
+        problems.append(f"EDL status is '{edl.get('status')}'")
+    handoff = edl.get("handoff")
+    if isinstance(handoff, dict) and handoff.get("render_ready") is False:
+        reason = (
+            handoff.get("reason")
+            or handoff.get("blocked_reason")
+            or handoff.get("blocking_reason")
+        )
+        problems.append(
+            "handoff marks render_ready as false" + (f": {reason}" if reason else "")
+        )
+
+    sources = edl.get("sources")
+    ranges = edl.get("ranges")
+    if not isinstance(sources, dict) or not sources:
+        problems.append("sources must contain at least one source video")
+        sources = {}
+    if not isinstance(ranges, list) or not ranges:
+        problems.append("ranges must contain at least one playable edit range")
+        ranges = []
+
+    for source_id, value in sources.items():
+        if not isinstance(value, str) or not value.strip():
+            problems.append(f"source '{source_id}' has no file path")
+            continue
+        if check_files:
+            path = _resolve_path(value, edit_dir)
+            if not path.is_file():
+                problems.append(f"source '{source_id}' file does not exist: {path}")
+
+    for index, value in enumerate(ranges):
+        if not isinstance(value, dict):
+            problems.append(f"range {index} must be an object")
+            continue
+        source_id = value.get("source")
+        if source_id not in sources:
+            problems.append(f"range {index} references unknown source '{source_id}'")
+        try:
+            start = float(value["start"])
+            end = float(value["end"])
+            if start < 0 or end <= start:
+                raise ValueError
+        except (KeyError, TypeError, ValueError):
+            problems.append(f"range {index} requires start >= 0 and end > start")
+
+    try:
+        deliverables = normalize_deliverables(edl, edit_dir)
+        for deliverable in deliverables:
+            reframe = deliverable["reframe"]
+            track_value = reframe.get("track_file") or reframe.get("track")
+            if check_files and reframe["mode"] == "track":
+                if isinstance(track_value, str) and not _resolve_path(
+                    track_value, edit_dir
+                ).is_file():
+                    problems.append(
+                        f"deliverable '{deliverable['id']}' track file does not exist: "
+                        f"{_resolve_path(track_value, edit_dir)}"
+                    )
+                    continue
+                try:
+                    keyframes = _track_keyframes(reframe, edit_dir)
+                except (OSError, json.JSONDecodeError) as exc:
+                    problems.append(
+                        f"deliverable '{deliverable['id']}' track data could not be read: {exc}"
+                    )
+                    continue
+                if not keyframes:
+                    track_id = reframe.get("track_id")
+                    suffix = f" '{track_id}'" if track_id else ""
+                    problems.append(
+                        f"deliverable '{deliverable['id']}' tracking keyframes{suffix} are empty or missing"
+                    )
+    except EDLValidationError as exc:
+        problems.append(str(exc))
+
+    if problems:
+        formatted = "\n".join(f"- {problem}" for problem in problems)
+        raise EDLValidationError(f"EDL is not renderable:\n{formatted}")

--- a/helpers/edl.py
+++ b/helpers/edl.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import copy
 import json
+import math
 import re
 from fractions import Fraction
 from pathlib import Path
@@ -419,6 +420,9 @@ def validate_edl(
     strict check for legacy-version EDLs with ``require_caption_provenance``.
     """
     problems: list[str] = []
+    # a non object root cannot be inspected so it is reported instead of crashing below
+    if not isinstance(edl, dict):
+        raise EDLValidationError("EDL is not renderable:\n- edl must be a JSON object")
     try:
         version = int(edl.get("version", 1))
     except (TypeError, ValueError):
@@ -477,10 +481,11 @@ def validate_edl(
         try:
             start = float(value["start"])
             end = float(value["end"])
-            if start < 0 or end <= start:
+            # nan and inf compare as ordered so they need an explicit finite check
+            if not math.isfinite(start) or not math.isfinite(end) or start < 0 or end <= start:
                 raise ValueError
         except (KeyError, TypeError, ValueError):
-            problems.append(f"range {index} requires start >= 0 and end > start")
+            problems.append(f"range {index} requires finite start >= 0 and end > start")
 
     try:
         deliverables = normalize_deliverables(edl, edit_dir)

--- a/helpers/edl.py
+++ b/helpers/edl.py
@@ -1,7 +1,3 @@
-# validation and normalization for the public edl contract
-# it checks sources ranges caption provenance and deliverable targets before anything expensive runs
-# nothing here imports the renderer so any tool can validate an edit before rendering
-
 """Validation and normalization for the public video-use EDL contract.
 
 This module deliberately has no renderer dependencies. Local tools and

--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -1,3 +1,7 @@
+# color grading helper that builds ffmpeg filter strings and applies them to a video
+# it ships a few named presets and an auto mode that samples frame stats to pick a small corrective eq
+# render py imports get_preset and auto_grade_for_clip and the cli wraps the same functions
+
 """Apply a color grade to a video via ffmpeg filter chain.
 
 Two modes:
@@ -63,6 +67,7 @@ PRESETS: dict[str, str] = {
 }
 
 
+# look up the ffmpeg filter string for a named preset and fail loudly on unknown names
 def get_preset(name: str) -> str:
     """Return the ffmpeg filter string for a preset name. Empty string for 'none'."""
     if name not in PRESETS:
@@ -75,6 +80,7 @@ def get_preset(name: str) -> str:
 # -------- Auto grade (data-driven, per-clip) --------------------------------
 
 
+# run ffmpeg signalstats over a sampled range and average the luma and saturation readings into normalized stats
 def _sample_frame_stats(
     video: Path,
     start: float,
@@ -121,6 +127,7 @@ def _sample_frame_stats(
         sat_avgs: list[float] = []
         bit_depth: int = 8
 
+        # pull the numeric value after the last equals sign on a metadata line
         def _parse_value(line: str) -> float | None:
             try:
                 return float(line.rsplit("=", 1)[1])
@@ -175,6 +182,7 @@ def _sample_frame_stats(
         Path(metadata_path).unlink(missing_ok=True)
 
 
+# analyze a clip range and derive a bounded corrective eq filter with no creative color shift
 def auto_grade_for_clip(
     video: Path,
     start: float = 0.0,
@@ -271,8 +279,10 @@ def auto_grade_for_clip(
     return filter_string, stats
 
 
+# run ffmpeg to write the graded output or stream copy when the filter is empty
 def apply_grade(input_path: Path, output_path: Path, filter_string: str) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    # an empty filter means no grade so copy streams without re encoding
     if not filter_string:
         cmd = [
             "ffmpeg", "-y", "-i", str(input_path),
@@ -291,6 +301,7 @@ def apply_grade(input_path: Path, output_path: Path, filter_string: str) -> None
     subprocess.run(cmd, check=True)
 
 
+# cli entry point that handles preset listing analysis and the normal grade run
 def main() -> None:
     ap = argparse.ArgumentParser(description="Apply a color grade via ffmpeg filter chain")
     ap.add_argument("input", type=Path, nargs="?", help="Input video")

--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -1,7 +1,3 @@
-# color grading helper that builds ffmpeg filter strings and applies them to a video
-# it ships a few named presets and an auto mode that samples frame stats to pick a small corrective eq
-# render py imports get_preset and auto_grade_for_clip and the cli wraps the same functions
-
 """Apply a color grade to a video via ffmpeg filter chain.
 
 Two modes:

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -1,3 +1,7 @@
+# packs scribe word level transcript json files into one phrase level markdown document
+# words are grouped into phrases split on long silences or speaker changes and each phrase carries a start and end stamp
+# the editor sub agent reads the result to pick cuts so it favors compactness over raw detail
+
 """Pack all Scribe transcripts in <edit>/transcripts/ into one readable markdown.
 
 Groups word-level entries into phrase-level lines, breaking on any silence
@@ -21,11 +25,13 @@ import sys
 from pathlib import Path
 
 
+# render seconds as a zero padded fixed width string so stamps line up in columns
 def format_time(seconds: float) -> str:
     """Format a time in seconds as "NNN.NN" with fixed 6-char width for alignment."""
     return f"{seconds:06.2f}"
 
 
+# render a duration as seconds or minutes plus seconds for the section headers
 def format_duration(seconds: float) -> str:
     """Format a duration as "Ms" or "Mm SSs"."""
     if seconds < 60:
@@ -35,6 +41,7 @@ def format_duration(seconds: float) -> str:
     return f"{m}m {s:04.1f}s"
 
 
+# walk scribe word entries and cut them into phrases on silence gaps or speaker changes
 def group_into_phrases(
     words: list[dict],
     silence_threshold: float = 0.5,
@@ -51,6 +58,7 @@ def group_into_phrases(
     current_start: float | None = None
     current_speaker: str | None = None
 
+    # emit the current phrase if it has any visible text then reset the accumulator
     def flush() -> None:
         nonlocal current_words, current_start, current_speaker
         if not current_words:
@@ -61,6 +69,7 @@ def group_into_phrases(
             raw = (w.get("text") or "").strip()
             if not raw:
                 continue
+            # wrap audio events in parentheses unless scribe already did
             if t == "audio_event":
                 if not raw.startswith("("):
                     raw = f"({raw})"
@@ -71,7 +80,9 @@ def group_into_phrases(
             current_speaker = None
             return
         text = " ".join(text_parts)
+        # glue punctuation tokens back onto the preceding word
         text = text.replace(" ,", ",").replace(" .", ".").replace(" ?", "?").replace(" !", "!")
+        # fall back through end then start then phrase start so a missing timestamp cannot break the flush
         end_time = current_words[-1].get("end", current_words[-1].get("start", current_start or 0.0))
         phrases.append({
             "start": current_start,
@@ -122,6 +133,7 @@ def group_into_phrases(
     return phrases
 
 
+# load one transcript json and return its name duration and phrase list
 def pack_one_file(json_path: Path, silence_threshold: float) -> tuple[str, float, list[dict]]:
     """Return (header_name, duration, phrases) for one transcript file."""
     data = json.loads(json_path.read_text())
@@ -134,6 +146,7 @@ def pack_one_file(json_path: Path, silence_threshold: float) -> tuple[str, float
     return json_path.stem, duration, phrases
 
 
+# build the markdown document with a header block and one section per transcript
 def render_markdown(entries: list[tuple[str, float, list[dict]]], silence_threshold: float) -> str:
     lines: list[str] = []
     lines.append("# Packed transcripts")
@@ -162,6 +175,7 @@ def render_markdown(entries: list[tuple[str, float, list[dict]]], silence_thresh
     return "\n".join(lines)
 
 
+# cli entry point that finds transcript json files packs them and writes takes_packed md
 def main() -> None:
     ap = argparse.ArgumentParser(description="Pack Scribe transcripts into takes_packed.md")
     ap.add_argument("--edit-dir", type=Path, required=True, help="Edit directory containing transcripts/")

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -1,7 +1,3 @@
-# packs scribe word level transcript json files into one phrase level markdown document
-# words are grouped into phrases split on long silences or speaker changes and each phrase carries a start and end stamp
-# the editor sub agent reads the result to pick cuts so it favors compactness over raw detail
-
 """Pack all Scribe transcripts in <edit>/transcripts/ into one readable markdown.
 
 Groups word-level entries into phrase-level lines, breaking on any silence

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -1,3 +1,7 @@
+# the ffmpeg render pipeline that turns an edl into finished video files
+# it extracts graded segments and concatenates them and then composites overlays and subtitles and normalizes loudness
+# it also handles per deliverable reframing and the overlay preflight contact sheet and the command line entry point
+
 """Render a video from an EDL.
 
 Implements the HEURISTICS render pipeline in the correct order:
@@ -43,9 +47,11 @@ from edl import EDLValidationError, normalize_deliverables, validate_edl
 try:
     from grade import get_preset, auto_grade_for_clip  # same directory
 except Exception:
+    # fallback preset lookup that returns no grade when the grade module is unavailable
     def get_preset(name: str) -> str:
         return ""
 
+    # fallback auto grade that returns a mild fixed correction when the grade module is unavailable
     def auto_grade_for_clip(video, start=0.0, duration=None, verbose=False):  # type: ignore
         return "eq=contrast=1.03:saturation=0.98", {}
 
@@ -70,12 +76,14 @@ SUB_FORCE_STYLE = (
 # -------- Helpers ------------------------------------------------------------
 
 
+# run a command with check and print an abbreviated version unless quiet
 def run(cmd: list[str], quiet: bool = False) -> None:
     if not quiet:
         print(f"  $ {' '.join(str(c) for c in cmd[:6])}{' …' if len(cmd) > 6 else ''}")
     subprocess.run(cmd, check=True)
 
 
+# turn the edl grade field into a filter string or the auto sentinel
 def resolve_grade_filter(grade_field: str | None) -> str:
     """The EDL's 'grade' field can be a preset name, a raw ffmpeg filter, or 'auto'.
 
@@ -96,6 +104,7 @@ def resolve_grade_filter(grade_field: str | None) -> str:
     return grade_field
 
 
+# resolve a path relative to base unless it is already absolute
 def resolve_path(maybe_path: str, base: Path) -> Path:
     """Resolve a path that may be absolute or relative to `base`."""
     p = Path(maybe_path)
@@ -104,6 +113,7 @@ def resolve_path(maybe_path: str, base: Path) -> Path:
     return (base / p).resolve()
 
 
+# ask ffprobe for the width and height of the first video stream
 def probe_video_size(video: Path) -> tuple[int, int]:
     """Return the first video stream's display size as ``(width, height)``."""
     try:
@@ -124,6 +134,7 @@ def probe_video_size(video: Path) -> tuple[int, int]:
         raise ValueError(f"could not probe video size: {video}") from exc
 
 
+# find an ffmpeg binary whose filter list includes subtitles so libass is available
 def ffmpeg_with_subtitles() -> str:
     """Find an ffmpeg build with libass, including Homebrew's keg-only build."""
     candidates = [
@@ -131,12 +142,14 @@ def ffmpeg_with_subtitles() -> str:
         "/opt/homebrew/opt/ffmpeg-full/bin/ffmpeg",
         "/usr/local/opt/ffmpeg-full/bin/ffmpeg",
     ]
+    # dedupe candidates while preserving order and skip empty entries
     for candidate in dict.fromkeys(item for item in candidates if item):
         probe = subprocess.run(
             [str(candidate), "-hide_banner", "-filters"],
             capture_output=True,
             text=True,
         )
+        # the filters listing names subtitles only when libass is compiled in
         if re.search(r"\bsubtitles\b", probe.stdout + probe.stderr):
             return str(candidate)
     raise RuntimeError(
@@ -170,6 +183,7 @@ TONEMAP_CHAIN = (
 )
 
 
+# detect pq or hlg transfer metadata on the first video stream
 def is_hdr_source(video: Path) -> bool:
     """Return True if the source uses a PQ or HLG transfer function."""
     try:
@@ -184,6 +198,7 @@ def is_hdr_source(video: Path) -> bool:
         return False
 
 
+# report whether the first video stream is taller than it is wide
 def is_portrait_source(video: Path) -> bool:
     """Return True if the displayed video is portrait, including rotation."""
     try:
@@ -224,6 +239,7 @@ def is_portrait_source(video: Path) -> bool:
         return False
 
 
+# validate an fps argument and return it as a reduced rational string
 def parse_fps(value: str) -> str:
     """Validate and canonicalize an ffmpeg frame rate."""
     text = value.strip()
@@ -250,6 +266,7 @@ def parse_fps(value: str) -> str:
     return f"{rate.numerator}/{rate.denominator}"
 
 
+# read the source frame rate from ffprobe preferring the average rate
 def probe_source_fps(video: Path) -> str | None:
     """Return an ffmpeg-ready source rate, preferring the average frame rate.
 
@@ -268,6 +285,7 @@ def probe_source_fps(video: Path) -> str | None:
         streams = json.loads(out.stdout).get("streams") or []
         if not streams:
             return None
+        # take the first usable rate and skip zero or unparsable values
         for field in ("avg_frame_rate", "r_frame_rate"):
             value = streams[0].get(field)
             if value and value != "0/0":
@@ -283,6 +301,7 @@ def probe_source_fps(video: Path) -> str | None:
 # -------- Per-segment extraction (Rule 2 + Rule 3) --------------------------
 
 
+# encode one edl range as its own mp4 with tone mapping scaling grade and audio fades applied
 def extract_segment(
     source: Path,
     seg_start: float,
@@ -305,12 +324,14 @@ def extract_segment(
     """
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
+    # scale by height for portrait sources so orientation is preserved
     portrait = is_portrait_source(source)
     if draft:
         scale = "scale=-2:1280" if portrait else "scale=1280:-2"
     else:
         scale = "scale=-2:1920" if portrait else "scale=1920:-2"
 
+    # tone map hdr first then scale then grade
     vf_parts: list[str] = []
     if is_hdr_source(source):
         vf_parts.append(TONEMAP_CHAIN)
@@ -352,6 +373,7 @@ def extract_segment(
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
 
+# extract every edl range into graded segment files sharing one output frame rate
 def extract_all_segments(
     edl: dict,
     edit_dir: Path,
@@ -420,10 +442,12 @@ def extract_all_segments(
 # -------- Lossless concat ----------------------------------------------------
 
 
+# join segment files losslessly with the concat demuxer
 def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -> None:
     """Lossless concat via the concat demuxer. No re-encode."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
     concat_list = edit_dir / "_concat.txt"
+    # the concat demuxer reads a text file listing each segment path
     concat_list.write_text("".join(f"file '{p.resolve()}'\n" for p in segment_paths))
 
     cmd = [
@@ -445,6 +469,7 @@ def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -
 PUNCT_BREAK = set(".,!?;:")
 
 
+# format seconds as an srt timestamp with millisecond precision
 def _srt_timestamp(seconds: float) -> str:
     total_ms = int(round(seconds * 1000))
     h, rem = divmod(total_ms, 3600_000)
@@ -453,6 +478,7 @@ def _srt_timestamp(seconds: float) -> str:
     return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
 
 
+# return transcript words that overlap the given source time range
 def _words_in_range(transcript: dict, t_start: float, t_end: float) -> list[dict]:
     out: list[dict] = []
     for w in transcript.get("words", []):
@@ -462,12 +488,14 @@ def _words_in_range(transcript: dict, t_start: float, t_end: float) -> list[dict
         we = w.get("end")
         if ws is None or we is None:
             continue
+        # keep only words that overlap the range
         if we <= t_start or ws >= t_end:
             continue
         out.append(w)
     return out
 
 
+# build an output timeline srt from per source transcripts using two word uppercase chunks
 def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
     """Build an output-timeline SRT from per-source transcripts.
 
@@ -513,6 +541,7 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
             chunks.append(current)
 
         for chunk in chunks:
+            # clamp chunk times to the segment then shift them onto the output timeline
             local_start = max(seg_start, chunk[0].get("start", seg_start))
             local_end = min(seg_end, chunk[-1].get("end", seg_end))
             out_start = max(0.0, local_start - seg_start) + seg_offset
@@ -550,6 +579,7 @@ LOUDNORM_TP = -1.0
 LOUDNORM_LRA = 11.0
 
 
+# run the loudnorm first pass and parse its json measurement from stderr
 def measure_loudness(
     video_path: Path,
     integrated_lufs: float = LOUDNORM_I,
@@ -583,12 +613,14 @@ def measure_loudness(
         data = json.loads(stderr[start : end + 1])
     except json.JSONDecodeError:
         return None
+    # require every measured field the second pass needs
     needed = {"input_i", "input_tp", "input_lra", "input_thresh", "target_offset"}
     if not needed.issubset(data.keys()):
         return None
     return data
 
 
+# normalize audio with two pass loudnorm or a one pass approximation in preview mode
 def apply_loudnorm_two_pass(
     input_path: Path,
     output_path: Path,
@@ -631,6 +663,7 @@ def apply_loudnorm_two_pass(
         true_peak_dbtp=true_peak_dbtp,
         lra=lra,
     )
+    # fall back to the one pass filter when measurement did not produce json
     if measurement is None:
         print("  loudnorm measurement failed — falling back to 1-pass")
         return apply_loudnorm_two_pass(
@@ -645,6 +678,7 @@ def apply_loudnorm_two_pass(
     print(f"    measured: I={measurement['input_i']} LUFS  "
           f"TP={measurement['input_tp']}  LRA={measurement['input_lra']}")
 
+    # feed the measured values back so the second pass applies a linear gain
     filter_str = (
         f"loudnorm=I={integrated_lufs}:TP={true_peak_dbtp}:LRA={lra}"
         f":measured_I={measurement['input_i']}"
@@ -671,6 +705,7 @@ def apply_loudnorm_two_pass(
 # -------- Per-deliverable reframing -----------------------------------------
 
 
+# load and validate subject center keyframes from inline data or a json track file
 def _load_track_keyframes(reframe: dict, edit_dir: Path) -> list[dict]:
     """Load normalized subject-center keyframes from inline data or JSON."""
     raw = reframe.get("keyframes")
@@ -685,6 +720,7 @@ def _load_track_keyframes(reframe: dict, edit_dir: Path) -> list[dict]:
             payload = json.loads(track_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise ValueError(f"could not read tracked reframe data: {track_path}") from exc
+        # a file with named tracks needs a track_id to pick one
         if isinstance(payload, dict) and isinstance(payload.get("tracks"), dict):
             track_id = reframe.get("track_id")
             if not track_id:
@@ -706,6 +742,7 @@ def _load_track_keyframes(reframe: dict, edit_dir: Path) -> list[dict]:
             raise ValueError(f"tracked reframe keyframe {index} must be an object")
         try:
             timestamp = float(item.get("time", item.get("t")))
+            # accept a center pair or a subject box or separate center fields
             center = item.get("center")
             box = item.get("subject_box") or item.get("box")
             if isinstance(center, (list, tuple)) and len(center) == 2:
@@ -722,6 +759,7 @@ def _load_track_keyframes(reframe: dict, edit_dir: Path) -> list[dict]:
             raise ValueError(
                 f"tracked reframe keyframe {index} requires numeric time, center_x, and center_y"
             ) from exc
+        # keyframes must be strictly increasing so the piecewise expression is well defined
         if timestamp < 0 or timestamp <= previous_time:
             raise ValueError("tracked reframe keyframe times must be non-negative and increasing")
         if not 0.0 <= center_x <= 1.0 or not 0.0 <= center_y <= 1.0:
@@ -731,6 +769,7 @@ def _load_track_keyframes(reframe: dict, edit_dir: Path) -> list[dict]:
     return keyframes
 
 
+# build a nested if expression that interpolates one center coordinate over time
 def _piecewise_track_expression(
     keyframes: list[dict],
     coordinate: str,
@@ -748,7 +787,9 @@ def _piecewise_track_expression(
         end = float(second["time"])
         first_value = float(first[coordinate])
         delta = float(second[coordinate]) - first_value
+        # progress runs from 0 to 1 across this keyframe pair and is clamped outside it
         progress = f"max(0,min(1,(t-{start:.8f})/{end - start:.8f}))"
+        # smoothstep easing for smooth and a frozen start value for hold
         if interpolation == "smooth":
             progress = f"({progress})*({progress})*(3-2*({progress}))"
         elif interpolation == "hold":
@@ -757,12 +798,14 @@ def _piecewise_track_expression(
             raise ValueError("track interpolation must be linear, smooth, or hold")
         segment_expression = f"{first_value:.8f}+({delta:.8f})*({progress})"
         expressions.append((end, segment_expression))
+    # nest the segments from last to first so each if guards its own end time
     result = f"{float(keyframes[-1][coordinate]):.8f}"
     for end, interpolation in reversed(expressions):
         result = f"if(lt(t,{end:.8f}),{interpolation},{result})"
     return result
 
 
+# crop or letterbox the base into one deliverable aspect ratio while keeping its audio
 def build_reframed_base(
     base_path: Path,
     output_path: Path,
@@ -784,6 +827,7 @@ def build_reframed_base(
     """
     source_width, source_height = probe_video_size(base_path)
     mode = str(reframe.get("mode") or "cover")
+    # contain scales to fit then pads to the target size with a background color
     if mode == "contain":
         background = str(reframe.get("background") or "black").replace("'", "")
         video_filter = (
@@ -792,6 +836,7 @@ def build_reframed_base(
             f"setsar=1,fps={fps}"
         )
     else:
+        # pick the largest even crop that matches the target ratio inside the source
         source_ratio = source_width / source_height
         target_ratio = width / height
         if source_ratio > target_ratio:
@@ -810,6 +855,7 @@ def build_reframed_base(
             center_y = _piecewise_track_expression(
                 keyframes, "center_y", interpolation
             )
+            # center the crop on the tracked point and clamp so it stays inside the frame
             crop_x = f"max(0,min(iw-ow,({center_x})*iw-ow/2))"
             crop_y = f"max(0,min(ih-oh,({center_y})*ih-oh/2))"
         elif mode == "cover":
@@ -875,6 +921,7 @@ COMPOSITION_LAYOUTS = {
 }
 
 
+# validate a rectangle given as fractions of the output frame
 def _normalized_rect(value: dict, label: str) -> dict[str, float]:
     """Validate an EDL rectangle expressed as fractions of the output frame."""
     try:
@@ -884,6 +931,7 @@ def _normalized_rect(value: dict, label: str) -> dict[str, float]:
             f"{label} must contain numeric x, y, width, and height values"
         ) from exc
 
+    # reject rects with a negative origin or non positive size or that spill past the frame edge
     if rect["x"] < 0 or rect["y"] < 0 or rect["width"] <= 0 or rect["height"] <= 0:
         raise ValueError(f"{label} must use non-negative x/y and positive width/height")
     if rect["x"] + rect["width"] > 1.000001 or rect["y"] + rect["height"] > 1.000001:
@@ -891,7 +939,9 @@ def _normalized_rect(value: dict, label: str) -> dict[str, float]:
     return rect
 
 
+# report whether two normalized rectangles overlap in space
 def _rects_intersect(a: dict[str, float], b: dict[str, float]) -> bool:
+    # two rects miss when one is entirely left right above or below the other
     return not (
         a["x"] + a["width"] <= b["x"]
         or b["x"] + b["width"] <= a["x"]
@@ -900,6 +950,7 @@ def _rects_intersect(a: dict[str, float], b: dict[str, float]) -> bool:
     )
 
 
+# report whether two half open time ranges overlap
 def _time_ranges_intersect(
     first_start: float,
     first_end: float,
@@ -909,6 +960,7 @@ def _time_ranges_intersect(
     return first_start < second_end and second_start < first_end
 
 
+# read and validate the output timeline start and end of an overlay
 def overlay_time_range(overlay: dict) -> tuple[float, float]:
     try:
         start = float(overlay["start_in_output"])
@@ -920,6 +972,7 @@ def overlay_time_range(overlay: dict) -> tuple[float, float]:
     return start, start + duration
 
 
+# resolve an overlay layout or rect into a normalized rectangle that stays clear of the caption rail
 def resolve_overlay_rect(
     overlay: dict,
     has_subtitles: bool,
@@ -934,6 +987,7 @@ def resolve_overlay_rect(
     composition = overlay.get("composition")
     layout = overlay.get("layout")
     custom = overlay.get("rect")
+    # a composition name fixes the layout so conflicting layout or rect values are rejected
     if composition is not None:
         allowed = {*COMPOSITION_LAYOUTS, "picture_in_picture"}
         if composition not in allowed:
@@ -979,6 +1033,7 @@ def resolve_overlay_rect(
             if caption_region["x"] == 0.0 and caption_region["width"] == 1.0:
                 rect["height"] = min(rect["height"], caption_region["y"])
 
+    # any remaining overlap with the caption rail is a hard error
     if caption_region and _rects_intersect(rect, caption_region):
         raise ValueError(
             "overlay rectangle intersects captions.safe_region; move or resize the "
@@ -987,6 +1042,7 @@ def resolve_overlay_rect(
     return rect
 
 
+# reject overlays that collide with each other or protected regions and check web asset provenance
 def validate_overlay_contracts(
     overlays: list[dict],
     protected_regions: list[dict] | None,
@@ -1003,6 +1059,7 @@ def validate_overlay_contracts(
         rect = resolve_overlay_rect(overlay, has_subtitles, caption_config)
         resolved.append((overlay, rect, start, end))
 
+        # web overlays must carry provenance and may only repeat via reuse_of
         if overlay.get("media_kind") == "web":
             required = ("source_url", "source_start", "source_end", "asset_id")
             missing = [field for field in required if overlay.get(field) in (None, "")]
@@ -1028,6 +1085,7 @@ def validate_overlay_contracts(
             else:
                 seen_web_assets[asset_id] = overlay
 
+    # protected illustration regions only conflict with overlays active in the same interval and cutaways are exempt
     for region_index, region in enumerate(protected_regions):
         label = str(region.get("owner") or region.get("id") or region_index)
         try:
@@ -1052,6 +1110,7 @@ def validate_overlay_contracts(
                     "during the same output interval; use a cutaway or move the overlay"
                 )
 
+    # overlays that share space and time are rejected unless one allows overlap
     for index, (first, first_rect, first_start, first_end) in enumerate(resolved):
         if first_rect is None or first.get("allow_overlap"):
             continue
@@ -1068,6 +1127,7 @@ def validate_overlay_contracts(
                 )
 
 
+# convert a normalized value to an even pixel count clamped within bounds
 def _even_pixel(value: float, maximum: int, *, minimum: int = 0) -> int:
     """Convert a normalized coordinate/size to an even pixel value for yuv420p."""
     pixels = int(round(value * maximum))
@@ -1077,6 +1137,7 @@ def _even_pixel(value: float, maximum: int, *, minimum: int = 0) -> int:
     return max(minimum, pixels)
 
 
+# composite overlays onto the base and burn subtitles last in one ffmpeg filter graph
 def build_final_composite(
     base_path: Path,
     overlays: list[dict],
@@ -1112,6 +1173,7 @@ def build_final_composite(
     for idx, ov in enumerate(overlays, start=1):
         t = float(ov["start_in_output"])
         rect = resolve_overlay_rect(ov, has_subs, caption_config)
+        # legacy overlays without a layout fill the whole frame
         if rect is None:
             filter_parts.append(
                 f"[{idx}:v]scale={base_width}:{base_height}:"
@@ -1123,6 +1185,7 @@ def build_final_composite(
 
         width = _even_pixel(rect["width"], base_width, minimum=2)
         height = _even_pixel(rect["height"], base_height, minimum=2)
+        # cover fills the rect by cropping and contain letterboxes with a background
         fit = ov.get("fit", "cover")
         if fit == "cover":
             geometry = (
@@ -1155,6 +1218,7 @@ def build_final_composite(
             x = _even_pixel(rect["x"], base_width)
             y = _even_pixel(rect["y"], base_height)
             position = f"x={x}:y={y}"
+        # enable limits the overlay to its output window even though the input is pts shifted
         filter_parts.append(
             f"{current}[a{idx}]overlay={position}:enable="
             f"'between(t,{t:.3f},{end:.3f})'{next_label}"
@@ -1163,7 +1227,9 @@ def build_final_composite(
 
     # Subtitles LAST — Rule 1
     if has_subs:
+        # escape colons and quotes so the path survives filter option parsing
         subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
+        # ass files carry their own style while srt gets the forced style
         if subtitles_path.suffix.lower() == ".ass":
             filter_parts.append(f"{current}subtitles='{subs_abs}'[outv]")
         else:
@@ -1199,8 +1265,10 @@ def build_final_composite(
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
 
+# grab one frame from a video or normalize a still image for the preflight sheet
 def _extract_review_frame(media: Path, timestamp: float, output: Path) -> None:
     """Extract one video frame, or normalize a still image, for preflight."""
+    # still images are converted directly instead of going through ffmpeg
     if media.suffix.casefold() in {".png", ".jpg", ".jpeg", ".webp", ".tif", ".tiff"}:
         from PIL import Image
 
@@ -1224,6 +1292,7 @@ def _extract_review_frame(media: Path, timestamp: float, output: Path) -> None:
     subprocess.run(command, check=True)
 
 
+# draw an entry middle and exit contact sheet for every overlay without rendering the video
 def build_overlay_preflight(
     base_path: Path,
     overlays: list[dict],
@@ -1271,6 +1340,7 @@ def build_overlay_preflight(
         for row, overlay in enumerate(overlays):
             start, end = overlay_time_range(overlay)
             duration = end - start
+            # sample just inside each edge and at the middle of the overlay window
             inset = min(0.10, duration / 4)
             local_samples = (inset, duration / 2, max(inset, duration - inset))
             rect = resolve_overlay_rect(overlay, has_subtitles, caption_config)
@@ -1298,6 +1368,7 @@ def build_overlay_preflight(
                 y = int(round(rect["y"] * cell_height))
                 width = max(1, int(round(rect["width"] * cell_width)))
                 height = max(1, int(round(rect["height"] * cell_height)))
+                # mirror the contain and cover math from the final composite
                 if overlay.get("fit", "cover") == "contain":
                     background = Image.new(
                         "RGBA", (width, height), str(overlay.get("background", "#050914"))
@@ -1318,6 +1389,7 @@ def build_overlay_preflight(
 
                 draw = ImageDraw.Draw(frame, "RGBA")
                 draw.rectangle((x, y, x + width - 1, y + height - 1), outline="#48E0A4", width=3)
+                # tint the caption rail and outline protected regions that are active at this time
                 if caption_region is not None:
                     cx = int(round(caption_region["x"] * cell_width))
                     cy = int(round(caption_region["y"] * cell_height))
@@ -1359,6 +1431,7 @@ def build_overlay_preflight(
 # -------- Main ---------------------------------------------------------------
 
 
+# reframe composite and normalize one output or deliverable and clean up intermediates
 def render_one_output(
     *,
     base_path: Path,
@@ -1381,6 +1454,7 @@ def render_one_output(
         "lra": LOUDNORM_LRA,
     }
     overlays = edl.get("overlays") or []
+    # a deliverable gets a reframed base and its own loudness and optional overlay list
     if deliverable is not None:
         reframed_path = out_path.with_suffix(".reframed.mp4")
         build_reframed_base(
@@ -1399,6 +1473,7 @@ def render_one_output(
         if "overlays" in deliverable:
             overlays = deliverable.get("overlays") or []
 
+    # the prenorm composite and reframed base are removed even when a step fails
     try:
         if no_loudnorm:
             build_final_composite(
@@ -1447,6 +1522,7 @@ def render_one_output(
     print(f"done:{label} {out_path} ({size_mb:.1f} MB)")
 
 
+# command line entry point that validates the edl and runs the full pipeline
 def main() -> None:
     ap = argparse.ArgumentParser(description="Render a video from an EDL")
     ap.add_argument("edl", type=Path, help="Path to edl.json")
@@ -1528,6 +1604,7 @@ def main() -> None:
         deliverables = normalize_deliverables(edl, edit_dir, output_dir=output_dir)
     except EDLValidationError as exc:
         sys.exit(str(exc))
+    # cross check the output selectors before any media work starts
     if args.output_dir and not (args.all_deliverables or args.deliverable):
         ap.error("--output-dir requires --deliverable or --all-deliverables")
     if args.all_deliverables and not deliverables:
@@ -1552,6 +1629,7 @@ def main() -> None:
     out_path = args.output.resolve() if args.output else None
     overlays = edl.get("overlays") or []
 
+    # a preflight base skips extraction and concat and only draws the contact sheet
     if args.preflight_base is not None:
         if not args.preflight_overlays:
             ap.error("--preflight-base requires --preflight-overlays")
@@ -1599,6 +1677,7 @@ def main() -> None:
                 print(f"warning: subtitles path in EDL does not exist: {subs_path}")
                 subs_path = None
 
+    # preflight after concat uses the freshly built base
     if args.preflight_overlays:
         if out_path is None:
             ap.error("overlay preflight requires -o/--output")
@@ -1616,6 +1695,7 @@ def main() -> None:
     # 4. Reframe each delivery, composite overlays/subtitles LAST, then loudnorm.
     if selected_deliverables:
         for deliverable in selected_deliverables:
+            # a single selected deliverable may be redirected with the output flag
             delivery_output = (
                 out_path
                 if len(selected_deliverables) == 1 and out_path is not None

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -1229,7 +1229,7 @@ def build_final_composite(
     if has_subs:
         # escape colons and quotes so the path survives filter option parsing
         subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
-        # ass files carry their own style while srt gets the forced style
+        # ASS files carry their own style while srt gets the forced style
         if subtitles_path.suffix.lower() == ".ass":
             filter_parts.append(f"{current}subtitles='{subs_abs}'[outv]")
         else:

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -1,7 +1,3 @@
-# the ffmpeg render pipeline that turns an edl into a finished video file
-# it extracts graded segments and concatenates them and then composites overlays and subtitles and normalizes loudness
-# it also builds the master srt from transcripts and holds the command line entry point
-
 """Render a video from an EDL.
 
 Implements the HEURISTICS render pipeline in the correct order:

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -17,6 +17,9 @@ Usage:
     python helpers/render.py <edl.json> -o preview.mp4 --preview
     python helpers/render.py <edl.json> -o final.mp4 --build-subtitles
     python helpers/render.py <edl.json> -o final.mp4 --no-subtitles
+    python helpers/render.py <edl.json> --all-deliverables
+    python helpers/render.py <edl.json> -o overlay_preflight.png \
+      --preflight-overlays --preflight-base base.mp4
 """
 
 from __future__ import annotations
@@ -24,21 +27,25 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from fractions import Fraction
 from pathlib import Path
+
+HELPERS_DIR = str(Path(__file__).resolve().parent)
+if HELPERS_DIR not in sys.path:
+    sys.path.insert(0, HELPERS_DIR)
+
+from edl import EDLValidationError, normalize_deliverables, validate_edl
 
 try:
     from grade import get_preset, auto_grade_for_clip  # same directory
 except Exception:
-    # fallback that only knows the identity grade when the grade helper is unavailable
-    # fallback that only knows the identity grade when the grade helper is unavailable
     def get_preset(name: str) -> str:
         return ""
 
-    # fallback that skips auto grading when the grade helper is unavailable
-    # fallback that skips auto grading when the grade helper is unavailable
     def auto_grade_for_clip(video, start=0.0, duration=None, verbose=False):  # type: ignore
         return "eq=contrast=1.03:saturation=0.98", {}
 
@@ -63,14 +70,12 @@ SUB_FORCE_STYLE = (
 # -------- Helpers ------------------------------------------------------------
 
 
-# run a command with check and print an abbreviated version unless quiet
 def run(cmd: list[str], quiet: bool = False) -> None:
     if not quiet:
         print(f"  $ {' '.join(str(c) for c in cmd[:6])}{' …' if len(cmd) > 6 else ''}")
     subprocess.run(cmd, check=True)
 
 
-# turn the edl grade field into a filter string or the auto sentinel
 def resolve_grade_filter(grade_field: str | None) -> str:
     """The EDL's 'grade' field can be a preset name, a raw ffmpeg filter, or 'auto'.
 
@@ -91,13 +96,53 @@ def resolve_grade_filter(grade_field: str | None) -> str:
     return grade_field
 
 
-# resolve a path relative to base unless it is already absolute
 def resolve_path(maybe_path: str, base: Path) -> Path:
     """Resolve a path that may be absolute or relative to `base`."""
     p = Path(maybe_path)
     if p.is_absolute():
         return p
     return (base / p).resolve()
+
+
+def probe_video_size(video: Path) -> tuple[int, int]:
+    """Return the first video stream's display size as ``(width, height)``."""
+    try:
+        out = subprocess.run(
+            [
+                "ffprobe", "-v", "error", "-select_streams", "v:0",
+                "-show_entries", "stream=width,height", "-of", "json", str(video),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        streams = json.loads(out.stdout).get("streams") or []
+        if not streams:
+            raise ValueError("no video stream")
+        return int(streams[0]["width"]), int(streams[0]["height"])
+    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError, ValueError) as exc:
+        raise ValueError(f"could not probe video size: {video}") from exc
+
+
+def ffmpeg_with_subtitles() -> str:
+    """Find an ffmpeg build with libass, including Homebrew's keg-only build."""
+    candidates = [
+        shutil.which("ffmpeg"),
+        "/opt/homebrew/opt/ffmpeg-full/bin/ffmpeg",
+        "/usr/local/opt/ffmpeg-full/bin/ffmpeg",
+    ]
+    for candidate in dict.fromkeys(item for item in candidates if item):
+        probe = subprocess.run(
+            [str(candidate), "-hide_banner", "-filters"],
+            capture_output=True,
+            text=True,
+        )
+        if re.search(r"\bsubtitles\b", probe.stdout + probe.stderr):
+            return str(candidate)
+    raise RuntimeError(
+        "subtitles require an ffmpeg build with libass; install ffmpeg-full or "
+        "another libass-enabled build"
+    )
 
 
 # -------- HDR → SDR tone mapping (HLG / PQ sources) --------------------------
@@ -125,7 +170,6 @@ TONEMAP_CHAIN = (
 )
 
 
-# detect pq or hlg transfer metadata on the first video stream
 def is_hdr_source(video: Path) -> bool:
     """Return True if the source uses a PQ or HLG transfer function."""
     try:
@@ -140,7 +184,6 @@ def is_hdr_source(video: Path) -> bool:
         return False
 
 
-# report whether the first video stream is taller than it is wide
 def is_portrait_source(video: Path) -> bool:
     """Return True if the displayed video is portrait, including rotation."""
     try:
@@ -181,7 +224,6 @@ def is_portrait_source(video: Path) -> bool:
         return False
 
 
-# validate an fps argument and return it as a reduced rational string
 def parse_fps(value: str) -> str:
     """Validate and canonicalize an ffmpeg frame rate."""
     text = value.strip()
@@ -208,7 +250,6 @@ def parse_fps(value: str) -> str:
     return f"{rate.numerator}/{rate.denominator}"
 
 
-# read the source frame rate from ffprobe preferring the average rate
 def probe_source_fps(video: Path) -> str | None:
     """Return an ffmpeg-ready source rate, preferring the average frame rate.
 
@@ -227,7 +268,6 @@ def probe_source_fps(video: Path) -> str | None:
         streams = json.loads(out.stdout).get("streams") or []
         if not streams:
             return None
-        # take the first usable rate and skip zero or unparsable values
         for field in ("avg_frame_rate", "r_frame_rate"):
             value = streams[0].get(field)
             if value and value != "0/0":
@@ -243,7 +283,6 @@ def probe_source_fps(video: Path) -> str | None:
 # -------- Per-segment extraction (Rule 2 + Rule 3) --------------------------
 
 
-# encode one edl range as its own mp4 with tone mapping scaling grade and audio fades applied
 def extract_segment(
     source: Path,
     seg_start: float,
@@ -266,14 +305,12 @@ def extract_segment(
     """
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # scale by height for portrait sources so orientation is preserved
     portrait = is_portrait_source(source)
     if draft:
         scale = "scale=-2:1280" if portrait else "scale=1280:-2"
     else:
         scale = "scale=-2:1920" if portrait else "scale=1920:-2"
 
-    # tone map hdr first then scale then grade
     vf_parts: list[str] = []
     if is_hdr_source(source):
         vf_parts.append(TONEMAP_CHAIN)
@@ -315,7 +352,6 @@ def extract_segment(
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
 
-# extract every edl range into graded segment files sharing one output frame rate
 def extract_all_segments(
     edl: dict,
     edit_dir: Path,
@@ -384,12 +420,10 @@ def extract_all_segments(
 # -------- Lossless concat ----------------------------------------------------
 
 
-# join segment files losslessly with the concat demuxer
 def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -> None:
     """Lossless concat via the concat demuxer. No re-encode."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
     concat_list = edit_dir / "_concat.txt"
-    # the concat demuxer reads a text file listing each segment path
     concat_list.write_text("".join(f"file '{p.resolve()}'\n" for p in segment_paths))
 
     cmd = [
@@ -411,7 +445,6 @@ def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -
 PUNCT_BREAK = set(".,!?;:")
 
 
-# format seconds as an srt timestamp with millisecond precision
 def _srt_timestamp(seconds: float) -> str:
     total_ms = int(round(seconds * 1000))
     h, rem = divmod(total_ms, 3600_000)
@@ -420,7 +453,6 @@ def _srt_timestamp(seconds: float) -> str:
     return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
 
 
-# return transcript words that overlap the given source time range
 def _words_in_range(transcript: dict, t_start: float, t_end: float) -> list[dict]:
     out: list[dict] = []
     for w in transcript.get("words", []):
@@ -430,14 +462,12 @@ def _words_in_range(transcript: dict, t_start: float, t_end: float) -> list[dict
         we = w.get("end")
         if ws is None or we is None:
             continue
-        # keep only words that overlap the range
         if we <= t_start or ws >= t_end:
             continue
         out.append(w)
     return out
 
 
-# build an output timeline srt from per source transcripts using two word uppercase chunks
 def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
     """Build an output-timeline SRT from per-source transcripts.
 
@@ -483,7 +513,6 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
             chunks.append(current)
 
         for chunk in chunks:
-            # clamp chunk times to the segment then shift them onto the output timeline
             local_start = max(seg_start, chunk[0].get("start", seg_start))
             local_end = min(seg_end, chunk[-1].get("end", seg_end))
             out_start = max(0.0, local_start - seg_start) + seg_offset
@@ -521,15 +550,19 @@ LOUDNORM_TP = -1.0
 LOUDNORM_LRA = 11.0
 
 
-# run the loudnorm first pass and parse its json measurement from stderr
-def measure_loudness(video_path: Path) -> dict[str, str] | None:
+def measure_loudness(
+    video_path: Path,
+    integrated_lufs: float = LOUDNORM_I,
+    true_peak_dbtp: float = LOUDNORM_TP,
+    lra: float = LOUDNORM_LRA,
+) -> dict[str, str] | None:
     """Run ffmpeg loudnorm first pass and parse the JSON measurement.
 
     Returns a dict with measured_i, measured_tp, measured_lra, measured_thresh,
     target_offset, or None if measurement failed.
     """
     filter_str = (
-        f"loudnorm=I={LOUDNORM_I}:TP={LOUDNORM_TP}:LRA={LOUDNORM_LRA}:print_format=json"
+        f"loudnorm=I={integrated_lufs}:TP={true_peak_dbtp}:LRA={lra}:print_format=json"
     )
     cmd = [
         "ffmpeg", "-y", "-hide_banner", "-nostats",
@@ -556,11 +589,13 @@ def measure_loudness(video_path: Path) -> dict[str, str] | None:
     return data
 
 
-# normalize audio with two pass loudnorm or a one pass approximation in preview mode
 def apply_loudnorm_two_pass(
     input_path: Path,
     output_path: Path,
     preview: bool = False,
+    integrated_lufs: float = LOUDNORM_I,
+    true_peak_dbtp: float = LOUDNORM_TP,
+    lra: float = LOUDNORM_LRA,
 ) -> bool:
     """Run two-pass loudnorm on input_path, write normalized copy to output_path.
 
@@ -572,7 +607,9 @@ def apply_loudnorm_two_pass(
     """
     if preview:
         # One-pass approximation — faster, slightly less accurate.
-        filter_str = f"loudnorm=I={LOUDNORM_I}:TP={LOUDNORM_TP}:LRA={LOUDNORM_LRA}"
+        filter_str = (
+            f"loudnorm=I={integrated_lufs}:TP={true_peak_dbtp}:LRA={lra}"
+        )
         cmd = [
             "ffmpeg", "-y", "-hide_banner", "-nostats",
             "-i", str(input_path),
@@ -588,16 +625,28 @@ def apply_loudnorm_two_pass(
 
     # Full two-pass
     print(f"  loudnorm pass 1: measuring {input_path.name}")
-    measurement = measure_loudness(input_path)
+    measurement = measure_loudness(
+        input_path,
+        integrated_lufs=integrated_lufs,
+        true_peak_dbtp=true_peak_dbtp,
+        lra=lra,
+    )
     if measurement is None:
         print("  loudnorm measurement failed — falling back to 1-pass")
-        return apply_loudnorm_two_pass(input_path, output_path, preview=True)
+        return apply_loudnorm_two_pass(
+            input_path,
+            output_path,
+            preview=True,
+            integrated_lufs=integrated_lufs,
+            true_peak_dbtp=true_peak_dbtp,
+            lra=lra,
+        )
 
     print(f"    measured: I={measurement['input_i']} LUFS  "
           f"TP={measurement['input_tp']}  LRA={measurement['input_lra']}")
 
     filter_str = (
-        f"loudnorm=I={LOUDNORM_I}:TP={LOUDNORM_TP}:LRA={LOUDNORM_LRA}"
+        f"loudnorm=I={integrated_lufs}:TP={true_peak_dbtp}:LRA={lra}"
         f":measured_I={measurement['input_i']}"
         f":measured_TP={measurement['input_tp']}"
         f":measured_LRA={measurement['input_lra']}"
@@ -619,16 +668,423 @@ def apply_loudnorm_two_pass(
     return True
 
 
+# -------- Per-deliverable reframing -----------------------------------------
+
+
+def _load_track_keyframes(reframe: dict, edit_dir: Path) -> list[dict]:
+    """Load normalized subject-center keyframes from inline data or JSON."""
+    raw = reframe.get("keyframes")
+    if raw is None and isinstance(reframe.get("track"), list):
+        raw = reframe["track"]
+    if raw is None:
+        track_value = reframe.get("track_file") or reframe.get("track")
+        if not isinstance(track_value, str):
+            raise ValueError("tracked reframe requires inline keyframes or a JSON track file")
+        track_path = resolve_path(track_value, edit_dir)
+        try:
+            payload = json.loads(track_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"could not read tracked reframe data: {track_path}") from exc
+        if isinstance(payload, dict) and isinstance(payload.get("tracks"), dict):
+            track_id = reframe.get("track_id")
+            if not track_id:
+                raise ValueError(
+                    f"tracked reframe file contains named tracks; choose one with track_id: {track_path}"
+                )
+            raw = payload["tracks"].get(str(track_id))
+            if raw is None:
+                raise ValueError(f"tracked reframe track_id '{track_id}' was not found: {track_path}")
+        else:
+            raw = payload.get("keyframes") if isinstance(payload, dict) else payload
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("tracked reframe keyframes must be a non-empty list")
+
+    keyframes: list[dict] = []
+    previous_time = -1.0
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"tracked reframe keyframe {index} must be an object")
+        try:
+            timestamp = float(item.get("time", item.get("t")))
+            center = item.get("center")
+            box = item.get("subject_box") or item.get("box")
+            if isinstance(center, (list, tuple)) and len(center) == 2:
+                raw_x, raw_y = center
+            elif isinstance(box, dict):
+                raw_x = float(box["x"]) + float(box["width"]) / 2
+                raw_y = float(box["y"]) + float(box["height"]) / 2
+            else:
+                raw_x = item.get("center_x", item.get("x"))
+                raw_y = item.get("center_y", item.get("y"))
+            center_x = float(raw_x)
+            center_y = float(raw_y)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"tracked reframe keyframe {index} requires numeric time, center_x, and center_y"
+            ) from exc
+        if timestamp < 0 or timestamp <= previous_time:
+            raise ValueError("tracked reframe keyframe times must be non-negative and increasing")
+        if not 0.0 <= center_x <= 1.0 or not 0.0 <= center_y <= 1.0:
+            raise ValueError("tracked reframe centers must use normalized values from 0 to 1")
+        keyframes.append({"time": timestamp, "center_x": center_x, "center_y": center_y})
+        previous_time = timestamp
+    return keyframes
+
+
+def _piecewise_track_expression(
+    keyframes: list[dict],
+    coordinate: str,
+    interpolation: str = "linear",
+) -> str:
+    """Build a continuous ffmpeg expression from sparse tracking keyframes."""
+    if coordinate not in {"center_x", "center_y"}:
+        raise ValueError("track coordinate must be center_x or center_y")
+    if len(keyframes) == 1:
+        return f"{float(keyframes[0][coordinate]):.8f}"
+
+    expressions: list[tuple[float, str]] = []
+    for first, second in zip(keyframes, keyframes[1:]):
+        start = float(first["time"])
+        end = float(second["time"])
+        first_value = float(first[coordinate])
+        delta = float(second[coordinate]) - first_value
+        progress = f"max(0,min(1,(t-{start:.8f})/{end - start:.8f}))"
+        if interpolation == "smooth":
+            progress = f"({progress})*({progress})*(3-2*({progress}))"
+        elif interpolation == "hold":
+            progress = "0"
+        elif interpolation != "linear":
+            raise ValueError("track interpolation must be linear, smooth, or hold")
+        segment_expression = f"{first_value:.8f}+({delta:.8f})*({progress})"
+        expressions.append((end, segment_expression))
+    result = f"{float(keyframes[-1][coordinate]):.8f}"
+    for end, interpolation in reversed(expressions):
+        result = f"if(lt(t,{end:.8f}),{interpolation},{result})"
+    return result
+
+
+def build_reframed_base(
+    base_path: Path,
+    output_path: Path,
+    *,
+    width: int,
+    height: int,
+    fps: str,
+    reframe: dict,
+    edit_dir: Path,
+    preview: bool = False,
+    draft: bool = False,
+) -> None:
+    """Create one aspect-ratio-specific base while preserving its audio.
+
+    ``cover`` uses a centered crop, ``contain`` letterboxes, and ``track``
+    follows interpolated normalized subject centers authored on the output
+    timeline. Tracking is explicit and deterministic; it never silently falls
+    back to a center crop when tracking data is missing.
+    """
+    source_width, source_height = probe_video_size(base_path)
+    mode = str(reframe.get("mode") or "cover")
+    if mode == "contain":
+        background = str(reframe.get("background") or "black").replace("'", "")
+        video_filter = (
+            f"scale={width}:{height}:force_original_aspect_ratio=decrease,"
+            f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:color={background},"
+            f"setsar=1,fps={fps}"
+        )
+    else:
+        source_ratio = source_width / source_height
+        target_ratio = width / height
+        if source_ratio > target_ratio:
+            crop_width = max(2, int(source_height * target_ratio) // 2 * 2)
+            crop_height = source_height // 2 * 2
+        else:
+            crop_width = source_width // 2 * 2
+            crop_height = max(2, int(source_width / target_ratio) // 2 * 2)
+
+        if mode == "track":
+            keyframes = _load_track_keyframes(reframe, edit_dir)
+            interpolation = str(reframe.get("interpolation") or "linear")
+            center_x = _piecewise_track_expression(
+                keyframes, "center_x", interpolation
+            )
+            center_y = _piecewise_track_expression(
+                keyframes, "center_y", interpolation
+            )
+            crop_x = f"max(0,min(iw-ow,({center_x})*iw-ow/2))"
+            crop_y = f"max(0,min(ih-oh,({center_y})*ih-oh/2))"
+        elif mode == "cover":
+            crop_x, crop_y = "(iw-ow)/2", "(ih-oh)/2"
+        else:
+            raise ValueError(f"unsupported reframe mode: {mode}")
+        video_filter = (
+            f"crop={crop_width}:{crop_height}:x='{crop_x}':y='{crop_y}',"
+            f"scale={width}:{height},setsar=1,fps={fps}"
+        )
+
+    if draft:
+        preset, crf = "ultrafast", "28"
+    elif preview:
+        preset, crf = "medium", "22"
+    else:
+        preset, crf = "fast", "20"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    print(f"reframing → {output_path.name} ({width}x{height}@{fps}, {mode})")
+    command = [
+        "ffmpeg", "-y", "-hide_banner", "-nostats",
+        "-i", str(base_path),
+        "-vf", video_filter,
+        "-map", "0:v:0", "-map", "0:a?",
+        "-c:v", "libx264", "-preset", preset, "-crf", crf,
+        "-pix_fmt", "yuv420p",
+        "-c:a", "copy",
+        "-movflags", "+faststart",
+        str(output_path),
+    ]
+    subprocess.run(
+        command,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+
+
 # -------- Final compositing (Rule 1 + Rule 4) -------------------------------
 
 
-# composite overlays onto the base and burn subtitles last in one ffmpeg filter graph
+DEFAULT_CAPTION_REGION = {"x": 0.0, "y": 0.84, "width": 1.0, "height": 0.16}
+
+OVERLAY_LAYOUTS = {
+    # ``full`` means the full visual canvas. When captions are present, that
+    # canvas stops above the caption rail rather than hiding words under video.
+    "full": {"x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0},
+    # Inset layouts preserve a title band above and the caption rail below.
+    "center": {"x": 0.18, "y": 0.15, "width": 0.64, "height": 0.58},
+    "left": {"x": 0.04, "y": 0.17, "width": 0.44, "height": 0.57},
+    "right": {"x": 0.52, "y": 0.17, "width": 0.44, "height": 0.57},
+    "pip_left": {"x": 0.05, "y": 0.50, "width": 0.30, "height": 0.28},
+    "pip_center": {"x": 0.35, "y": 0.50, "width": 0.30, "height": 0.28},
+    "pip_right": {"x": 0.65, "y": 0.50, "width": 0.30, "height": 0.28},
+}
+
+# Composition names express the editorial relationship, not merely coordinates.
+# For split modes, the name describes where the external footage sits.
+COMPOSITION_LAYOUTS = {
+    "cutaway": "full",
+    "split_left": "left",
+    "split_right": "right",
+}
+
+
+def _normalized_rect(value: dict, label: str) -> dict[str, float]:
+    """Validate an EDL rectangle expressed as fractions of the output frame."""
+    try:
+        rect = {key: float(value[key]) for key in ("x", "y", "width", "height")}
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{label} must contain numeric x, y, width, and height values"
+        ) from exc
+
+    if rect["x"] < 0 or rect["y"] < 0 or rect["width"] <= 0 or rect["height"] <= 0:
+        raise ValueError(f"{label} must use non-negative x/y and positive width/height")
+    if rect["x"] + rect["width"] > 1.000001 or rect["y"] + rect["height"] > 1.000001:
+        raise ValueError(f"{label} must stay inside the normalized output frame")
+    return rect
+
+
+def _rects_intersect(a: dict[str, float], b: dict[str, float]) -> bool:
+    return not (
+        a["x"] + a["width"] <= b["x"]
+        or b["x"] + b["width"] <= a["x"]
+        or a["y"] + a["height"] <= b["y"]
+        or b["y"] + b["height"] <= a["y"]
+    )
+
+
+def _time_ranges_intersect(
+    first_start: float,
+    first_end: float,
+    second_start: float,
+    second_end: float,
+) -> bool:
+    return first_start < second_end and second_start < first_end
+
+
+def overlay_time_range(overlay: dict) -> tuple[float, float]:
+    try:
+        start = float(overlay["start_in_output"])
+        duration = float(overlay["duration"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("overlay requires numeric start_in_output and duration") from exc
+    if start < 0 or duration <= 0:
+        raise ValueError("overlay requires start_in_output >= 0 and duration > 0")
+    return start, start + duration
+
+
+def resolve_overlay_rect(
+    overlay: dict,
+    has_subtitles: bool,
+    caption_config: dict | None = None,
+) -> dict[str, float] | None:
+    """Resolve a named/custom overlay layout and protect the caption rail.
+
+    Legacy overlays with neither ``layout`` nor ``rect`` return ``None`` and
+    preserve their original full-frame behavior. New explainer overlays should
+    always name a layout so their spatial contract can be validated.
+    """
+    composition = overlay.get("composition")
+    layout = overlay.get("layout")
+    custom = overlay.get("rect")
+    if composition is not None:
+        allowed = {*COMPOSITION_LAYOUTS, "picture_in_picture"}
+        if composition not in allowed:
+            choices = ", ".join(sorted(allowed))
+            raise ValueError(
+                f"unknown overlay composition '{composition}'; choose {choices}"
+            )
+        if composition in COMPOSITION_LAYOUTS:
+            expected_layout = COMPOSITION_LAYOUTS[composition]
+            if custom is not None or layout not in (None, expected_layout):
+                raise ValueError(
+                    f"composition '{composition}' owns layout '{expected_layout}' and "
+                    "cannot be combined with another layout or custom rect"
+                )
+            layout = expected_layout
+        elif layout is None and custom is None:
+            raise ValueError(
+                "picture_in_picture requires layout pip_left/pip_center/pip_right or a custom rect"
+            )
+        elif custom is None and layout not in {"pip_left", "pip_center", "pip_right"}:
+            raise ValueError(
+                "picture_in_picture must use pip_left, pip_center, pip_right, or a custom rect"
+            )
+    if layout is None and custom is None:
+        return None
+    if custom is not None and layout not in (None, "custom"):
+        raise ValueError("overlay must use either a named layout or rect, not both")
+
+    if custom is not None:
+        rect = _normalized_rect(custom, "overlay rect")
+    else:
+        if layout not in OVERLAY_LAYOUTS:
+            choices = ", ".join([*OVERLAY_LAYOUTS, "custom"])
+            raise ValueError(f"unknown overlay layout '{layout}'; choose {choices}")
+        rect = dict(OVERLAY_LAYOUTS[layout])
+
+    caption_region: dict[str, float] | None = None
+    if has_subtitles:
+        raw_region = (caption_config or {}).get("safe_region", DEFAULT_CAPTION_REGION)
+        caption_region = _normalized_rect(raw_region, "caption safe_region")
+        if layout == "full" and custom is None:
+            # Full footage fills every pixel that is not reserved for captions.
+            if caption_region["x"] == 0.0 and caption_region["width"] == 1.0:
+                rect["height"] = min(rect["height"], caption_region["y"])
+
+    if caption_region and _rects_intersect(rect, caption_region):
+        raise ValueError(
+            "overlay rectangle intersects captions.safe_region; move or resize the "
+            "overlay so captions never cover footage or illustrations"
+        )
+    return rect
+
+
+def validate_overlay_contracts(
+    overlays: list[dict],
+    protected_regions: list[dict] | None,
+    has_subtitles: bool,
+    caption_config: dict | None = None,
+) -> None:
+    """Reject temporal/spatial collisions before starting an expensive render."""
+    resolved: list[tuple[dict, dict[str, float] | None, float, float]] = []
+    protected_regions = protected_regions or []
+
+    seen_web_assets: dict[str, dict] = {}
+    for index, overlay in enumerate(overlays):
+        start, end = overlay_time_range(overlay)
+        rect = resolve_overlay_rect(overlay, has_subtitles, caption_config)
+        resolved.append((overlay, rect, start, end))
+
+        if overlay.get("media_kind") == "web":
+            required = ("source_url", "source_start", "source_end", "asset_id")
+            missing = [field for field in required if overlay.get(field) in (None, "")]
+            if not (overlay.get("id") or overlay.get("beat_id")):
+                missing.append("id or beat_id")
+            if missing:
+                raise ValueError(
+                    f"web overlay {index} is missing provenance fields: {', '.join(missing)}"
+                )
+            asset_id = str(overlay["asset_id"])
+            prior = seen_web_assets.get(asset_id)
+            if prior is not None:
+                prior_id = prior.get("id") or prior.get("beat_id")
+                if overlay.get("reuse_of") != prior_id:
+                    raise ValueError(
+                        f"web asset {asset_id} appears more than once; reuse_of must "
+                        f"reference the original overlay '{prior_id}'"
+                    )
+                if overlay.get("file") != prior.get("file"):
+                    raise ValueError(
+                        f"reused web asset {asset_id} must reference the same prepared file"
+                    )
+            else:
+                seen_web_assets[asset_id] = overlay
+
+    for region_index, region in enumerate(protected_regions):
+        label = str(region.get("owner") or region.get("id") or region_index)
+        try:
+            region_start = float(region["start_in_output"])
+            region_end = region_start + float(region["duration"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"protected region '{label}' requires numeric start_in_output and duration"
+            ) from exc
+        if region_start < 0 or region_end <= region_start:
+            raise ValueError(f"protected region '{label}' has an invalid time range")
+        region_rect = _normalized_rect(region.get("rect"), f"protected region '{label}'")
+        for overlay, rect, start, end in resolved:
+            if overlay.get("composition") == "cutaway":
+                continue
+            if rect is None or not _time_ranges_intersect(start, end, region_start, region_end):
+                continue
+            if _rects_intersect(rect, region_rect):
+                overlay_label = overlay.get("id") or overlay.get("beat_id") or overlay.get("file")
+                raise ValueError(
+                    f"overlay '{overlay_label}' intersects protected illustration '{label}' "
+                    "during the same output interval; use a cutaway or move the overlay"
+                )
+
+    for index, (first, first_rect, first_start, first_end) in enumerate(resolved):
+        if first_rect is None or first.get("allow_overlap"):
+            continue
+        for second, second_rect, second_start, second_end in resolved[index + 1 :]:
+            if second_rect is None or second.get("allow_overlap"):
+                continue
+            if not _time_ranges_intersect(first_start, first_end, second_start, second_end):
+                continue
+            if _rects_intersect(first_rect, second_rect):
+                first_label = first.get("id") or first.get("file")
+                second_label = second.get("id") or second.get("file")
+                raise ValueError(
+                    f"overlays '{first_label}' and '{second_label}' overlap in space and time"
+                )
+
+
+def _even_pixel(value: float, maximum: int, *, minimum: int = 0) -> int:
+    """Convert a normalized coordinate/size to an even pixel value for yuv420p."""
+    pixels = int(round(value * maximum))
+    pixels = max(minimum, min(maximum, pixels))
+    if pixels % 2:
+        pixels -= 1
+    return max(minimum, pixels)
+
+
 def build_final_composite(
     base_path: Path,
     overlays: list[dict],
     subtitles_path: Path | None,
     out_path: Path,
     edit_dir: Path,
+    caption_config: dict | None = None,
+    protected_regions: list[dict] | None = None,
 ) -> None:
     """Final pass: base → overlays (PTS-shifted) → subtitles LAST → out.
 
@@ -636,6 +1092,9 @@ def build_final_composite(
     """
     has_overlays = bool(overlays)
     has_subs = subtitles_path is not None and subtitles_path.exists()
+    validate_overlay_contracts(
+        overlays, protected_regions, has_subs, caption_config
+    )
 
     if not has_overlays and not has_subs:
         # Nothing to do — just rename/copy base to final name
@@ -647,11 +1106,40 @@ def build_final_composite(
         ov_path = resolve_path(ov["file"], edit_dir)
         inputs += ["-i", str(ov_path)]
 
+    base_width, base_height = probe_video_size(base_path)
     filter_parts: list[str] = []
     # PTS-shift every overlay so its frame 0 lands at start_in_output
     for idx, ov in enumerate(overlays, start=1):
         t = float(ov["start_in_output"])
-        filter_parts.append(f"[{idx}:v]setpts=PTS-STARTPTS+{t}/TB[a{idx}]")
+        rect = resolve_overlay_rect(ov, has_subs, caption_config)
+        if rect is None:
+            filter_parts.append(
+                f"[{idx}:v]scale={base_width}:{base_height}:"
+                "force_original_aspect_ratio=increase,"
+                f"crop={base_width}:{base_height},setsar=1,"
+                f"setpts=PTS-STARTPTS+{t}/TB[a{idx}]"
+            )
+            continue
+
+        width = _even_pixel(rect["width"], base_width, minimum=2)
+        height = _even_pixel(rect["height"], base_height, minimum=2)
+        fit = ov.get("fit", "cover")
+        if fit == "cover":
+            geometry = (
+                f"scale={width}:{height}:force_original_aspect_ratio=increase,"
+                f"crop={width}:{height}"
+            )
+        elif fit == "contain":
+            background = str(ov.get("background", "#050914")).replace("'", "")
+            geometry = (
+                f"scale={width}:{height}:force_original_aspect_ratio=decrease,"
+                f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:color={background}"
+            )
+        else:
+            raise ValueError("overlay fit must be 'cover' or 'contain'")
+        filter_parts.append(
+            f"[{idx}:v]{geometry},setsar=1,setpts=PTS-STARTPTS+{t}/TB[a{idx}]"
+        )
 
     # Chain overlays on top of base
     current = "[0:v]"
@@ -660,17 +1148,28 @@ def build_final_composite(
         dur = float(ov["duration"])
         end = t + dur
         next_label = f"[v{idx}]"
+        rect = resolve_overlay_rect(ov, has_subs, caption_config)
+        if rect is None:
+            position = "x=0:y=0"
+        else:
+            x = _even_pixel(rect["x"], base_width)
+            y = _even_pixel(rect["y"], base_height)
+            position = f"x={x}:y={y}"
         filter_parts.append(
-            f"{current}[a{idx}]overlay=enable='between(t,{t:.3f},{end:.3f})'{next_label}"
+            f"{current}[a{idx}]overlay={position}:enable="
+            f"'between(t,{t:.3f},{end:.3f})'{next_label}"
         )
         current = next_label
 
     # Subtitles LAST — Rule 1
     if has_subs:
         subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
-        filter_parts.append(
-            f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
-        )
+        if subtitles_path.suffix.lower() == ".ass":
+            filter_parts.append(f"{current}subtitles='{subs_abs}'[outv]")
+        else:
+            filter_parts.append(
+                f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
+            )
         out_label = "[outv]"
     else:
         # Rename the last overlay output to [outv] for consistency
@@ -682,8 +1181,9 @@ def build_final_composite(
 
     filter_complex = ";".join(filter_parts)
 
+    ffmpeg_binary = ffmpeg_with_subtitles() if has_subs else "ffmpeg"
     cmd = [
-        "ffmpeg", "-y",
+        ffmpeg_binary, "-y",
         *inputs,
         "-filter_complex", filter_complex,
         "-map", out_label,
@@ -699,14 +1199,273 @@ def build_final_composite(
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
 
+def _extract_review_frame(media: Path, timestamp: float, output: Path) -> None:
+    """Extract one video frame, or normalize a still image, for preflight."""
+    if media.suffix.casefold() in {".png", ".jpg", ".jpeg", ".webp", ".tif", ".tiff"}:
+        from PIL import Image
+
+        with Image.open(media) as image:
+            image.convert("RGBA").save(output)
+        return
+    command = [
+        "ffmpeg",
+        "-y",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-ss",
+        f"{max(0.0, timestamp):.3f}",
+        "-i",
+        str(media),
+        "-frames:v",
+        "1",
+        str(output),
+    ]
+    subprocess.run(command, check=True)
+
+
+def build_overlay_preflight(
+    base_path: Path,
+    overlays: list[dict],
+    output: Path,
+    edit_dir: Path,
+    *,
+    has_subtitles: bool,
+    caption_config: dict | None,
+    protected_regions: list[dict] | None,
+) -> Path:
+    """Create an entry/middle/exit contact sheet without rendering the video.
+
+    The sheet uses the exact layout math from final compositing and marks the
+    caption rail plus active protected illustration regions. It is intended as
+    the cheap approval gate before an expensive full Manim/FFmpeg pass.
+    """
+    if not overlays:
+        raise ValueError("overlay preflight requires at least one overlay")
+    if output.suffix.casefold() != ".png":
+        raise ValueError("overlay preflight output must be a .png file")
+    validate_overlay_contracts(
+        overlays, protected_regions, has_subtitles, caption_config
+    )
+
+    from PIL import Image, ImageDraw, ImageOps
+
+    cell_width, cell_height = 640, 360
+    label_height = 34
+    columns = 3
+    sheet = Image.new(
+        "RGB",
+        (cell_width * columns, (cell_height + label_height) * len(overlays)),
+        "#080b12",
+    )
+    protected_regions = protected_regions or []
+    caption_region = None
+    if has_subtitles:
+        caption_region = _normalized_rect(
+            (caption_config or {}).get("safe_region", DEFAULT_CAPTION_REGION),
+            "caption safe_region",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="video-use-preflight-") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        for row, overlay in enumerate(overlays):
+            start, end = overlay_time_range(overlay)
+            duration = end - start
+            inset = min(0.10, duration / 4)
+            local_samples = (inset, duration / 2, max(inset, duration - inset))
+            rect = resolve_overlay_rect(overlay, has_subtitles, caption_config)
+            if rect is None:
+                rect = {"x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0}
+            overlay_path = resolve_path(str(overlay["file"]), edit_dir)
+            if not overlay_path.exists():
+                raise ValueError(f"overlay file does not exist: {overlay_path}")
+
+            for column, local_time in enumerate(local_samples):
+                output_time = start + local_time
+                base_frame = temp_dir / f"base-{row}-{column}.png"
+                media_frame = temp_dir / f"overlay-{row}-{column}.png"
+                _extract_review_frame(base_path, output_time, base_frame)
+                _extract_review_frame(overlay_path, local_time, media_frame)
+
+                with Image.open(base_frame) as image:
+                    frame = ImageOps.fit(
+                        image.convert("RGBA"), (cell_width, cell_height), method=Image.Resampling.LANCZOS
+                    )
+                with Image.open(media_frame) as image:
+                    source = image.convert("RGBA")
+
+                x = int(round(rect["x"] * cell_width))
+                y = int(round(rect["y"] * cell_height))
+                width = max(1, int(round(rect["width"] * cell_width)))
+                height = max(1, int(round(rect["height"] * cell_height)))
+                if overlay.get("fit", "cover") == "contain":
+                    background = Image.new(
+                        "RGBA", (width, height), str(overlay.get("background", "#050914"))
+                    )
+                    contained = ImageOps.contain(
+                        source, (width, height), method=Image.Resampling.LANCZOS
+                    )
+                    background.alpha_composite(
+                        contained,
+                        ((width - contained.width) // 2, (height - contained.height) // 2),
+                    )
+                    placed = background
+                else:
+                    placed = ImageOps.fit(
+                        source, (width, height), method=Image.Resampling.LANCZOS
+                    )
+                frame.alpha_composite(placed, (x, y))
+
+                draw = ImageDraw.Draw(frame, "RGBA")
+                draw.rectangle((x, y, x + width - 1, y + height - 1), outline="#48E0A4", width=3)
+                if caption_region is not None:
+                    cx = int(round(caption_region["x"] * cell_width))
+                    cy = int(round(caption_region["y"] * cell_height))
+                    cw = int(round(caption_region["width"] * cell_width))
+                    ch = int(round(caption_region["height"] * cell_height))
+                    draw.rectangle((cx, cy, cx + cw, cy + ch), fill=(255, 177, 66, 35))
+                    draw.rectangle((cx, cy, cx + cw, cy + ch), outline="#FFB142", width=2)
+                for region in protected_regions:
+                    region_start = float(region["start_in_output"])
+                    region_end = region_start + float(region["duration"])
+                    if not region_start <= output_time <= region_end:
+                        continue
+                    protected = _normalized_rect(region.get("rect"), "protected region")
+                    px = int(round(protected["x"] * cell_width))
+                    py = int(round(protected["y"] * cell_height))
+                    pw = int(round(protected["width"] * cell_width))
+                    ph = int(round(protected["height"] * cell_height))
+                    draw.rectangle((px, py, px + pw, py + ph), outline="#FF5964", width=3)
+
+                label = (
+                    f"{overlay.get('id') or overlay.get('beat_id') or f'overlay {row + 1}'}  "
+                    f"{('entry', 'middle', 'exit')[column]}  t={output_time:.2f}s"
+                )
+                cell_y = row * (cell_height + label_height)
+                sheet.paste(frame.convert("RGB"), (column * cell_width, cell_y))
+                label_draw = ImageDraw.Draw(sheet)
+                label_draw.text(
+                    (column * cell_width + 10, cell_y + cell_height + 8),
+                    label,
+                    fill="#EEF2FA",
+                )
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    sheet.save(output)
+    print(f"overlay preflight: {output}")
+    return output
+
+
 # -------- Main ---------------------------------------------------------------
 
 
-# command line entry point that validates the edl and runs the full pipeline
+def render_one_output(
+    *,
+    base_path: Path,
+    edl: dict,
+    edit_dir: Path,
+    out_path: Path,
+    subtitles_path: Path | None,
+    preview: bool,
+    draft: bool,
+    no_loudnorm: bool,
+    deliverable: dict | None = None,
+) -> None:
+    """Composite and normalize one legacy output or declared deliverable."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    render_base = base_path
+    reframed_path: Path | None = None
+    loudness = {
+        "integrated_lufs": LOUDNORM_I,
+        "true_peak_dbtp": LOUDNORM_TP,
+        "lra": LOUDNORM_LRA,
+    }
+    overlays = edl.get("overlays") or []
+    if deliverable is not None:
+        reframed_path = out_path.with_suffix(".reframed.mp4")
+        build_reframed_base(
+            base_path,
+            reframed_path,
+            width=int(deliverable["width"]),
+            height=int(deliverable["height"]),
+            fps=str(deliverable["fps"]),
+            reframe=deliverable["reframe"],
+            edit_dir=edit_dir,
+            preview=preview,
+            draft=draft,
+        )
+        render_base = reframed_path
+        loudness = deliverable["loudness"]
+        if "overlays" in deliverable:
+            overlays = deliverable.get("overlays") or []
+
+    try:
+        if no_loudnorm:
+            build_final_composite(
+                render_base,
+                overlays,
+                subtitles_path,
+                out_path,
+                edit_dir,
+                edl.get("captions"),
+                edl.get("protected_regions"),
+            )
+        else:
+            tmp_composite = out_path.with_suffix(".prenorm.mp4")
+            try:
+                build_final_composite(
+                    render_base,
+                    overlays,
+                    subtitles_path,
+                    tmp_composite,
+                    edit_dir,
+                    edl.get("captions"),
+                    edl.get("protected_regions"),
+                )
+                print(
+                    "loudness normalization → "
+                    f"{loudness['integrated_lufs']:g} LUFS / "
+                    f"{loudness['true_peak_dbtp']:g} dBTP / "
+                    f"LRA {loudness['lra']:g}"
+                )
+                apply_loudnorm_two_pass(
+                    tmp_composite,
+                    out_path,
+                    preview=draft,
+                    integrated_lufs=float(loudness["integrated_lufs"]),
+                    true_peak_dbtp=float(loudness["true_peak_dbtp"]),
+                    lra=float(loudness["lra"]),
+                )
+            finally:
+                tmp_composite.unlink(missing_ok=True)
+    finally:
+        if reframed_path is not None:
+            reframed_path.unlink(missing_ok=True)
+
+    size_mb = out_path.stat().st_size / (1024 * 1024)
+    label = f" [{deliverable['id']}]" if deliverable else ""
+    print(f"done:{label} {out_path} ({size_mb:.1f} MB)")
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="Render a video from an EDL")
     ap.add_argument("edl", type=Path, help="Path to edl.json")
-    ap.add_argument("-o", "--output", type=Path, required=True, help="Output video path")
+    ap.add_argument("-o", "--output", type=Path, help="Output video path")
+    selection = ap.add_mutually_exclusive_group()
+    selection.add_argument(
+        "--deliverable",
+        help="Render one deliverable id from the EDL; its declared file is used unless -o is set",
+    )
+    selection.add_argument(
+        "--all-deliverables",
+        action="store_true",
+        help="Render every deliverable declared in the EDL",
+    )
+    ap.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Override declared deliverable files and write <id>.mp4 into this directory",
+    )
     ap.add_argument(
         "--preview",
         action="store_true",
@@ -730,7 +1489,19 @@ def main() -> None:
     ap.add_argument(
         "--no-loudnorm",
         action="store_true",
-        help="Skip audio loudness normalization. Default is on (-14 LUFS, -1 dBTP, LRA 11).",
+        help="Skip audio loudness normalization. Default is on and uses each "
+             "deliverable target, or -14 LUFS / -1 dBTP / LRA 11 for legacy output.",
+    )
+    ap.add_argument(
+        "--preflight-overlays",
+        action="store_true",
+        help="Write a PNG contact sheet for overlay entry/middle/exit frames and stop",
+    )
+    ap.add_argument(
+        "--preflight-base",
+        type=Path,
+        default=None,
+        help="Existing base video for a fast overlay preflight; skips segment extraction",
     )
     ap.add_argument(
         "--fps",
@@ -748,7 +1519,58 @@ def main() -> None:
 
     edl = json.loads(edl_path.read_text())
     edit_dir = edl_path.parent
-    out_path = args.output.resolve()
+    try:
+        validate_edl(edl, edit_dir)
+    except EDLValidationError as exc:
+        sys.exit(str(exc))
+    output_dir = args.output_dir.resolve() if args.output_dir else None
+    try:
+        deliverables = normalize_deliverables(edl, edit_dir, output_dir=output_dir)
+    except EDLValidationError as exc:
+        sys.exit(str(exc))
+    if args.output_dir and not (args.all_deliverables or args.deliverable):
+        ap.error("--output-dir requires --deliverable or --all-deliverables")
+    if args.all_deliverables and not deliverables:
+        ap.error("--all-deliverables requires EDL deliverables")
+    if args.deliverable and not deliverables:
+        ap.error("--deliverable requires EDL deliverables")
+    selected_deliverables: list[dict] = []
+    if args.all_deliverables:
+        selected_deliverables = deliverables
+    elif args.deliverable:
+        selected_deliverables = [
+            item for item in deliverables if item["id"] == args.deliverable
+        ]
+        if not selected_deliverables:
+            choices = ", ".join(item["id"] for item in deliverables)
+            ap.error(f"unknown deliverable '{args.deliverable}'; choose {choices}")
+    elif args.output is None:
+        ap.error("-o/--output is required unless a deliverable selector is used")
+    if args.output is not None and args.all_deliverables:
+        ap.error("-o/--output cannot be combined with --all-deliverables; use --output-dir")
+
+    out_path = args.output.resolve() if args.output else None
+    overlays = edl.get("overlays") or []
+
+    if args.preflight_base is not None:
+        if not args.preflight_overlays:
+            ap.error("--preflight-base requires --preflight-overlays")
+        base_path = resolve_path(str(args.preflight_base), edit_dir)
+        if not base_path.exists():
+            sys.exit(f"preflight base not found: {base_path}")
+        if out_path is None:
+            ap.error("overlay preflight requires -o/--output")
+        has_subtitles = not args.no_subtitles and bool(edl.get("subtitles"))
+        build_overlay_preflight(
+            base_path,
+            overlays,
+            out_path,
+            edit_dir,
+            has_subtitles=has_subtitles,
+            caption_config=edl.get("captions"),
+            protected_regions=edl.get("protected_regions"),
+        )
+        return
 
     # 1. Extract per-segment (auto-grade per range if EDL grade is "auto")
     segment_paths = extract_all_segments(
@@ -777,21 +1599,51 @@ def main() -> None:
                 print(f"warning: subtitles path in EDL does not exist: {subs_path}")
                 subs_path = None
 
-    # 4. Composite (overlays + subtitles LAST) → intermediate (pre-loudnorm) path
-    overlays = edl.get("overlays") or []
-    if args.no_loudnorm:
-        # Composite directly to final output
-        build_final_composite(base_path, overlays, subs_path, out_path, edit_dir)
-    else:
-        # Composite to a temp file, then run loudnorm → final output
-        tmp_composite = out_path.with_suffix(".prenorm.mp4")
-        build_final_composite(base_path, overlays, subs_path, tmp_composite, edit_dir)
-        print("loudness normalization → social-ready (-14 LUFS / -1 dBTP / LRA 11)")
-        apply_loudnorm_two_pass(tmp_composite, out_path, preview=args.draft)
-        tmp_composite.unlink(missing_ok=True)
+    if args.preflight_overlays:
+        if out_path is None:
+            ap.error("overlay preflight requires -o/--output")
+        build_overlay_preflight(
+            base_path,
+            overlays,
+            out_path,
+            edit_dir,
+            has_subtitles=subs_path is not None and subs_path.exists(),
+            caption_config=edl.get("captions"),
+            protected_regions=edl.get("protected_regions"),
+        )
+        return
 
-    size_mb = out_path.stat().st_size / (1024 * 1024)
-    print(f"\ndone: {out_path} ({size_mb:.1f} MB)")
+    # 4. Reframe each delivery, composite overlays/subtitles LAST, then loudnorm.
+    if selected_deliverables:
+        for deliverable in selected_deliverables:
+            delivery_output = (
+                out_path
+                if len(selected_deliverables) == 1 and out_path is not None
+                else deliverable["output_path"]
+            )
+            render_one_output(
+                base_path=base_path,
+                edl=edl,
+                edit_dir=edit_dir,
+                out_path=delivery_output,
+                subtitles_path=subs_path,
+                preview=args.preview,
+                draft=args.draft,
+                no_loudnorm=args.no_loudnorm,
+                deliverable=deliverable,
+            )
+    else:
+        assert out_path is not None
+        render_one_output(
+            base_path=base_path,
+            edl=edl,
+            edit_dir=edit_dir,
+            out_path=out_path,
+            subtitles_path=subs_path,
+            preview=args.preview,
+            draft=args.draft,
+            no_loudnorm=args.no_loudnorm,
+        )
 
 
 if __name__ == "__main__":

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import shutil
 import subprocess
@@ -927,6 +928,9 @@ def _normalized_rect(value: dict, label: str) -> dict[str, float]:
             f"{label} must contain numeric x, y, width, and height values"
         ) from exc
 
+    # nan and inf slip through ordered comparisons so they are rejected first
+    if not all(math.isfinite(number) for number in rect.values()):
+        raise ValueError(f"{label} must contain finite numbers")
     # reject rects with a negative origin or non positive size or that spill past the frame edge
     if rect["x"] < 0 or rect["y"] < 0 or rect["width"] <= 0 or rect["height"] <= 0:
         raise ValueError(f"{label} must use non-negative x/y and positive width/height")

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -1,7 +1,3 @@
-# the ffmpeg render pipeline that turns an edl into finished video files
-# it extracts graded segments and concatenates them and then composites overlays and subtitles and normalizes loudness
-# it also handles per deliverable reframing and the overlay preflight contact sheet and the command line entry point
-
 """Render a video from an EDL.
 
 Implements the HEURISTICS render pipeline in the correct order:

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -1,3 +1,7 @@
+# the ffmpeg render pipeline that turns an edl into a finished video file
+# it extracts graded segments and concatenates them and then composites overlays and subtitles and normalizes loudness
+# it also builds the master srt from transcripts and holds the command line entry point
+
 """Render a video from an EDL.
 
 Implements the HEURISTICS render pipeline in the correct order:
@@ -32,9 +36,13 @@ from pathlib import Path
 try:
     from grade import get_preset, auto_grade_for_clip  # same directory
 except Exception:
+    # fallback that only knows the identity grade when the grade helper is unavailable
+    # fallback that only knows the identity grade when the grade helper is unavailable
     def get_preset(name: str) -> str:
         return ""
 
+    # fallback that skips auto grading when the grade helper is unavailable
+    # fallback that skips auto grading when the grade helper is unavailable
     def auto_grade_for_clip(video, start=0.0, duration=None, verbose=False):  # type: ignore
         return "eq=contrast=1.03:saturation=0.98", {}
 
@@ -59,12 +67,14 @@ SUB_FORCE_STYLE = (
 # -------- Helpers ------------------------------------------------------------
 
 
+# run a command with check and print an abbreviated version unless quiet
 def run(cmd: list[str], quiet: bool = False) -> None:
     if not quiet:
         print(f"  $ {' '.join(str(c) for c in cmd[:6])}{' …' if len(cmd) > 6 else ''}")
     subprocess.run(cmd, check=True)
 
 
+# turn the edl grade field into a filter string or the auto sentinel
 def resolve_grade_filter(grade_field: str | None) -> str:
     """The EDL's 'grade' field can be a preset name, a raw ffmpeg filter, or 'auto'.
 
@@ -85,6 +95,7 @@ def resolve_grade_filter(grade_field: str | None) -> str:
     return grade_field
 
 
+# resolve a path relative to base unless it is already absolute
 def resolve_path(maybe_path: str, base: Path) -> Path:
     """Resolve a path that may be absolute or relative to `base`."""
     p = Path(maybe_path)
@@ -118,6 +129,7 @@ TONEMAP_CHAIN = (
 )
 
 
+# detect pq or hlg transfer metadata on the first video stream
 def is_hdr_source(video: Path) -> bool:
     """Return True if the source uses a PQ or HLG transfer function."""
     try:
@@ -132,6 +144,7 @@ def is_hdr_source(video: Path) -> bool:
         return False
 
 
+# report whether the first video stream is taller than it is wide
 def is_portrait_source(video: Path) -> bool:
     """Return True if the displayed video is portrait, including rotation."""
     try:
@@ -172,6 +185,7 @@ def is_portrait_source(video: Path) -> bool:
         return False
 
 
+# validate an fps argument and return it as a reduced rational string
 def parse_fps(value: str) -> str:
     """Validate and canonicalize an ffmpeg frame rate."""
     text = value.strip()
@@ -198,6 +212,7 @@ def parse_fps(value: str) -> str:
     return f"{rate.numerator}/{rate.denominator}"
 
 
+# read the source frame rate from ffprobe preferring the average rate
 def probe_source_fps(video: Path) -> str | None:
     """Return an ffmpeg-ready source rate, preferring the average frame rate.
 
@@ -216,6 +231,7 @@ def probe_source_fps(video: Path) -> str | None:
         streams = json.loads(out.stdout).get("streams") or []
         if not streams:
             return None
+        # take the first usable rate and skip zero or unparsable values
         for field in ("avg_frame_rate", "r_frame_rate"):
             value = streams[0].get(field)
             if value and value != "0/0":
@@ -231,6 +247,7 @@ def probe_source_fps(video: Path) -> str | None:
 # -------- Per-segment extraction (Rule 2 + Rule 3) --------------------------
 
 
+# encode one edl range as its own mp4 with tone mapping scaling grade and audio fades applied
 def extract_segment(
     source: Path,
     seg_start: float,
@@ -253,12 +270,14 @@ def extract_segment(
     """
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
+    # scale by height for portrait sources so orientation is preserved
     portrait = is_portrait_source(source)
     if draft:
         scale = "scale=-2:1280" if portrait else "scale=1280:-2"
     else:
         scale = "scale=-2:1920" if portrait else "scale=1920:-2"
 
+    # tone map hdr first then scale then grade
     vf_parts: list[str] = []
     if is_hdr_source(source):
         vf_parts.append(TONEMAP_CHAIN)
@@ -300,6 +319,7 @@ def extract_segment(
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
 
+# extract every edl range into graded segment files sharing one output frame rate
 def extract_all_segments(
     edl: dict,
     edit_dir: Path,
@@ -368,10 +388,12 @@ def extract_all_segments(
 # -------- Lossless concat ----------------------------------------------------
 
 
+# join segment files losslessly with the concat demuxer
 def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -> None:
     """Lossless concat via the concat demuxer. No re-encode."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
     concat_list = edit_dir / "_concat.txt"
+    # the concat demuxer reads a text file listing each segment path
     concat_list.write_text("".join(f"file '{p.resolve()}'\n" for p in segment_paths))
 
     cmd = [
@@ -393,6 +415,7 @@ def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -
 PUNCT_BREAK = set(".,!?;:")
 
 
+# format seconds as an srt timestamp with millisecond precision
 def _srt_timestamp(seconds: float) -> str:
     total_ms = int(round(seconds * 1000))
     h, rem = divmod(total_ms, 3600_000)
@@ -401,6 +424,7 @@ def _srt_timestamp(seconds: float) -> str:
     return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
 
 
+# return transcript words that overlap the given source time range
 def _words_in_range(transcript: dict, t_start: float, t_end: float) -> list[dict]:
     out: list[dict] = []
     for w in transcript.get("words", []):
@@ -410,12 +434,14 @@ def _words_in_range(transcript: dict, t_start: float, t_end: float) -> list[dict
         we = w.get("end")
         if ws is None or we is None:
             continue
+        # keep only words that overlap the range
         if we <= t_start or ws >= t_end:
             continue
         out.append(w)
     return out
 
 
+# build an output timeline srt from per source transcripts using two word uppercase chunks
 def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
     """Build an output-timeline SRT from per-source transcripts.
 
@@ -461,6 +487,7 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
             chunks.append(current)
 
         for chunk in chunks:
+            # clamp chunk times to the segment then shift them onto the output timeline
             local_start = max(seg_start, chunk[0].get("start", seg_start))
             local_end = min(seg_end, chunk[-1].get("end", seg_end))
             out_start = max(0.0, local_start - seg_start) + seg_offset
@@ -498,6 +525,7 @@ LOUDNORM_TP = -1.0
 LOUDNORM_LRA = 11.0
 
 
+# run the loudnorm first pass and parse its json measurement from stderr
 def measure_loudness(video_path: Path) -> dict[str, str] | None:
     """Run ffmpeg loudnorm first pass and parse the JSON measurement.
 
@@ -532,6 +560,7 @@ def measure_loudness(video_path: Path) -> dict[str, str] | None:
     return data
 
 
+# normalize audio with two pass loudnorm or a one pass approximation in preview mode
 def apply_loudnorm_two_pass(
     input_path: Path,
     output_path: Path,
@@ -597,6 +626,7 @@ def apply_loudnorm_two_pass(
 # -------- Final compositing (Rule 1 + Rule 4) -------------------------------
 
 
+# composite overlays onto the base and burn subtitles last in one ffmpeg filter graph
 def build_final_composite(
     base_path: Path,
     overlays: list[dict],
@@ -676,6 +706,7 @@ def build_final_composite(
 # -------- Main ---------------------------------------------------------------
 
 
+# command line entry point that validates the edl and runs the full pipeline
 def main() -> None:
     ap = argparse.ArgumentParser(description="Render a video from an EDL")
     ap.add_argument("edl", type=Path, help="Path to edl.json")

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -1,7 +1,3 @@
-# renders a filmstrip and waveform composite png for a time range of a video
-# frames come from ffmpeg the audio envelope is a windowed rms over a temp wav and transcript words and silences are drawn over the ribbon
-# meant as an on demand drill down at cut decisions rather than a bulk index
-
 """Filmstrip + waveform composite PNG for a time range of a video.
 
 The only visual drill-down tool. Given a video and a [start, end] range,

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -54,7 +54,7 @@ def extract_frames(video: Path, start: float, end: float, n: int, dest_dir: Path
             "-i", str(video),
             "-frames:v", "1",
             "-q:v", "4",
-            "-vf", "scale=320:-2",
+            "-vf", "scale=320:-2,format=yuvj420p",
             str(out),
         ]
         subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -1,3 +1,7 @@
+# renders a filmstrip and waveform composite png for a time range of a video
+# frames come from ffmpeg the audio envelope is a windowed rms over a temp wav and transcript words and silences are drawn over the ribbon
+# meant as an on demand drill down at cut decisions rather than a bulk index
+
 """Filmstrip + waveform composite PNG for a time range of a video.
 
 The only visual drill-down tool. Given a video and a [start, end] range,
@@ -34,11 +38,13 @@ from PIL import Image, ImageDraw, ImageFont
 # -------- Frame extraction ---------------------------------------------------
 
 
+# grab n evenly spaced jpeg frames from the range with ffmpeg and return their paths in order
 def extract_frames(video: Path, start: float, end: float, n: int, dest_dir: Path) -> list[Path]:
     """Extract N frames evenly spaced across [start, end]. Returns paths in order."""
     dest_dir.mkdir(parents=True, exist_ok=True)
     if n < 1:
         n = 1
+    # a single frame sits at the midpoint otherwise spread frames so the first and last land on the range edges
     if n == 1:
         times = [(start + end) / 2.0]
     else:
@@ -65,6 +71,7 @@ def extract_frames(video: Path, start: float, end: float, n: int, dest_dir: Path
 # -------- Audio envelope (librosa if available, ffmpeg fallback) ------------
 
 
+# dump the audio range to a mono wav and turn it into a normalized rms envelope of fixed length
 def compute_envelope(video: Path, start: float, end: float, samples: int = 2000) -> np.ndarray:
     """Extract the audio segment and return an RMS envelope of length `samples`.
 
@@ -100,6 +107,7 @@ def compute_envelope(video: Path, start: float, end: float, samples: int = 2000)
         usable = (n // window) * window
         reshaped = pcm[:usable].reshape(-1, window)
         env = np.sqrt(np.mean(reshaped ** 2, axis=1))
+        # pad or trim so the envelope always has exactly samples entries
         if env.size < samples:
             env = np.pad(env, (0, samples - env.size))
         elif env.size > samples:
@@ -115,6 +123,7 @@ def compute_envelope(video: Path, start: float, end: float, samples: int = 2000)
 # -------- Transcript word overlays ------------------------------------------
 
 
+# return transcript word entries that overlap the requested range
 def words_in_range(transcript_path: Path, start: float, end: float) -> list[dict]:
     if not transcript_path.exists():
         return []
@@ -126,12 +135,14 @@ def words_in_range(transcript_path: Path, start: float, end: float) -> list[dict
         we = w.get("end")
         if ws is None or we is None:
             continue
+        # skip tokens that end before the range or begin after it
         if we <= start or ws >= end:
             continue
         out.append(w)
     return out
 
 
+# scan kept tokens for gaps of at least threshold seconds and return them as time pairs
 def find_silences(words: list[dict], start: float, end: float, threshold: float = 0.4) -> list[tuple[float, float]]:
     """Find gaps >= threshold seconds inside [start, end] between kept tokens."""
     gaps: list[tuple[float, float]] = []
@@ -143,6 +154,7 @@ def find_silences(words: list[dict], start: float, end: float, threshold: float 
         if ws - prev_end >= threshold:
             gaps.append((prev_end, ws))
         prev_end = max(prev_end, w.get("end", ws))
+    # also report a trailing gap between the last token and the range end
     if end - prev_end >= threshold:
         gaps.append((prev_end, end))
     return gaps
@@ -160,6 +172,7 @@ FONT_CANDIDATES = [
 ]
 
 
+# try the known monospace and system font paths and fall back to the pillow default
 def load_font(size: int) -> ImageFont.ImageFont:
     for fp in FONT_CANDIDATES:
         if Path(fp).exists():
@@ -181,6 +194,7 @@ SILENCE = (50, 80, 120, 120)  # muted blue, semi-transparent
 WAVE = (140, 180, 255)
 
 
+# draw the full composite of header filmstrip silence bands waveform word labels and time ruler then save it
 def render_timeline(
     video: Path,
     start: float,
@@ -235,6 +249,7 @@ def render_timeline(
         # Filmstrip
         x = 50
         strip_width = canvas_width - 100
+        # paste frames at full size when they fit otherwise scale the whole strip down to the canvas width
         if total_frame_w <= strip_width:
             cursor = 50
             for img in imgs:
@@ -256,6 +271,7 @@ def render_timeline(
         strip_x1 = 50 + draw_width
         strip_span = strip_x1 - strip_x0
 
+        # map a timestamp inside the range onto a pixel column of the strip
         def time_to_x(t: float) -> int:
             frac = (t - start) / max(1e-6, (end - start))
             return int(strip_x0 + frac * strip_span)
@@ -277,6 +293,7 @@ def render_timeline(
         max_amp = wave_h // 2 - 8
         points_top: list[tuple[int, int]] = []
         points_bot: list[tuple[int, int]] = []
+        # mirror the envelope above and below the midline to draw a symmetric waveform
         for i, v in enumerate(env):
             xi = strip_x0 + int(i * strip_span / max(1, len(env) - 1))
             a = int(v * max_amp)
@@ -299,6 +316,7 @@ def render_timeline(
             text = (w.get("text") or "").strip()
             if not text or ws is None or we is None:
                 continue
+            # skip very short words and labels that would land within 28 px of the previous one
             if (we - ws) < 0.05:
                 continue
             cx = (time_to_x(ws) + time_to_x(we)) // 2
@@ -330,6 +348,7 @@ def render_timeline(
         print(f"saved: {out_path}  ({out_path.stat().st_size // 1024} KB)")
 
 
+# cli entry point that validates the range resolves the transcript and output paths and renders the png
 def main() -> None:
     ap = argparse.ArgumentParser(description="Filmstrip + waveform composite for a video range")
     ap.add_argument("video", type=Path, nargs="?", help="Source video")
@@ -372,6 +391,7 @@ def main() -> None:
         if auto.exists():
             transcript = auto
 
+    # default the output into the verify folder under the edit directory with the range in the file name
     out_path = args.output
     if out_path is None:
         out_dir = video.parent / "edit" / "verify"

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -1,3 +1,7 @@
+# transcribes a single video with elevenlabs scribe and caches the response as json
+# audio is extracted to a mono 16khz wav with ffmpeg then uploaded with diarization audio events and word timestamps
+# transcribe_batch imports load_api_key and transcribe_one to fan the same work out across files
+
 """Transcribe a video with ElevenLabs Scribe.
 
 Extracts mono 16kHz audio via ffmpeg, uploads to Scribe with verbatim +
@@ -33,9 +37,12 @@ import requests
 SCRIBE_URL = "https://api.elevenlabs.io/v1/speech-to-text"
 
 
+# read the elevenlabs api key from a dotenv file or the environment and exit if neither has it
 def load_api_key() -> str:
+    # check the repo root dotenv first then the working directory
     for candidate in [Path(__file__).resolve().parent.parent / ".env", Path(".env")]:
         if candidate.exists():
+            # parse key equals value lines and strip surrounding quotes from the value
             for line in candidate.read_text().splitlines():
                 line = line.strip()
                 if not line or line.startswith("#") or "=" not in line:
@@ -49,6 +56,7 @@ def load_api_key() -> str:
     return v
 
 
+# count the audio streams in a container so multi track recordings can be flagged
 def count_audio_tracks(video_path: Path) -> int:
     """How many audio streams the container holds."""
     out = subprocess.run(
@@ -59,6 +67,7 @@ def count_audio_tracks(video_path: Path) -> int:
     return len([ln for ln in out.stdout.splitlines() if ln.strip()])
 
 
+# measure the peak level of a wav in dbfs so a silent track is caught before upload
 def peak_dbfs(wav_path: Path) -> float:
     """Peak level of a 16-bit PCM wav, in dBFS. -inf for digital silence."""
     peak = 0
@@ -71,6 +80,7 @@ def peak_dbfs(wav_path: Path) -> float:
     return 20 * math.log10(peak / 32768) if peak > 0 else float("-inf")
 
 
+# use ffmpeg to write a mono 16khz pcm wav from the video
 def extract_audio(video_path: Path, dest: Path, audio_track: int = 0) -> None:
     cmd = [
         "ffmpeg", "-y", "-i", str(video_path),
@@ -81,6 +91,7 @@ def extract_audio(video_path: Path, dest: Path, audio_track: int = 0) -> None:
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
+# upload the wav to the scribe endpoint with verbatim settings and return the parsed json
 def call_scribe(
     audio_path: Path,
     api_key: str,
@@ -107,12 +118,14 @@ def call_scribe(
             timeout=1800,
         )
 
+    # any non 200 response is treated as a hard failure with a trimmed body for context
     if resp.status_code != 200:
         raise RuntimeError(f"Scribe returned {resp.status_code}: {resp.text[:500]}")
 
     return resp.json()
 
 
+# resolve where a transcript lands with the track number in the name for anything but track zero
 def transcript_path(edit_dir: Path, video: Path, audio_track: int = 0) -> Path:
     """Where a video's transcript lands.
 
@@ -125,6 +138,7 @@ def transcript_path(edit_dir: Path, video: Path, audio_track: int = 0) -> Path:
     return edit_dir / "transcripts" / f"{video.stem}{suffix}.json"
 
 
+# transcribe one video into the transcripts folder and return the json path reusing a cached file if present
 def transcribe_one(
     video: Path,
     edit_dir: Path,
@@ -189,6 +203,7 @@ def transcribe_one(
     return out_path
 
 
+# cli entry point that resolves the video and edit directory then runs a single transcription
 def main() -> None:
     ap = argparse.ArgumentParser(description="Transcribe a video with ElevenLabs Scribe")
     ap.add_argument("video", type=Path, help="Path to video file")

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -1,7 +1,3 @@
-# transcribes a single video with elevenlabs scribe and caches the response as json
-# audio is extracted to a mono 16khz wav with ffmpeg then uploaded with diarization audio events and word timestamps
-# transcribe_batch imports load_api_key and transcribe_one to fan the same work out across files
-
 """Transcribe a video with ElevenLabs Scribe.
 
 Extracts mono 16kHz audio via ffmpeg, uploads to Scribe with verbatim +

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -1,3 +1,7 @@
+# batch transcribes every video in a directory using a thread pool of scribe workers
+# it reuses transcribe_one so per file caching still applies and only pending sources are uploaded
+# failures are collected and reported at the end with a non zero exit
+
 """Batch-transcribe every video in a directory with 4 parallel workers.
 
 Walks <videos_dir> for common video extensions, runs ElevenLabs Scribe on
@@ -26,6 +30,7 @@ from transcribe import load_api_key, transcribe_one, transcript_path
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
 
 
+# list files in the directory whose suffix is a known video extension in sorted order
 def find_videos(videos_dir: Path) -> list[Path]:
     videos = sorted(
         p for p in videos_dir.iterdir()
@@ -34,6 +39,7 @@ def find_videos(videos_dir: Path) -> list[Path]:
     return videos
 
 
+# cli entry point that splits videos into cached and pending sets then transcribes the pending ones in parallel
 def main() -> None:
     ap = argparse.ArgumentParser(description="Parallel batch transcription of a videos directory")
     ap.add_argument("videos_dir", type=Path, help="Directory containing source videos")

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -1,7 +1,3 @@
-# batch transcribes every video in a directory using a thread pool of scribe workers
-# it reuses transcribe_one so per file caching still applies and only pending sources are uploaded
-# failures are collected and reported at the end with a non zero exit
-
 """Batch-transcribe every video in a directory with 4 parallel workers.
 
 Walks <videos_dir> for common video extensions, runs ElevenLabs Scribe on

--- a/install.md
+++ b/install.md
@@ -57,7 +57,7 @@ Homebrew's keg-only `ffmpeg-full` when the default build lacks it. `yt-dlp` is o
 ```bash
 # macOS
 command -v ffmpeg >/dev/null || brew install ffmpeg
-brew list ffmpeg-full >/dev/null 2>&1 || brew install ffmpeg-full  # caption burn-in
+ffmpeg -hide_banner -filters 2>/dev/null | grep -q ' subtitles ' || brew install ffmpeg-full  # only if the default build lacks libass
 command -v yt-dlp >/dev/null || brew install yt-dlp     # optional
 
 # Debian / Ubuntu

--- a/install.md
+++ b/install.md
@@ -50,11 +50,14 @@ command -v uv >/dev/null && uv sync || pip install -e .
 
 ### 3. Install ffmpeg (+ optional yt-dlp)
 
-`ffmpeg` and `ffprobe` are hard requirements. `yt-dlp` is only needed if the user wants to pull sources from URLs. Animation engines such as HyperFrames, Remotion, and Manim are installed lazily the first time a project actually needs them.
+`ffmpeg` and `ffprobe` are hard requirements. Burning SRT/ASS captions also
+requires an ffmpeg build with `libass`; `render.py` automatically finds
+Homebrew's keg-only `ffmpeg-full` when the default build lacks it. `yt-dlp` is only needed if the user wants to pull sources from URLs. Animation engines such as HyperFrames, Remotion, and Manim are installed lazily the first time a project actually needs them.
 
 ```bash
 # macOS
 command -v ffmpeg >/dev/null || brew install ffmpeg
+brew list ffmpeg-full >/dev/null 2>&1 || brew install ffmpeg-full  # caption burn-in
 command -v yt-dlp >/dev/null || brew install yt-dlp     # optional
 
 # Debian / Ubuntu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "video-use"
 version = "0.1.0"
-description = "Conversation-driven video editor skill for Claude Code"
+description = "Conversation-driven video production framework for coding agents"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
@@ -21,3 +21,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 py-modules = []
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/references/deliverables.md
+++ b/references/deliverables.md
@@ -35,7 +35,7 @@ renders each deliverable from one staged edit.
 }
 ```
 
-- `id` is a stable name used by `--deliverable <id>` and by remote workers.
+- `id` is a stable name used by `--deliverable <id>` and by any tool that reads the outputs.
 - `file` is relative to the EDL directory unless absolute.
 - `width`/`height` may also be written as `resolution: "1080x1920"`.
 - `fps` accepts integers, decimals, or rationals such as `30000/1001`.
@@ -73,7 +73,6 @@ python helpers/render.py edit/edl.json --deliverable social_9x16
 python helpers/render.py edit/edl.json --all-deliverables --output-dir <dir>
 ```
 
-Use `--output-dir` when a remote worker must keep all artifacts inside its own
-run directory. Blocked EDLs, empty ranges, missing sources, missing tracks,
+Use `--output-dir` to keep every rendered deliverable inside one directory. Blocked EDLs, empty ranges, missing sources, missing tracks,
 invalid dimensions, and invalid loudness targets are rejected before any
 extraction starts.

--- a/references/deliverables.md
+++ b/references/deliverables.md
@@ -19,7 +19,7 @@ renders each deliverable from one staged edit.
       "width": 1920,
       "height": 1080,
       "fps": 30,
-      "reframe_track": "broadcast_16x9",
+      "reframe": "cover",
       "loudness": {"integrated_lufs": -24, "true_peak_dbtp": -2, "lra": 11}
     },
     {

--- a/references/deliverables.md
+++ b/references/deliverables.md
@@ -1,0 +1,79 @@
+# Deliverables, reframe tracks, and loudness targets
+
+Declare every delivery format in the EDL instead of running ad hoc ffmpeg
+commands. `helpers/edl.py` validates the declaration and `helpers/render.py`
+renders each deliverable from one staged edit.
+
+## Declaration
+
+```json
+{
+  "reframe": {
+    "mode": "track",
+    "track_file": "reframe_tracks.json"
+  },
+  "deliverables": [
+    {
+      "id": "broadcast_16x9",
+      "file": "deliverables/broadcast.mp4",
+      "width": 1920,
+      "height": 1080,
+      "fps": 30,
+      "reframe_track": "broadcast_16x9",
+      "loudness": {"integrated_lufs": -24, "true_peak_dbtp": -2, "lra": 11}
+    },
+    {
+      "id": "social_9x16",
+      "file": "deliverables/social_vertical.mp4",
+      "width": 1080,
+      "height": 1920,
+      "fps": 30,
+      "reframe_track": "social_9x16",
+      "loudness": {"integrated_lufs": -16, "true_peak_dbtp": -1, "lra": 11}
+    }
+  ]
+}
+```
+
+- `id` is a stable name used by `--deliverable <id>` and by remote workers.
+- `file` is relative to the EDL directory unless absolute.
+- `width`/`height` may also be written as `resolution: "1080x1920"`.
+- `fps` accepts integers, decimals, or rationals such as `30000/1001`.
+- `loudness` sets the two-pass loudnorm target per deliverable.
+
+## Reframe modes
+
+- `cover` is an explicit center crop to the deliverable's aspect.
+- `contain` letterboxes or pillarboxes.
+- `track` follows normalized subject-center keyframes. A tracked request never
+  falls back to a center crop silently; a missing track is an error.
+
+The track file uses output-timeline seconds and normalized source coordinates:
+
+```json
+{
+  "tracks": {
+    "social_9x16": [
+      {"time": 0.0, "center_x": 0.32, "center_y": 0.48},
+      {"time": 4.5, "center_x": 0.68, "center_y": 0.47}
+    ]
+  }
+}
+```
+
+Keyframes are interpolated linearly between times. Each deliverable names its
+track with `reframe_track`; the root `reframe` object supplies the shared mode
+and track file.
+
+## Rendering
+
+```bash
+python helpers/render.py edit/edl.json --all-deliverables
+python helpers/render.py edit/edl.json --deliverable social_9x16
+python helpers/render.py edit/edl.json --all-deliverables --output-dir <dir>
+```
+
+Use `--output-dir` when a remote worker must keep all artifacts inside its own
+run directory. Blocked EDLs, empty ranges, missing sources, missing tracks,
+invalid dimensions, and invalid loudness targets are rejected before any
+extraction starts.

--- a/references/overlays.md
+++ b/references/overlays.md
@@ -1,0 +1,72 @@
+# Overlay compositions, protected regions, and the preflight gate
+
+`helpers/render.py` validates every overlay's spatial and temporal contract
+before it starts an expensive render. This file documents that contract; the
+EDL example in `SKILL.md` shows the fields in place.
+
+## Rectangles
+
+All rectangles are normalized to the output frame: `{"x", "y", "width",
+"height"}` as fractions in `0..1`, origin top-left. A rectangle must stay
+inside the frame. Overlays without `composition`, `layout`, or `rect` keep the
+legacy full-frame behavior and are not checked for collisions.
+
+## Named layouts
+
+| Layout | Rect | Use |
+|---|---|---|
+| `full` | whole canvas | cutaways; stops above the caption rail when captions exist |
+| `center` | 0.18, 0.15, 0.64 × 0.58 | inset panel with a title band above |
+| `left` / `right` | 0.04 or 0.52, 0.17, 0.44 × 0.57 | one half of a split |
+| `pip_left` / `pip_center` / `pip_right` | y 0.50, 0.30 × 0.28 | small picture-in-picture |
+| `custom` | your `rect` | anything else |
+
+## Compositions
+
+A composition names the editorial relationship, not just coordinates:
+
+- `cutaway` owns layout `full` and intentionally replaces the base canvas. It
+  is the only composition allowed to cover a protected region.
+- `split_left` / `split_right` own layouts `left` / `right`; the footage sits on
+  the named side and the illustration occupies the companion region.
+- `picture_in_picture` requires `layout: pip_left|pip_center|pip_right` or a
+  custom `rect` in genuine negative space.
+
+A composition cannot be combined with a different named layout or a custom
+rect. Use `fit: cover` for an intentional crop, `fit: contain` when every source
+pixel matters.
+
+## Protected regions
+
+Declare each underlying illustration's occupied area and active window in
+`protected_regions`:
+
+```json
+{"owner": "base_matrix", "start_in_output": 30.0, "duration": 8.0,
+ "rect": {"x": 0.08, "y": 0.18, "width": 0.84, "height": 0.56}}
+```
+
+The renderer rejects any split or picture-in-picture overlay whose rect
+intersects a protected region during the same output interval. Two overlays
+that overlap in both space and time are also rejected unless one sets
+`allow_overlap: true`.
+
+## Caption rail
+
+When subtitles exist, `captions.safe_region` (default: bottom 16% of the
+frame) is reserved. A `full` layout is shortened to stop above it; any other
+named or custom rect that intersects it is rejected, so captions never cover
+footage or illustrations.
+
+## Preflight gate
+
+Run the cheap insertion check before a full composite:
+
+```bash
+python helpers/render.py <edl> -o <edit>/overlay_preflight.png \
+  --preflight-overlays --preflight-base <base-video>
+```
+
+It draws entry, middle, and exit frames for each overlay with the overlay rect,
+the protected regions, and the caption rail marked. Inspect it, fix the EDL,
+and only then render the preview.

--- a/tests/test_caption_provenance.py
+++ b/tests/test_caption_provenance.py
@@ -1,3 +1,6 @@
+# tests for the caption provenance rules in the edl validator
+# they cover the version gate the strict handoff override and evidence files with and without timed words
+
 import json
 from pathlib import Path
 
@@ -6,6 +9,7 @@ import pytest
 from helpers.edl import EDLValidationError, validate_edl
 
 
+# build a minimal renderable edl with one real source file and one range
 def _ready_edl(tmp_path: Path, *, version: int = 2) -> dict:
     source = tmp_path / "source.mp4"
     source.write_bytes(b"video")
@@ -16,6 +20,7 @@ def _ready_edl(tmp_path: Path, *, version: int = 2) -> dict:
     }
 
 
+# write a tiny ass file so the subtitles path exists on disk
 def _write_subtitles(tmp_path: Path) -> None:
     (tmp_path / "master.ass").write_text(
         "[Events]\nDialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,Hello\n",
@@ -23,6 +28,7 @@ def _write_subtitles(tmp_path: Path) -> None:
     )
 
 
+# an edl with no captions block passes even under the strict handoff policy
 def test_music_only_edl_needs_no_caption_contract(tmp_path: Path) -> None:
     validate_edl(
         _ready_edl(tmp_path),
@@ -31,6 +37,7 @@ def test_music_only_edl_needs_no_caption_contract(tmp_path: Path) -> None:
     )
 
 
+# version two edls with subtitles must declare captions provenance
 def test_version_two_rejects_subtitles_without_speech_provenance(
     tmp_path: Path,
 ) -> None:
@@ -42,6 +49,7 @@ def test_version_two_rejects_subtitles_without_speech_provenance(
         validate_edl(edl, tmp_path)
 
 
+# the strict override applies the speech evidence rule to legacy version one edls
 def test_fresh_handoff_policy_rejects_legacy_unproven_captions(
     tmp_path: Path,
 ) -> None:
@@ -53,6 +61,7 @@ def test_fresh_handoff_policy_rejects_legacy_unproven_captions(
         validate_edl(edl, tmp_path, require_caption_provenance=True)
 
 
+# version one edls with bare subtitles still validate by default
 def test_version_one_caption_edl_remains_legacy_compatible(tmp_path: Path) -> None:
     edl = _ready_edl(tmp_path, version=1)
     _write_subtitles(tmp_path)
@@ -61,6 +70,7 @@ def test_version_one_caption_edl_remains_legacy_compatible(tmp_path: Path) -> No
     validate_edl(edl, tmp_path)
 
 
+# a transcript with timestamped words satisfies the provenance contract
 def test_caption_contract_accepts_timestamped_source_speech(tmp_path: Path) -> None:
     edl = _ready_edl(tmp_path)
     _write_subtitles(tmp_path)
@@ -92,6 +102,7 @@ def test_caption_contract_accepts_timestamped_source_speech(tmp_path: Path) -> N
     validate_edl(edl, tmp_path)
 
 
+# evidence json with an empty words list is rejected
 def test_caption_contract_rejects_evidence_without_spoken_words(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_caption_provenance.py
+++ b/tests/test_caption_provenance.py
@@ -1,0 +1,115 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from helpers.edl import EDLValidationError, validate_edl
+
+
+def _ready_edl(tmp_path: Path, *, version: int = 2) -> dict:
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"video")
+    return {
+        "version": version,
+        "sources": {"source": "source.mp4"},
+        "ranges": [{"source": "source", "start": 0, "end": 3}],
+    }
+
+
+def _write_subtitles(tmp_path: Path) -> None:
+    (tmp_path / "master.ass").write_text(
+        "[Events]\nDialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,Hello\n",
+        encoding="utf-8",
+    )
+
+
+def test_music_only_edl_needs_no_caption_contract(tmp_path: Path) -> None:
+    validate_edl(
+        _ready_edl(tmp_path),
+        tmp_path,
+        require_caption_provenance=True,
+    )
+
+
+def test_version_two_rejects_subtitles_without_speech_provenance(
+    tmp_path: Path,
+) -> None:
+    edl = _ready_edl(tmp_path)
+    _write_subtitles(tmp_path)
+    edl["subtitles"] = "master.ass"
+
+    with pytest.raises(EDLValidationError, match="captions.provenance"):
+        validate_edl(edl, tmp_path)
+
+
+def test_fresh_handoff_policy_rejects_legacy_unproven_captions(
+    tmp_path: Path,
+) -> None:
+    edl = _ready_edl(tmp_path, version=1)
+    _write_subtitles(tmp_path)
+    edl["subtitles"] = "master.ass"
+
+    with pytest.raises(EDLValidationError, match="audible speech"):
+        validate_edl(edl, tmp_path, require_caption_provenance=True)
+
+
+def test_version_one_caption_edl_remains_legacy_compatible(tmp_path: Path) -> None:
+    edl = _ready_edl(tmp_path, version=1)
+    _write_subtitles(tmp_path)
+    edl["subtitles"] = "master.ass"
+
+    validate_edl(edl, tmp_path)
+
+
+def test_caption_contract_accepts_timestamped_source_speech(tmp_path: Path) -> None:
+    edl = _ready_edl(tmp_path)
+    _write_subtitles(tmp_path)
+    transcript = tmp_path / "transcripts" / "source.json"
+    transcript.parent.mkdir()
+    transcript.write_text(
+        json.dumps(
+            {
+                "words": [
+                    {"type": "word", "text": "Hello", "start": 0.1, "end": 0.5}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    edl.update(
+        {
+            "subtitles": "master.ass",
+            "captions": {
+                "provenance": {
+                    "kind": "source_transcript",
+                    "files": ["transcripts/source.json"],
+                },
+                "safe_region": {"x": 0, "y": 0.84, "width": 1, "height": 0.16},
+            },
+        }
+    )
+
+    validate_edl(edl, tmp_path)
+
+
+def test_caption_contract_rejects_evidence_without_spoken_words(
+    tmp_path: Path,
+) -> None:
+    edl = _ready_edl(tmp_path)
+    _write_subtitles(tmp_path)
+    transcript = tmp_path / "transcript.json"
+    transcript.write_text(json.dumps({"words": []}), encoding="utf-8")
+    edl.update(
+        {
+            "subtitles": "master.ass",
+            "captions": {
+                "provenance": {
+                    "kind": "narration_alignment",
+                    "files": ["transcript.json"],
+                }
+            },
+        }
+    )
+
+    with pytest.raises(EDLValidationError, match="no timestamped spoken words"):
+        validate_edl(edl, tmp_path)

--- a/tests/test_caption_provenance.py
+++ b/tests/test_caption_provenance.py
@@ -1,5 +1,6 @@
-# tests for the caption provenance rules in the edl validator
-# they cover the version gate the strict handoff override and evidence files with and without timed words
+"""tests for the caption provenance rules in the edl validator
+they cover the version gate the strict handoff override and evidence files with and without timed words
+"""
 
 import json
 from pathlib import Path

--- a/tests/test_caption_provenance.py
+++ b/tests/test_caption_provenance.py
@@ -20,7 +20,7 @@ def _ready_edl(tmp_path: Path, *, version: int = 2) -> dict:
     }
 
 
-# write a tiny ass file so the subtitles path exists on disk
+# write a tiny ASS file so the subtitles path exists on disk
 def _write_subtitles(tmp_path: Path) -> None:
     (tmp_path / "master.ass").write_text(
         "[Events]\nDialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,Hello\n",

--- a/tests/test_captions_ass.py
+++ b/tests/test_captions_ass.py
@@ -1,5 +1,5 @@
 # unit tests for the captions helper
-# they cover word loading from elevenlabs and generic payloads and cue chunking and ass output
+# they cover word loading from elevenlabs and generic payloads and cue chunking and ASS output
 
 import json
 import tempfile
@@ -50,9 +50,9 @@ class ChunkWordsTests(unittest.TestCase):
         self.assertAlmostEqual(cues[0][1], 1.4)
 
 
-# tests for ass file output
+# tests for ASS file output
 class WriteAssTests(unittest.TestCase):
-    # the ass file carries the play resolution the caption style and a wrapped long cue
+    # the ASS file carries the play resolution the caption style and a wrapped long cue
     def test_writes_caption_style_and_wrapped_dialogue(self):
         with tempfile.TemporaryDirectory() as tmp:
             out = Path(tmp) / "master.ass"

--- a/tests/test_captions_ass.py
+++ b/tests/test_captions_ass.py
@@ -1,0 +1,67 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from helpers import captions
+
+
+class LoadWordsTests(unittest.TestCase):
+    def test_reads_elevenlabs_character_alignment(self):
+        payload = {
+            "alignment": {
+                "characters": list("Hi there."),
+                "character_start_times_seconds": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+                "character_end_times_seconds": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+            }
+        }
+        words = captions.load_words(payload)
+        self.assertEqual([w["text"] for w in words], ["Hi", "there."])
+        self.assertEqual(words[0]["start"], 0.0)
+        self.assertEqual(words[1]["end"], 0.9)
+
+    def test_reads_generic_word_list(self):
+        words = captions.load_words({"words": [{"word": "Go", "start": 1.0, "end": 1.2}]})
+        self.assertEqual(words, [{"text": "Go", "start": 1.0, "end": 1.2}])
+
+    def test_rejects_payload_without_timing(self):
+        with self.assertRaises(ValueError):
+            captions.load_words({"text": "no timestamps"})
+
+
+class ChunkWordsTests(unittest.TestCase):
+    def test_breaks_on_punctuation_and_max_words(self):
+        words = [
+            {"text": t, "start": i * 0.5, "end": i * 0.5 + 0.4}
+            for i, t in enumerate(["We", "fixed", "this.", "Now", "it", "works", "fast", "again"])
+        ]
+        cues = captions.chunk_words(words, max_words=3, max_characters=44)
+        self.assertEqual([c[2] for c in cues], ["We fixed this.", "Now it works", "fast again"])
+        self.assertEqual(cues[0][0], 0.0)
+        self.assertAlmostEqual(cues[0][1], 1.4)
+
+
+class WriteAssTests(unittest.TestCase):
+    def test_writes_caption_style_and_wrapped_dialogue(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "master.ass"
+            captions.write_ass(
+                [(0.0, 1.5, "Short cue"), (2.0, 4.0, "This cue is long enough that it wraps twice")],
+                out,
+                width=1920,
+                height=1080,
+            )
+            text = out.read_text()
+        self.assertIn("PlayResX: 1920", text)
+        self.assertIn("Style: Caption,Helvetica,42", text)
+        self.assertIn("Dialogue: 0,0:00:00.00,0:00:01.50,Caption,,0,0,0,,Short cue", text)
+        self.assertIn("\\N", text.splitlines()[-1])
+
+    def test_rejects_safe_rail_outside_bounds(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(ValueError):
+                captions.write_ass([], Path(tmp) / "x.ass", safe_bottom=0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_captions_ass.py
+++ b/tests/test_captions_ass.py
@@ -1,3 +1,6 @@
+# unit tests for the captions helper
+# they cover word loading from elevenlabs and generic payloads and cue chunking and ass output
+
 import json
 import tempfile
 import unittest
@@ -6,7 +9,9 @@ from pathlib import Path
 from helpers import captions
 
 
+# tests for load_words input handling
 class LoadWordsTests(unittest.TestCase):
+    # elevenlabs character timings are merged into words with the right start and end
     def test_reads_elevenlabs_character_alignment(self):
         payload = {
             "alignment": {
@@ -20,16 +25,20 @@ class LoadWordsTests(unittest.TestCase):
         self.assertEqual(words[0]["start"], 0.0)
         self.assertEqual(words[1]["end"], 0.9)
 
+    # a plain words array using the word key is normalized to text
     def test_reads_generic_word_list(self):
         words = captions.load_words({"words": [{"word": "Go", "start": 1.0, "end": 1.2}]})
         self.assertEqual(words, [{"text": "Go", "start": 1.0, "end": 1.2}])
 
+    # a payload with no timing data raises
     def test_rejects_payload_without_timing(self):
         with self.assertRaises(ValueError):
             captions.load_words({"text": "no timestamps"})
 
 
+# tests for cue chunking
 class ChunkWordsTests(unittest.TestCase):
+    # cues break on sentence punctuation and on the max word count
     def test_breaks_on_punctuation_and_max_words(self):
         words = [
             {"text": t, "start": i * 0.5, "end": i * 0.5 + 0.4}
@@ -41,7 +50,9 @@ class ChunkWordsTests(unittest.TestCase):
         self.assertAlmostEqual(cues[0][1], 1.4)
 
 
+# tests for ass file output
 class WriteAssTests(unittest.TestCase):
+    # the ass file carries the play resolution the caption style and a wrapped long cue
     def test_writes_caption_style_and_wrapped_dialogue(self):
         with tempfile.TemporaryDirectory() as tmp:
             out = Path(tmp) / "master.ass"
@@ -57,6 +68,7 @@ class WriteAssTests(unittest.TestCase):
         self.assertIn("Dialogue: 0,0:00:00.00,0:00:01.50,Caption,,0,0,0,,Short cue", text)
         self.assertIn("\\N", text.splitlines()[-1])
 
+    # a safe rail fraction outside the allowed range raises
     def test_rejects_safe_rail_outside_bounds(self):
         with tempfile.TemporaryDirectory() as tmp:
             with self.assertRaises(ValueError):

--- a/tests/test_captions_substation.py
+++ b/tests/test_captions_substation.py
@@ -1,5 +1,6 @@
-# unit tests for the captions helper
-# they cover word loading from elevenlabs and generic payloads and cue chunking and ASS output
+"""unit tests for the captions helper
+they cover word loading from elevenlabs and generic payloads and cue chunking and ASS output
+"""
 
 import json
 import tempfile
@@ -56,7 +57,7 @@ class WriteAssTests(unittest.TestCase):
     def test_writes_caption_style_and_wrapped_dialogue(self):
         with tempfile.TemporaryDirectory() as tmp:
             out = Path(tmp) / "master.ass"
-            captions.write_ass(
+            captions.write_substation(
                 [(0.0, 1.5, "Short cue"), (2.0, 4.0, "This cue is long enough that it wraps twice")],
                 out,
                 width=1920,
@@ -72,7 +73,7 @@ class WriteAssTests(unittest.TestCase):
     def test_rejects_safe_rail_outside_bounds(self):
         with tempfile.TemporaryDirectory() as tmp:
             with self.assertRaises(ValueError):
-                captions.write_ass([], Path(tmp) / "x.ass", safe_bottom=0.5)
+                captions.write_substation([], Path(tmp) / "x.ass", safe_bottom=0.5)
 
 
 if __name__ == "__main__":

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -4,14 +4,16 @@ comments must not carry punctuation so they stay short and readable at a glance
 """
 
 import ast
+import io
 import re
+import tokenize
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKIP_DIRS = {".venv", "venv", "node_modules", "__pycache__", ".git", "media", "edit"}
 PUNCTUATION = re.compile(r"[.,:;()\"'`]")
-DEFINITION = re.compile(r"\s*(async def|def|class) \w")
+DEFINITIONS = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
 
 
 # yield every python file in the repo that is not inside a skipped directory
@@ -30,24 +32,39 @@ def audit(text):
     if first and first[0].startswith("#"):
         problems.append("hash comment header should be a module docstring")
     try:
-        if ast.get_docstring(ast.parse(text)) is None:
-            problems.append("missing module docstring")
+        tree = ast.parse(text)
     except SyntaxError:
         problems.append("file does not parse")
-    for index, line in enumerate(lines):
-        if not DEFINITION.match(line):
+        return problems
+    if ast.get_docstring(tree) is None:
+        problems.append("missing module docstring")
+    comments = real_comments(text)
+    for node in sorted(definitions(tree), key=lambda item: item.lineno):
+        # decorators sit between the comment and the definition so look above the first decorator
+        start = min([node.lineno, *[item.lineno for item in node.decorator_list]])
+        above = start - 1
+        if above not in comments:
+            problems.append(f"line {node.lineno} has no comment above {node.name}")
             continue
-        above = index - 1
-        # decorators sit between the comment and the definition
-        while above >= 0 and lines[above].strip().startswith("@"):
-            above -= 1
-        if above < 0 or not lines[above].strip().startswith("#"):
-            problems.append(f"line {index + 1} has no comment above {line.strip()[:40]}")
-            continue
-        comment = lines[above].strip().lstrip("#").strip()
-        if PUNCTUATION.search(comment):
-            problems.append(f"line {above + 1} comment contains punctuation")
+        if PUNCTUATION.search(comments[above]):
+            problems.append(f"line {above} comment contains punctuation")
     return problems
+
+
+# yield every function and class node in the tree so text inside strings never counts as a definition
+def definitions(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, DEFINITIONS):
+            yield node
+
+
+# map line number to comment text for lines that hold nothing but a real comment token
+def real_comments(text):
+    comments = {}
+    for token in tokenize.generate_tokens(io.StringIO(text).readline):
+        if token.type == tokenize.COMMENT and token.line.strip().startswith("#"):
+            comments[token.start[0]] = token.string.lstrip("#").strip()
+    return comments
 
 
 # one test that scans the whole repo so a single failure lists every offending file

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -43,7 +43,7 @@ def audit(text):
         # decorators sit between the comment and the definition so look above the first decorator
         start = min([node.lineno, *[item.lineno for item in node.decorator_list]])
         above = start - 1
-        if above not in comments:
+        if above not in comments or not comments[above]:
             problems.append(f"line {node.lineno} has no comment above {node.name}")
             continue
         if PUNCTUATION.search(comments[above]):

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -1,0 +1,58 @@
+# guards the comment convention across every python file in the repo
+# each file starts with a plain header block and every def or class has one plain comment line above it
+# comments must not carry punctuation so they stay short and readable at a glance
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {".venv", "venv", "node_modules", "__pycache__", ".git", "media", "edit"}
+PUNCTUATION = re.compile(r"[.,:;()\"'`]")
+DEFINITION = re.compile(r"\s*(async def|def|class) \w")
+
+
+# yield every python file in the repo that is not inside a skipped directory
+def python_files():
+    for path in ROOT.rglob("*.py"):
+        if not any(part in SKIP_DIRS for part in path.relative_to(ROOT).parts):
+            yield path
+
+
+# return the problems found in one file as short strings
+def audit(text):
+    lines = text.splitlines()
+    problems = []
+    first = [line for line in lines[:6] if line.strip() and not line.startswith("#!")]
+    if not first or not first[0].startswith("#"):
+        problems.append("missing header comment block")
+    for index, line in enumerate(lines):
+        if not DEFINITION.match(line):
+            continue
+        above = index - 1
+        # decorators sit between the comment and the definition
+        while above >= 0 and lines[above].strip().startswith("@"):
+            above -= 1
+        if above < 0 or not lines[above].strip().startswith("#"):
+            problems.append(f"line {index + 1} has no comment above {line.strip()[:40]}")
+            continue
+        comment = lines[above].strip().lstrip("#").strip()
+        if PUNCTUATION.search(comment):
+            problems.append(f"line {above + 1} comment contains punctuation")
+    return problems
+
+
+# one test that scans the whole repo so a single failure lists every offending file
+class CommentStyleTests(unittest.TestCase):
+    # every python file must satisfy the header and per definition comment rules
+    def test_every_python_file_follows_the_convention(self):
+        failures = {}
+        for path in python_files():
+            problems = audit(path.read_text(encoding="utf-8"))
+            if problems:
+                failures[str(path.relative_to(ROOT))] = problems[:5]
+        self.assertEqual(failures, {}, "comment convention violations")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -1,7 +1,9 @@
-# guards the comment convention across every python file in the repo
-# each file starts with a plain header block and every def or class has one plain comment line above it
-# comments must not carry punctuation so they stay short and readable at a glance
+"""guards the comment convention across every python file in the repo
+each file opens with a module docstring and every def or class has one plain comment line above it
+comments must not carry punctuation so they stay short and readable at a glance
+"""
 
+import ast
 import re
 import unittest
 from pathlib import Path
@@ -23,9 +25,15 @@ def python_files():
 def audit(text):
     lines = text.splitlines()
     problems = []
+    # the file opens with a docstring and not with a block of hash comments
     first = [line for line in lines[:6] if line.strip() and not line.startswith("#!")]
-    if not first or not first[0].startswith("#"):
-        problems.append("missing header comment block")
+    if first and first[0].startswith("#"):
+        problems.append("hash comment header should be a module docstring")
+    try:
+        if ast.get_docstring(ast.parse(text)) is None:
+            problems.append("missing module docstring")
+    except SyntaxError:
+        problems.append("file does not parse")
     for index, line in enumerate(lines):
         if not DEFINITION.match(line):
             continue

--- a/tests/test_deliverables.py
+++ b/tests/test_deliverables.py
@@ -1,0 +1,271 @@
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from helpers.edl import EDLValidationError, normalize_deliverables, validate_edl
+from helpers import render
+
+
+def _ready_edl(source: Path) -> dict:
+    return {
+        "version": 1,
+        "sources": {"source": str(source)},
+        "ranges": [{"source": "source", "start": 0, "end": 5}],
+    }
+
+
+def test_blocked_edl_is_rejected_before_render(tmp_path: Path) -> None:
+    edl = {
+        "status": "blocked_missing_source_media",
+        "sources": {},
+        "ranges": [],
+        "handoff": {
+            "render_ready": False,
+            "blocking_reason": "stage one source video",
+        },
+    }
+
+    with pytest.raises(EDLValidationError) as error:
+        validate_edl(edl, tmp_path)
+
+    message = str(error.value)
+    assert "blocked_missing_source_media" in message
+    assert "stage one source video" in message
+    assert "at least one source video" in message
+    assert "at least one playable edit range" in message
+
+
+def test_agent_authored_delivery_aliases_normalize_to_public_contract(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"video")
+    track = tmp_path / "reframe_tracks.json"
+    track.write_text(
+        json.dumps(
+            {
+                "tracks": {
+                    "social_9x16": [
+                        {"time": 0, "center_x": 0.3, "center_y": 0.5},
+                        {"time": 5, "center_x": 0.7, "center_y": 0.5},
+                    ]
+                }
+            }
+        )
+    )
+    edl = {
+        **_ready_edl(source),
+        "reframe": {
+            "mode": "tracked_subject",
+            "tracking_asset": "reframe_tracks.json",
+        },
+        "deliverables": [
+            {
+                "id": "social_9x16",
+                "file": "deliverables/social.mp4",
+                "width": 1080,
+                "height": 1920,
+                "fps": 30,
+                "reframe_track": "social_9x16",
+                "audio": {
+                    "integrated_loudness_lufs": -16,
+                    "true_peak_dbtp": -1,
+                    "loudness_range_lu": 9,
+                },
+            }
+        ],
+    }
+
+    validate_edl(edl, tmp_path)
+    delivery = normalize_deliverables(edl, tmp_path)[0]
+
+    assert delivery["fps"] == "30/1"
+    assert delivery["reframe"] == {
+        "mode": "track",
+        "tracking_asset": "reframe_tracks.json",
+        "track_id": "social_9x16",
+        "track_file": "reframe_tracks.json",
+        "interpolation": "linear",
+    }
+    assert delivery["loudness"] == {
+        "integrated_lufs": -16.0,
+        "true_peak_dbtp": -1.0,
+        "lra": 9.0,
+    }
+
+
+def test_tracked_delivery_without_tracking_data_is_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"video")
+    edl = {
+        **_ready_edl(source),
+        "deliverables": [
+            {
+                "id": "vertical",
+                "resolution": "1080x1920",
+                "reframe": {"mode": "track"},
+            }
+        ],
+    }
+
+    with pytest.raises(EDLValidationError, match="has no keyframes or track file"):
+        validate_edl(edl, tmp_path)
+
+
+def test_empty_named_track_is_rejected_before_render(tmp_path: Path) -> None:
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"video")
+    (tmp_path / "tracks.json").write_text(
+        json.dumps({"tracks": {"vertical": []}})
+    )
+    edl = {
+        **_ready_edl(source),
+        "reframe": {"mode": "track", "track_file": "tracks.json"},
+        "deliverables": [
+            {
+                "id": "vertical",
+                "width": 1080,
+                "height": 1920,
+                "reframe_track": "vertical",
+            }
+        ],
+    }
+
+    with pytest.raises(EDLValidationError, match="keyframes 'vertical' are empty"):
+        validate_edl(edl, tmp_path)
+
+
+def test_named_track_supports_subject_boxes(tmp_path: Path) -> None:
+    track = tmp_path / "track.json"
+    track.write_text(
+        json.dumps(
+            {
+                "tracks": {
+                    "vertical": [
+                        {
+                            "time": 0,
+                            "subject_box": {
+                                "x": 0.2,
+                                "y": 0.1,
+                                "width": 0.2,
+                                "height": 0.6,
+                            },
+                        },
+                        {"time": 2, "center": [0.7, 0.5]},
+                    ]
+                }
+            }
+        )
+    )
+
+    keyframes = render._load_track_keyframes(
+        {"mode": "track", "track_file": "track.json", "track_id": "vertical"},
+        tmp_path,
+    )
+
+    assert keyframes == [
+        {"time": 0.0, "center_x": pytest.approx(0.3), "center_y": pytest.approx(0.4)},
+        {"time": 2.0, "center_x": 0.7, "center_y": 0.5},
+    ]
+
+
+def test_unsupported_delivery_codec_is_rejected_instead_of_ignored(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"video")
+    edl = {
+        **_ready_edl(source),
+        "deliverables": [
+            {
+                "id": "archive",
+                "width": 1920,
+                "height": 1080,
+                "video_codec": "prores",
+            }
+        ],
+    }
+
+    with pytest.raises(EDLValidationError, match="supports only H.264"):
+        validate_edl(edl, tmp_path)
+
+
+def test_reframe_command_uses_dynamic_track_and_requested_format(tmp_path: Path) -> None:
+    output = tmp_path / "vertical.mp4"
+    completed = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+    with (
+        patch.object(render, "probe_video_size", return_value=(1920, 1080)),
+        patch.object(render.subprocess, "run", return_value=completed) as run,
+    ):
+        render.build_reframed_base(
+            tmp_path / "base.mp4",
+            output,
+            width=1080,
+            height=1920,
+            fps="30/1",
+            reframe={
+                "mode": "track",
+                "keyframes": [
+                    {"time": 0, "center_x": 0.25, "center_y": 0.5},
+                    {"time": 2, "center_x": 0.75, "center_y": 0.5},
+                ],
+            },
+            edit_dir=tmp_path,
+        )
+
+    command = run.call_args.args[0]
+    video_filter = command[command.index("-vf") + 1]
+    assert "crop=606:1080" in video_filter
+    assert "if(lt(t,2.00000000)" in video_filter
+    assert "scale=1080:1920" in video_filter
+    assert "fps=30/1" in video_filter
+
+
+def test_smooth_tracking_uses_eased_interpolation() -> None:
+    expression = render._piecewise_track_expression(
+        [
+            {"time": 0, "center_x": 0.2},
+            {"time": 2, "center_x": 0.8},
+        ],
+        "center_x",
+        "smooth",
+    )
+
+    assert "3-2*" in expression
+    assert "if(lt(t,2.00000000)" in expression
+
+
+def test_loudnorm_passes_per_delivery_targets_to_measurement(tmp_path: Path) -> None:
+    measurement = {
+        "input_i": "-20.0",
+        "input_tp": "-3.0",
+        "input_lra": "5.0",
+        "input_thresh": "-30.0",
+        "target_offset": "0.0",
+    }
+    completed = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+    with (
+        patch.object(render, "measure_loudness", return_value=measurement) as measure,
+        patch.object(render.subprocess, "run", return_value=completed) as run,
+    ):
+        render.apply_loudnorm_two_pass(
+            tmp_path / "input.mp4",
+            tmp_path / "output.mp4",
+            integrated_lufs=-24,
+            true_peak_dbtp=-2,
+            lra=7,
+        )
+
+    measure.assert_called_once_with(
+        tmp_path / "input.mp4",
+        integrated_lufs=-24,
+        true_peak_dbtp=-2,
+        lra=7,
+    )
+    filter_value = run.call_args.args[0][run.call_args.args[0].index("-af") + 1]
+    assert "I=-24" in filter_value
+    assert "TP=-2" in filter_value
+    assert "LRA=7" in filter_value

--- a/tests/test_deliverables.py
+++ b/tests/test_deliverables.py
@@ -1,3 +1,6 @@
+# tests for deliverable normalization and the reframing and loudness parts of the renderer
+# they check alias handling tracked reframe validation and the ffmpeg commands built for deliveries
+
 import json
 import subprocess
 from pathlib import Path
@@ -9,6 +12,7 @@ from helpers.edl import EDLValidationError, normalize_deliverables, validate_edl
 from helpers import render
 
 
+# build a minimal version one edl pointing at the given source path
 def _ready_edl(source: Path) -> dict:
     return {
         "version": 1,
@@ -17,6 +21,7 @@ def _ready_edl(source: Path) -> dict:
     }
 
 
+# a blocked edl reports every problem at once before any render
 def test_blocked_edl_is_rejected_before_render(tmp_path: Path) -> None:
     edl = {
         "status": "blocked_missing_source_media",
@@ -38,6 +43,7 @@ def test_blocked_edl_is_rejected_before_render(tmp_path: Path) -> None:
     assert "at least one playable edit range" in message
 
 
+# agent style aliases for mode tracking asset and loudness normalize to the public names
 def test_agent_authored_delivery_aliases_normalize_to_public_contract(
     tmp_path: Path,
 ) -> None:
@@ -97,6 +103,7 @@ def test_agent_authored_delivery_aliases_normalize_to_public_contract(
     }
 
 
+# track mode without keyframes or a track file is rejected
 def test_tracked_delivery_without_tracking_data_is_rejected(tmp_path: Path) -> None:
     source = tmp_path / "source.mp4"
     source.write_bytes(b"video")
@@ -115,6 +122,7 @@ def test_tracked_delivery_without_tracking_data_is_rejected(tmp_path: Path) -> N
         validate_edl(edl, tmp_path)
 
 
+# a named track that exists but is empty is rejected
 def test_empty_named_track_is_rejected_before_render(tmp_path: Path) -> None:
     source = tmp_path / "source.mp4"
     source.write_bytes(b"video")
@@ -138,6 +146,7 @@ def test_empty_named_track_is_rejected_before_render(tmp_path: Path) -> None:
         validate_edl(edl, tmp_path)
 
 
+# subject boxes in a named track are converted to center points
 def test_named_track_supports_subject_boxes(tmp_path: Path) -> None:
     track = tmp_path / "track.json"
     track.write_text(
@@ -172,6 +181,7 @@ def test_named_track_supports_subject_boxes(tmp_path: Path) -> None:
     ]
 
 
+# a codec other than h264 raises instead of being silently replaced
 def test_unsupported_delivery_codec_is_rejected_instead_of_ignored(
     tmp_path: Path,
 ) -> None:
@@ -193,6 +203,7 @@ def test_unsupported_delivery_codec_is_rejected_instead_of_ignored(
         validate_edl(edl, tmp_path)
 
 
+# the reframe command crops to the target ratio and uses a time based expression and the requested fps
 def test_reframe_command_uses_dynamic_track_and_requested_format(tmp_path: Path) -> None:
     output = tmp_path / "vertical.mp4"
     completed = subprocess.CompletedProcess([], 0, stdout="", stderr="")
@@ -224,6 +235,7 @@ def test_reframe_command_uses_dynamic_track_and_requested_format(tmp_path: Path)
     assert "fps=30/1" in video_filter
 
 
+# smooth interpolation produces a smoothstep expression with per segment guards
 def test_smooth_tracking_uses_eased_interpolation() -> None:
     expression = render._piecewise_track_expression(
         [
@@ -238,6 +250,7 @@ def test_smooth_tracking_uses_eased_interpolation() -> None:
     assert "if(lt(t,2.00000000)" in expression
 
 
+# the per delivery loudness targets reach both the measurement and the second pass filter
 def test_loudnorm_passes_per_delivery_targets_to_measurement(tmp_path: Path) -> None:
     measurement = {
         "input_i": "-20.0",

--- a/tests/test_deliverables.py
+++ b/tests/test_deliverables.py
@@ -1,5 +1,6 @@
-# tests for deliverable normalization and the reframing and loudness parts of the renderer
-# they check alias handling tracked reframe validation and the ffmpeg commands built for deliveries
+"""tests for deliverable normalization and the reframing and loudness parts of the renderer
+they check alias handling tracked reframe validation and the ffmpeg commands built for deliveries
+"""
 
 import json
 import subprocess

--- a/tests/test_render_fps.py
+++ b/tests/test_render_fps.py
@@ -1,3 +1,7 @@
+# unit tests for the frame rate handling in helpers render py
+# they cover parse_fps canonical forms probe_source_fps ffprobe parsing and the rate resolution in extract_all_segments
+# render py is loaded by file path so the tests do not depend on it being importable as a package
+
 import argparse
 import contextlib
 import importlib.util
@@ -10,6 +14,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 
+# load render py straight from its file path under a private module name
 MODULE_PATH = Path(__file__).parents[1] / "helpers" / "render.py"
 SPEC = importlib.util.spec_from_file_location("video_use_render", MODULE_PATH)
 assert SPEC and SPEC.loader
@@ -17,7 +22,9 @@ render = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(render)
 
 
+# tests for parse_fps which turns user supplied rates into canonical rational strings
 class ParseFpsTests(unittest.TestCase):
+    # integer decimal and rational inputs all canonicalize to the expected fraction
     def test_accepts_integer_decimal_and_rational_rates(self):
         expected = {
             "60": "60/1",
@@ -28,12 +35,14 @@ class ParseFpsTests(unittest.TestCase):
             with self.subTest(value=value):
                 self.assertEqual(render.parse_fps(value), canonical)
 
+    # feeding a canonical rate back through parse_fps returns it unchanged
     def test_canonical_rates_are_idempotent(self):
         for value in ("60", "29.97", "30000/1001"):
             with self.subTest(value=value):
                 canonical = render.parse_fps(value)
                 self.assertEqual(render.parse_fps(canonical), canonical)
 
+    # malformed zero negative or oversized inputs raise an argparse type error
     def test_rejects_invalid_or_non_positive_rates(self):
         for value in (
             "",
@@ -51,7 +60,9 @@ class ParseFpsTests(unittest.TestCase):
                     render.parse_fps(value)
 
 
+# tests for probe_source_fps with ffprobe replaced by canned completed process results
 class ProbeSourceFpsTests(unittest.TestCase):
+    # build a fake ffprobe result whose json carries the given average and nominal rates
     @staticmethod
     def _probe_result(avg: str, nominal: str) -> subprocess.CompletedProcess:
         stdout = json.dumps({
@@ -59,28 +70,34 @@ class ProbeSourceFpsTests(unittest.TestCase):
         })
         return subprocess.CompletedProcess([], 0, stdout=stdout, stderr="")
 
+    # the average frame rate wins when ffprobe reports a usable one
     def test_prefers_average_rate(self):
         result = self._probe_result("30000/1001", "30/1")
         with patch.object(render.subprocess, "run", return_value=result):
             self.assertEqual(render.probe_source_fps(Path("source.mp4")), "30000/1001")
 
+    # a zero average rate falls back to the nominal r_frame_rate
     def test_falls_back_to_nominal_rate(self):
         result = self._probe_result("0/0", "60/1")
         with patch.object(render.subprocess, "run", return_value=result):
             self.assertEqual(render.probe_source_fps(Path("source.mp4")), "60/1")
 
+    # an empty streams list yields none instead of a rate
     def test_returns_none_for_unusable_probe_output(self):
         result = subprocess.CompletedProcess([], 0, stdout='{"streams": []}', stderr="")
         with patch.object(render.subprocess, "run", return_value=result):
             self.assertIsNone(render.probe_source_fps(Path("source.mp4")))
 
+    # an ffprobe process error yields none rather than propagating
     def test_returns_none_when_ffprobe_fails(self):
         error = subprocess.CalledProcessError(1, ["ffprobe"])
         with patch.object(render.subprocess, "run", side_effect=error):
             self.assertIsNone(render.probe_source_fps(Path("source.mp4")))
 
 
+# tests for how extract_all_segments chooses one rate for every segment
 class RenderRateTests(unittest.TestCase):
+    # minimal two source edl with one range per source
     @staticmethod
     def _edl() -> dict:
         return {
@@ -91,6 +108,7 @@ class RenderRateTests(unittest.TestCase):
             ],
         }
 
+    # only the first source is probed and its rate is applied to every segment
     def test_multi_source_render_resolves_one_rate_from_first_source(self):
         edl = self._edl()
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -105,6 +123,7 @@ class RenderRateTests(unittest.TestCase):
         probe.assert_called_once_with((edit_dir / "first.mp4").resolve())
         self.assertEqual([call.kwargs["rate"] for call in extract.call_args_list], ["60/1", "60/1"])
 
+    # an explicit fps argument skips probing and is canonicalized for every segment
     def test_explicit_rate_skips_probe_and_applies_to_every_segment(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             with (
@@ -122,6 +141,7 @@ class RenderRateTests(unittest.TestCase):
             ["30/1", "30/1"],
         )
 
+    # when probing fails every segment falls back to the 24 default
     def test_failed_probe_falls_back_to_24_for_every_segment(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             with (

--- a/tests/test_render_fps.py
+++ b/tests/test_render_fps.py
@@ -1,6 +1,7 @@
-# unit tests for the frame rate handling in helpers render py
-# they cover parse_fps canonical forms probe_source_fps ffprobe parsing and the rate resolution in extract_all_segments
-# render py is loaded by file path so the tests do not depend on it being importable as a package
+"""unit tests for the frame rate handling in helpers render py
+they cover parse_fps canonical forms probe_source_fps ffprobe parsing and the rate resolution in extract_all_segments
+render py is loaded by file path so the tests do not depend on it being importable as a package
+"""
 
 import argparse
 import contextlib

--- a/tests/test_render_orientation.py
+++ b/tests/test_render_orientation.py
@@ -1,3 +1,6 @@
+# tests for portrait detection in the render helper including rotation side data
+# it loads the helper from its file path and patches ffprobe so no real media is needed
+
 import importlib.util
 import json
 import subprocess
@@ -13,7 +16,9 @@ render = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(render)
 
 
+# portrait detection must honor display rotation but ignore plain rotate tags
 class PortraitDetectionTests(unittest.TestCase):
+    # run the detector against a fake ffprobe json stream
     def _is_portrait(self, stream: dict) -> bool:
         result = subprocess.CompletedProcess(
             [], 0, stdout=json.dumps({"streams": [stream]}), stderr=""
@@ -26,12 +31,15 @@ class PortraitDetectionTests(unittest.TestCase):
         self.assertNotIn("stream_tags=rotate", show_entries)
         return portrait
 
+    # taller than wide with no rotation is portrait
     def test_native_portrait_dimensions(self):
         self.assertTrue(self._is_portrait({"width": 1080, "height": 1920}))
 
+    # wider than tall with no rotation is landscape
     def test_native_landscape_dimensions(self):
         self.assertFalse(self._is_portrait({"width": 1920, "height": 1080}))
 
+    # a quarter turn in display side data flips a coded landscape into portrait
     def test_side_data_rotation_turns_coded_landscape_into_portrait(self):
         stream = {
             "width": 1920,
@@ -40,10 +48,12 @@ class PortraitDetectionTests(unittest.TestCase):
         }
         self.assertTrue(self._is_portrait(stream))
 
+    # a rotate tag without side data does not change the answer
     def test_plain_rotation_tag_without_side_data_is_ignored(self):
         stream = {"width": 1920, "height": 1080, "tags": {"rotate": "270"}}
         self.assertFalse(self._is_portrait(stream))
 
+    # a quarter turn can also flip a coded portrait into landscape
     def test_rotation_can_turn_coded_portrait_into_landscape(self):
         stream = {
             "width": 1080,
@@ -52,6 +62,7 @@ class PortraitDetectionTests(unittest.TestCase):
         }
         self.assertFalse(self._is_portrait(stream))
 
+    # unreadable probe output falls back to landscape
     def test_invalid_probe_output_falls_back_to_landscape(self):
         result = subprocess.CompletedProcess([], 0, stdout="not json", stderr="")
         with patch.object(render.subprocess, "run", return_value=result):

--- a/tests/test_render_orientation.py
+++ b/tests/test_render_orientation.py
@@ -1,5 +1,6 @@
-# tests for portrait detection in the render helper including rotation side data
-# it loads the helper from its file path and patches ffprobe so no real media is needed
+"""tests for portrait detection in the render helper including rotation side data
+it loads the helper from its file path and patches ffprobe so no real media is needed
+"""
 
 import importlib.util
 import json

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -1,3 +1,7 @@
+# tests that guard the public editing contract documented in skill md
+# they check that the numbered hard rules stay present and in order and that every referenced helper or reference path exists
+# the hard rules list is append only so new rules go at the end
+
 """Guard the public editing contract in SKILL.md.
 
 Two failure modes this protects against when several agents edit the file:
@@ -28,21 +32,28 @@ HARD_RULES = [
     "All session outputs in `<videos_dir>/edit/`.",
 ]
 
+# matches backticked paths under references helpers or skills
 PATH_PATTERN = re.compile(r"`((?:references|helpers|skills)/[A-Za-z0-9_./-]+)`")
 
 
+# slice out the body of the hard rules section up to the next second level heading
 def hard_rules_section(text: str) -> str:
+    # dotall plus multiline so the lazy group spans lines and the heading anchors match at line starts
     match = re.search(r"^## Hard Rules.*?$(.*?)^## ", text, re.S | re.M)
     assert match, "SKILL.md must contain a '## Hard Rules' section"
     return match.group(1)
 
 
+# test case that reads skill md once per test and checks its contract
 class SkillContractTests(unittest.TestCase):
+    # load the skill md text for each test
     def setUp(self) -> None:
         self.text = SKILL.read_text(encoding="utf-8")
 
+    # numbered bold rule titles must be consecutive and each expected rule must still sit at its index
     def test_hard_rules_are_present_in_order(self):
         section = hard_rules_section(self.text)
+        # capture the number and bold title of each numbered list item
         items = re.findall(r"^(\d+)\. \*\*(.+?)\*\*", section, re.M)
         numbers = [int(number) for number, _ in items]
         self.assertEqual(numbers, list(range(1, len(numbers) + 1)), "rules must be numbered consecutively")
@@ -50,6 +61,7 @@ class SkillContractTests(unittest.TestCase):
         for index, expected in enumerate(HARD_RULES):
             self.assertIn(expected, items[index][1], f"rule {index + 1} changed or moved")
 
+    # every backticked helper or reference path in skill md must exist on disk
     def test_referenced_paths_exist(self):
         missing = sorted(
             path

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -1,7 +1,3 @@
-# tests that guard the public editing contract documented in skill md
-# they check that the numbered hard rules stay present and in order and that every referenced helper or reference path exists
-# the hard rules list is append only so new rules go at the end
-
 """Guard the public editing contract in SKILL.md.
 
 Two failure modes this protects against when several agents edit the file:

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -1,0 +1,63 @@
+"""Guard the public editing contract in SKILL.md.
+
+Two failure modes this protects against when several agents edit the file:
+a hard rule silently disappears or gets renumbered, and a helper or reference
+path is documented but no longer exists in the tree.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "SKILL.md"
+
+# Append-only. Add new rules to the end of this list when SKILL.md gains one.
+HARD_RULES = [
+    "Subtitles are applied LAST in the filter chain",
+    "Per-segment extract",
+    "30ms audio fades at every segment boundary",
+    "Overlays use `setpts=PTS-STARTPTS+T/TB`",
+    "Master SRT uses output-timeline offsets",
+    "Never cut inside a word.",
+    "Pad every cut edge.",
+    "Word-level verbatim ASR only.",
+    "Cache transcripts per source.",
+    "Parallel sub-agents for multiple animations.",
+    "Strategy confirmation before execution.",
+    "All session outputs in `<videos_dir>/edit/`.",
+]
+
+PATH_PATTERN = re.compile(r"`((?:references|helpers|skills)/[A-Za-z0-9_./-]+)`")
+
+
+def hard_rules_section(text: str) -> str:
+    match = re.search(r"^## Hard Rules.*?$(.*?)^## ", text, re.S | re.M)
+    assert match, "SKILL.md must contain a '## Hard Rules' section"
+    return match.group(1)
+
+
+class SkillContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.text = SKILL.read_text(encoding="utf-8")
+
+    def test_hard_rules_are_present_in_order(self):
+        section = hard_rules_section(self.text)
+        items = re.findall(r"^(\d+)\. \*\*(.+?)\*\*", section, re.M)
+        numbers = [int(number) for number, _ in items]
+        self.assertEqual(numbers, list(range(1, len(numbers) + 1)), "rules must be numbered consecutively")
+        self.assertGreaterEqual(len(items), len(HARD_RULES), "a hard rule was removed")
+        for index, expected in enumerate(HARD_RULES):
+            self.assertIn(expected, items[index][1], f"rule {index + 1} changed or moved")
+
+    def test_referenced_paths_exist(self):
+        missing = sorted(
+            path
+            for path in set(PATH_PATTERN.findall(self.text))
+            if not (ROOT / path).exists()
+        )
+        self.assertEqual(missing, [], "SKILL.md names paths that do not exist")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -30,6 +30,8 @@ HARD_RULES = [
 
 # matches backticked paths under references helpers or skills
 PATH_PATTERN = re.compile(r"`((?:references|helpers|skills)/[A-Za-z0-9_./-]+)`")
+# matches a bare helper script name at the start of a backticked command
+HELPER_PATTERN = re.compile(r"`([A-Za-z0-9_]+\.py)\b")
 
 
 # slice out the body of the hard rules section up to the next second level heading
@@ -65,6 +67,15 @@ class SkillContractTests(unittest.TestCase):
             if not (ROOT / path).exists()
         )
         self.assertEqual(missing, [], "SKILL.md names paths that do not exist")
+
+    # every bare helper script named in a backticked command must exist under helpers
+    def test_bare_helper_names_exist(self):
+        missing = sorted(
+            name
+            for name in set(HELPER_PATTERN.findall(self.text))
+            if not (ROOT / "helpers" / name).exists()
+        )
+        self.assertEqual(missing, [], "SKILL.md names helper scripts that do not exist")
 
 
 if __name__ == "__main__":

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -26,6 +26,7 @@ HARD_RULES = [
     "Parallel sub-agents for multiple animations.",
     "Strategy confirmation before execution.",
     "All session outputs in `<videos_dir>/edit/`.",
+    "Captions transcribe audible speech only.",
 ]
 
 # matches backticked paths under references helpers or skills


### PR DESCRIPTION
 Grows the edit description format so one edit can produce several outputs, place overlays as cutaway, split, or picture in picture, protect regions from being covered, and prove captions match real speech. Version 1 edits still render unchanged. Includes a standalone validator and a 1080p preview.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the EDL from v1 to v2 so one edit can produce multiple deliverables, compose overlays, protect regions from coverage, and generate captions only from proven speech. Existing v1 edits keep their current rendering behavior, while invalid v2 inputs fail before upload or rendering.

**New Features**
- `deliverables` defines dimensions, frame rates, reframing, and loudness targets; `render.py --all-deliverables` renders each output plus a 1080p preview.
- Overlays support cutaway, split, and picture-in-picture layouts with protected-region collision preflight.
- Captions accept word or ElevenLabs character timings, skip music and sound-effect events, write UTF-8 ASS subtitles, and are omitted when no audible speech exists. Existing caption files are never overwritten, and failed encodes leave no finished deliverable behind.
- `helpers/edl.py` rejects malformed or ambiguous edits, including non-object or non-finite values, duplicate outputs, fractional versions, invalid source IDs, and missing or untimed caption evidence.

**Validation**
- Adds references and tests for deliverables, overlays, captions, frame rates, orientation, and the `SKILL.md` and comment conventions.
- Caption burn-in requires ffmpeg with `libass`; `render.py` detects Homebrew's `ffmpeg-full`, and `install.md` documents setup.

<sup>Written for commit 36177fea04d6f4f2c34b57fee863131a1cda5ca0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

