### PR TITLE
Fix ffmpeg filter-argument path escaping on Windows

### DIFF
--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -75,6 +76,21 @@ def get_preset(name: str) -> str:
 # -------- Auto grade (data-driven, per-clip) --------------------------------
 
 
+def ffpath(p) -> str:
+    """Escape a filesystem path for embedding in an ffmpeg filter argument.
+
+    The filter parser treats ":" as an option separator and backslash as an
+    escape, so a raw Windows path is mangled. Forward slashes plus an escaped
+    drive colon parse correctly. No-op off Windows.
+    """
+    p = str(p)
+    if os.name != "nt":
+        return p
+    # Unquoted filter-option context: the drive colon must survive both the
+    # filtergraph and the filter-argument parser, hence the doubled escape.
+    return p.replace("\\", "/").replace(":", r"\\:")
+
+
 def _sample_frame_stats(
     video: Path,
     start: float,
@@ -106,7 +122,7 @@ def _sample_frame_stats(
             "-ss", f"{start:.3f}",
             "-i", str(video),
             "-t", f"{duration:.3f}",
-            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file={metadata_path}",
+            "-vf", f"fps={fps:.2f},signalstats,metadata=print:file={ffpath(metadata_path)}",
             "-f", "null", "-",
         ]
         subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -641,7 +641,7 @@ def build_final_composite(
 
     # Subtitles LAST — Rule 1
     if has_subs:
-        subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
+        subs_abs = str(subtitles_path.resolve()).replace("\\", "/").replace(":", r"\:").replace("'", r"\'")
         filter_parts.append(
             f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
         )

--- a/install.md
+++ b/install.md
@@ -153,6 +153,7 @@ Tell the user, in one short message:
 ## Cold-start reminders
 
 - Symlink the **whole directory**, not just `SKILL.md`. The helpers need to sit next to it.
+- **Windows:** set `PYTHONIOENCODING=utf-8` before verifying anything. The helpers print `→` and `✓`, which raise `UnicodeEncodeError` on a cp1252 console and take down the run before it reaches ffmpeg — `setx PYTHONIOENCODING utf-8` makes it stick for new shells. A symlink also needs admin, so register the skill with a directory junction instead: `New-Item -ItemType Junction -Path $HOME\.claude\skillsideo-use -Target $HOME\Developerideo-use`.
 - If `.env` exists but the key is empty, treat it the same as missing — don't assume existence means validity.
 - `ffmpeg` from static builds works fine. Any modern (≥ 4.x) build is enough.
 - `yt-dlp` is optional. Don't block install on it; install lazily the first time a user asks to pull from a URL.


### PR DESCRIPTION
## Problem

On Windows, both auto-grading and subtitle burn-in fail outright. ffmpeg's filter parser treats `:` as an option separator and backslash as an escape, so a raw Windows path embedded in a filter argument is mangled before it reaches the filesystem.

Two sites are affected:

**`helpers/grade.py`** — builds `metadata=print:file=<path>` for `signalstats` sampling. This is an *unquoted* option context, so the drive colon must survive both the filtergraph and the filter-argument parser. Every auto-graded segment died with:

```
[AVFilterGraph] No option name near 'UsersYASWAN~1AppDataLocalTempmetadata.txt'
[AVFilterGraph] Error parsing a filter description
```

Since `grade: "auto"` is the common case, this takes down `render.py` for any EDL that uses it.

**`helpers/render.py`** — builds `subtitles='<path>'`. This is a *quoted* context where a single colon escape is correct, and that part was already there, but the backslashes survived and libass consumed them as escapes:

```
Error initializing filters
Error : No such file or directory
```

That breaks Hard Rule 1 (subtitles applied last) on Windows in the most confusing way possible — the render succeeds up to the final composite, then fails.

## Fix

Adds `ffpath()` in `grade.py`: forward slashes, plus a doubled drive-colon escape for the unquoted context. `render.py` converts to forward slashes before its existing single-escape, which is the right level for a quoted argument.

The two escaping levels are not interchangeable — I verified this empirically on ffmpeg 9.0.1:

| context | `C:\...` | `C\:/...` | `C\:/...` |
|---|---|---|---|
| `metadata=print:file=` (unquoted) | fail | fail | **ok** |
| `subtitles='...'` (quoted) | fail | **ok** | fail |

Both changes are no-ops off Windows: `ffpath()` returns early when `os.name != "nt"`, and POSIX paths have no backslashes to rewrite. No behavior change on macOS/Linux.

## `install.md`

Second commit adds one line to Cold-start reminders covering the two things a Windows user hits *before* ffmpeg is ever reached:

- The helpers print `→` and `✓`, which raise `UnicodeEncodeError` on a cp1252 console — this kills the step 6 verify itself. `PYTHONIOENCODING=utf-8` fixes it.
- Creating a symlink needs admin on Windows. A directory junction doesn't, and keeps `helpers/` a sibling of `SKILL.md` the same way.

Happy to drop that commit if you'd rather keep the PR to code only.

## Verification

Windows 11, ffmpeg 9.0.1, Python 3.11. Two-segment EDL with `grade: "auto"` and an SRT, rendered end to end: per-segment extract → lossless concat → subtitles last → loudnorm. `timeline_view` on the rendered output confirms captions are burned in and the 30ms fades are present at the cut boundary. Fails on `main`, passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdNEoiFdK3DyUxKFhSAY2E
