### PR TITLE
local whisper transcription for users without an elevenlabs key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 ELEVENLABS_API_KEY=
+# VIDEO_USE_TRANSCRIBER=local   # elevenlabs or local; omit to use the key above

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,8 @@ from being overwritten by another:
   history, so a later sync silently discards it.
 - Hard rules in `SKILL.md` are append-only. New rules get the next number.
   Removing or renumbering a rule requires an explicit reason in the commit.
-- Procedure prose belongs in `references/<feature>.md`. Edits to `SKILL.md`
+- Procedure prose belongs in `references/<feature>.md` at the repository root;
+  create that folder with the first reference file. Edits to `SKILL.md`
   are limited to rules, helper-index bullets, directory-tree lines, the EDL
   example, and one-line pointers to the reference files.
 - `tests/test_skill_contract.py` checks that the rules and every referenced

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# video-use repository context
+
+video-use is a public, conversation-driven video production framework. Changes
+made here may be packaged into the skill and reused by people with different
+machines, media, workflows, providers, brands, and output goals. Treat the
+repository as a general product, never as one person's customized clone.
+
+## Product principles
+
+- The delivered video is the product. Prioritize visual and audio quality,
+  editorial judgment, factual correctness, synchronization, pacing, and
+  production reliability.
+- Design reusable contracts and capabilities. Do not hardcode personal paths,
+  credentials, account ids, prompts, brands, preferences, lane history, or
+  assumptions about one project.
+- Keep provider-specific behavior behind narrow boundaries. Core EDL validation,
+  rendering, reframing, and QC must remain usable without the localhost GUI or
+  Modal.
+- Preserve backwards compatibility when practical. If a format must change,
+  provide a clear migration path and reject unsupported input with an actionable
+  error.
+- Never silently downgrade a requested feature. A missing source, track, model,
+  codec, or dependency should fail before expensive work begins and explain what
+  is required.
+- Defaults should be safe and broadly useful, while explicit project or user
+  requirements always win.
+- Keep credentials out of source, logs, fixtures, prompts, and generated
+  artifacts. Configuration belongs in environment variables or provider secret
+  stores.
+
+## Architecture boundaries
+
+- `SKILL.md` defines the agent workflow and public editing contract.
+- `helpers/` contains provider-independent production tools and validation.
+- `skills/` contains focused companion skills and reusable production assets.
+- `gui/` is an optional internal client and remote-execution adapter. It may
+  orchestrate core features but must not become the only place those features
+  exist.
+- `tests/` and `gui/tests/` protect public behavior and adapter behavior
+  respectively.
+
+Keep decision data explicit in portable project files such as `edit/edl.json`.
+Renderers should consume declared inputs deterministically. UI state, agent
+history, and cloud runtime state must not be required to reproduce an output.
+
+## Experimental GUI harness
+
+The four-lane GUI in `gui/` exists to generate many independent outputs quickly
+so developers can find ugly frames, weak editorial decisions, unsupported
+queries, and renderer failures before video-use users encounter them.
+
+- Use the four parallel Modal lanes for this branch's output-discovery runs.
+  Avoid one-off manual local benchmark renders when the harness can run the same
+  experiment and preserve comparable evidence.
+- Do not assume the public video-use workflow will adopt the GUI, Modal, its lane
+  model, or its run-storage APIs. Promote a finding into `helpers/`, `skills/`,
+  or `SKILL.md` only when the underlying capability is generally useful without
+  the harness.
+- Keep each lane's agent context fresh. Past run traces are evaluation evidence
+  for developers and must not leak into a new lane's creative context.
+- Preserve every run's durable evidence through `gui/run_store.py`: the compact
+  `run_summary.md`, deduplicated `trace.json`, raw Codex protocol when available,
+  complete `render.log`, generated edit handoff, and returned outputs.
+- Prefer `run_summary.md` when an agent needs quick context. Read the raw trace or
+  protocol only to investigate a specific decision, tool call, or failure.
+- Pin valuable successes and representative failures before cleanup. Never
+  delete a pinned run, and never delete an active lane.
+
+## Change workflow
+
+1. Identify whether a change belongs to the public editing contract, a reusable
+   helper, a focused skill, or an optional adapter.
+2. Implement the smallest complete general capability at the lowest reusable
+   layer. Wire adapters to that capability instead of duplicating it.
+3. Validate inputs locally before uploads or paid compute. Validate again at
+   remote execution boundaries.
+4. Add tests for successful use, invalid input, backwards compatibility, and
+   provider-boundary behavior where relevant.
+5. For render changes, create representative media and inspect the encoded
+   dimensions, duration, frame rate, visual framing, and audible output.
+6. Update the public EDL example or usage documentation whenever users or agents
+   need to author a new field.
+
+Cost and latency are secondary unless the user sets a budget or deadline. Improve
+them only when output quality and reliability remain equal or improve.
+
+## Communication and commits
+
+After code changes, summarize the affected files, the functions or contracts
+added, and what each does in plain language. Keep this technical context compact
+so someone can learn an unfamiliar codebase without reading every diff.
+
+Write simple, readable commit messages. Prefer short lowercase wording without
+punctuation.
+
+## Branch discipline
+
+Several agents work on this repository at once. To keep one agent's progress
+from being overwritten by another:
+
+- One feature per branch, one agent per branch. Never edit a worktree that
+  belongs to another branch; take files from a commit or tag instead.
+- Commit early. Uncommitted work in a worktree has no merge base and no
+  history, so a later sync silently discards it.
+- Hard rules in `SKILL.md` are append-only. New rules get the next number.
+  Removing or renumbering a rule requires an explicit reason in the commit.
+- Procedure prose belongs in `references/<feature>.md`. Edits to `SKILL.md`
+  are limited to rules, helper-index bullets, directory-tree lines, the EDL
+  example, and one-line pointers to the reference files.
+- `tests/test_skill_contract.py` checks that the rules and every referenced
+  path still exist. Run it before committing a `SKILL.md` change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,11 @@ repository as a general product, never as one person's customized clone.
   editorial judgment, factual correctness, synchronization, pacing, and
   production reliability.
 - Design reusable contracts and capabilities. Do not hardcode personal paths,
-  credentials, account ids, prompts, brands, preferences, lane history, or
-  assumptions about one project.
+  credentials, account ids, prompts, brands, preferences, or assumptions
+  about one project.
 - Keep provider-specific behavior behind narrow boundaries. Core EDL validation,
-  rendering, reframing, and QC must remain usable without the localhost GUI or
-  Modal.
+  rendering, reframing, and QC must remain usable from the command line without
+  any optional client or remote runner.
 - Preserve backwards compatibility when practical. If a format must change,
   provide a clear migration path and reject unsupported input with an actionable
   error.
@@ -33,38 +33,13 @@ repository as a general product, never as one person's customized clone.
 - `SKILL.md` defines the agent workflow and public editing contract.
 - `helpers/` contains provider-independent production tools and validation.
 - `skills/` contains focused companion skills and reusable production assets.
-- `gui/` is an optional internal client and remote-execution adapter. It may
-  orchestrate core features but must not become the only place those features
-  exist.
-- `tests/` and `gui/tests/` protect public behavior and adapter behavior
-  respectively.
+- `tests/` protects public behavior. Optional clients or remote runners may
+  orchestrate core features but must never become the only place a feature
+  exists.
 
 Keep decision data explicit in portable project files such as `edit/edl.json`.
 Renderers should consume declared inputs deterministically. UI state, agent
 history, and cloud runtime state must not be required to reproduce an output.
-
-## Experimental GUI harness
-
-The four-lane GUI in `gui/` exists to generate many independent outputs quickly
-so developers can find ugly frames, weak editorial decisions, unsupported
-queries, and renderer failures before video-use users encounter them.
-
-- Use the four parallel Modal lanes for this branch's output-discovery runs.
-  Avoid one-off manual local benchmark renders when the harness can run the same
-  experiment and preserve comparable evidence.
-- Do not assume the public video-use workflow will adopt the GUI, Modal, its lane
-  model, or its run-storage APIs. Promote a finding into `helpers/`, `skills/`,
-  or `SKILL.md` only when the underlying capability is generally useful without
-  the harness.
-- Keep each lane's agent context fresh. Past run traces are evaluation evidence
-  for developers and must not leak into a new lane's creative context.
-- Preserve every run's durable evidence through `gui/run_store.py`: the compact
-  `run_summary.md`, deduplicated `trace.json`, raw Codex protocol when available,
-  complete `render.log`, generated edit handoff, and returned outputs.
-- Prefer `run_summary.md` when an agent needs quick context. Read the raw trace or
-  protocol only to investigate a specific decision, tool call, or failure.
-- Pin valuable successes and representative failures before cleanup. Never
-  delete a pinned run, and never delete an active lane.
 
 ## Change workflow
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Paste into Claude Code, Codex, Hermes, Openclaw, or any agent with shell access:
 ```text
 Set up https://github.com/browser-use/video-use for me.
 
-Read install.md first to install this repo, wire up ffmpeg, register the skill with whichever agent you're running under, and set up the ElevenLabs API key — ask me to paste it when you need it. Then read SKILL.md for daily usage, and always read helpers/ because that's where the editing scripts live. After install, don't transcribe anything on your own — just tell me it's ready and wait for me to drop footage into a folder.
+Read install.md first to install this repo, wire up ffmpeg, register the skill with whichever agent you're running under, and set up transcription — ask me whether to paste an ElevenLabs API key or use the free local engine when you get there. Then read SKILL.md for daily usage, and always read helpers/ because that's where the editing scripts live. After install, don't transcribe anything on your own — just tell me it's ready and wait for me to drop footage into a folder.
 ```
 
-The agent handles the clone, dependencies, skill registration, and prompts you once for your ElevenLabs API key (grab one at [elevenlabs.io/app/settings/api-keys](https://elevenlabs.io/app/settings/api-keys)).
+The agent handles the clone, dependencies, skill registration, and asks you once how to transcribe: an ElevenLabs API key (grab one at [elevenlabs.io/app/settings/api-keys](https://elevenlabs.io/app/settings/api-keys)) for the best transcripts, or a local Whisper model that runs on your machine with no key.
 
 Then point your agent at a folder of raw takes:
 
@@ -63,9 +63,10 @@ uv sync                         # or: pip install -e .
 brew install ffmpeg             # required
 brew install yt-dlp             # optional, for downloading online sources
 
-# 3. Add your ElevenLabs API key
+# 3. Choose transcription: an ElevenLabs API key, or the local engine
 cp .env.example .env
-$EDITOR .env                    # ELEVENLABS_API_KEY=...
+$EDITOR .env                    # ELEVENLABS_API_KEY=...   or   VIDEO_USE_TRANSCRIBER=local
+python helpers/local_stt.py probe   # local only: prints the one install command this machine needs
 ```
 
 ## How it works
@@ -76,7 +77,7 @@ The LLM never watches the video. It **reads** it — through two layers that tog
   <img src="static/timeline-view.svg" alt="timeline_view composite — filmstrip + speaker track + waveform + word labels + silence-gap cut candidates" width="100%">
 </p>
 
-**Layer 1 — Audio transcript (always loaded).** One ElevenLabs Scribe call per source gives word-level timestamps, speaker diarization, and audio events (`(laughter)`, `(applause)`, `(sigh)`). All takes pack into a single ~12KB `takes_packed.md` — the LLM's primary reading view.
+**Layer 1 — Audio transcript (always loaded).** One ElevenLabs Scribe call per source (or one local Whisper pass, see `install.md`) gives word-level timestamps; Scribe adds speaker diarization and audio events (`(laughter)`, `(applause)`, `(sigh)`). All takes pack into a single ~12KB `takes_packed.md` — the LLM's primary reading view.
 
 ```
 ## C0103  (duration: 43.0s, 8 phrases)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cp .env.example .env
 $EDITOR .env                    # ELEVENLABS_API_KEY=...   or   VIDEO_USE_TRANSCRIBER=local
 # local engine only: probe the machine, then run the install command it prints
 python helpers/local_stt.py probe
-uv sync --extra stt-mlx         # or stt-cpu / stt-cuda, whichever the probe named
+uv sync --extra <extra the probe printed>   # stt-mlx on Apple Silicon, stt-cpu, or stt-cuda
 ```
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Paste into Claude Code, Codex, Hermes, Openclaw, or any agent with shell access:
 ```text
 Set up https://github.com/browser-use/video-use for me.
 
-Read install.md first to install this repo, wire up ffmpeg, register the skill with whichever agent you're running under, and set up transcription — ask me whether to paste an ElevenLabs API key or use the free local engine when you get there. Then read SKILL.md for daily usage, and always read helpers/ because that's where the editing scripts live. After install, don't transcribe anything on your own — just tell me it's ready and wait for me to drop footage into a folder.
+Read install.md first to install this repo, wire up ffmpeg, register the skill with whichever agent you're running under, and set up transcription — ask me whether to paste an ElevenLabs API key or use the free local engine when you get there. Then read SKILL.md for daily usage, and always read helpers/ because that's where the editing scripts live. After install, never run a paid Scribe transcription on your own (the free local check in install.md is fine) — just tell me it's ready and wait for me to drop footage into a folder.
 ```
 
 The agent handles the clone, dependencies, skill registration, and asks you once how to transcribe: an ElevenLabs API key (grab one at [elevenlabs.io/app/settings/api-keys](https://elevenlabs.io/app/settings/api-keys)) for the best transcripts, or a local Whisper model that runs on your machine with no key.
@@ -66,7 +66,9 @@ brew install yt-dlp             # optional, for downloading online sources
 # 3. Choose transcription: an ElevenLabs API key, or the local engine
 cp .env.example .env
 $EDITOR .env                    # ELEVENLABS_API_KEY=...   or   VIDEO_USE_TRANSCRIBER=local
-python helpers/local_stt.py probe   # local only: prints the one install command this machine needs
+# local engine only: probe the machine, then run the install command it prints
+python helpers/local_stt.py probe
+uv sync --extra stt-mlx         # or stt-cpu / stt-cuda, whichever the probe named
 ```
 
 ## How it works

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,7 +27,7 @@ These are the things where deviation produces silent failures or broken output. 
 6. **Never cut inside a word.** Snap every cut edge to a word boundary from the transcript.
 7. **Pad every cut edge.** Working window: 30–200ms. Transcript timestamps drift 50–100ms whichever engine made them — padding absorbs the drift. Tighter for fast-paced, looser for cinematic.
 8. **Word-level verbatim ASR only.** Never SRT/phrase mode (loses sub-second gap data). Never normalized fillers (loses editorial signal).
-9. **Cache transcripts per source.** Never re-transcribe unless the source file itself changed.
+9. **Cache transcripts per source.** Never re-transcribe unless the source file itself changed or the user explicitly asks to redo a transcript with the other engine (`transcribe.py --force`).
 10. **Parallel sub-agents for multiple animations.** Never sequential. Spawn N at once via the `Agent` tool; total wall time ≈ slowest one.
 11. **Strategy confirmation before execution.** Never touch the cut until the user has approved the plain-English plan.
 12. **All session outputs in `<videos_dir>/edit/`.** Never write inside the `video-use/` project directory.

--- a/SKILL.md
+++ b/SKILL.md
@@ -24,8 +24,8 @@ These are the things where deviation produces silent failures or broken output. 
 3. **30ms audio fades at every segment boundary** (`afade=t=in:st=0:d=0.03,afade=t=out:st={dur-0.03}:d=0.03`). Otherwise audible pops at every cut.
 4. **Overlays use `setpts=PTS-STARTPTS+T/TB`** to shift the overlay's frame 0 to its window start. Otherwise you see the middle of the animation during the overlay window.
 5. **Master SRT uses output-timeline offsets**: `output_time = word.start - segment_start + segment_offset`. Otherwise captions misalign after segment concat.
-6. **Never cut inside a word.** Snap every cut edge to a word boundary from the Scribe transcript.
-7. **Pad every cut edge.** Working window: 30–200ms. Scribe timestamps drift 50–100ms — padding absorbs the drift. Tighter for fast-paced, looser for cinematic.
+6. **Never cut inside a word.** Snap every cut edge to a word boundary from the transcript.
+7. **Pad every cut edge.** Working window: 30–200ms. Transcript timestamps drift 50–100ms whichever engine made them — padding absorbs the drift. Tighter for fast-paced, looser for cinematic.
 8. **Word-level verbatim ASR only.** Never SRT/phrase mode (loses sub-second gap data). Never normalized fillers (loses editorial signal).
 9. **Cache transcripts per source.** Never re-transcribe unless the source file itself changed.
 10. **Parallel sub-agents for multiple animations.** Never sequential. Spawn N at once via the `Agent` tool; total wall time ≈ slowest one.
@@ -45,7 +45,7 @@ The skill lives in `video-use/`. User footage lives wherever they put it. All se
     ├── project.md               ← memory; appended every session
     ├── takes_packed.md          ← phrase-level transcripts, the LLM's primary reading view
     ├── edl.json                 ← cut decisions
-    ├── transcripts/<name>.json  ← cached raw Scribe JSON
+    ├── transcripts/<name>.json  ← cached transcript JSON; its `engine` key says who made it
     ├── animations/slot_<id>/    ← per-animation source + render + reasoning
     ├── clips_graded/            ← per-segment extracts with grade + fades
     ├── master.srt               ← output-timeline subtitles
@@ -57,9 +57,9 @@ The skill lives in `video-use/`. User footage lives wherever they put it. All se
 
 ## Setup
 
-First-time install lives in `install.md` (clone, deps, ffmpeg, skill registration, API key). Don't re-run it every session; on cold start just verify:
+First-time install lives in `install.md` (clone, deps, ffmpeg, skill registration, transcription setup). Don't re-run it every session; on cold start just verify:
 
-- `ELEVENLABS_API_KEY` resolves — either in the environment or in `.env` at the video-use repo root. If missing, ask the user to paste one and write it to `.env` (never to the user's `<videos_dir>`).
+- A transcription engine resolves: `ELEVENLABS_API_KEY` or `VIDEO_USE_TRANSCRIBER=local`, in the environment or in `.env` at the video-use repo root (`.env` wins). If neither is set, ask the user once whether to paste an ElevenLabs key or use the local engine (`install.md` step 5) and write the answer to `.env` (never to the user's `<videos_dir>`). Never fall back from one engine to the other silently.
 - `ffmpeg` + `ffprobe` on PATH.
 - Python deps installed (`uv sync` or `pip install -e .` inside the repo).
 - Node.js + npm available if the session needs HyperFrames or Remotion slots. HyperFrames currently requires Node.js 22+.
@@ -67,12 +67,23 @@ First-time install lives in `install.md` (clone, deps, ffmpeg, skill registratio
 - First-use animation setup happens inside the slot directory, never at the video-use repo root. HyperFrames can be invoked with `npx --yes hyperframes ...`; Remotion can be scaffolded with `npx create-video@latest` or installed as a project-local dependency before using its `remotion render` command.
 - This skill vendors `skills/manim-video/`. Read its SKILL.md when building a Manim slot.
 
+### Local transcription
+
+With `VIDEO_USE_TRANSCRIBER=local`, `transcribe.py` runs Whisper large-v3-turbo on the user's machine (`mlx-whisper` on Apple Silicon, `faster-whisper` elsewhere; `local_stt.py probe` shows which). The transcript keeps the same shape — `words` entries with `type`, `text`, `start`, `end` — so every helper works unchanged, but the editing plan must account for what the local engine does not provide:
+
+- No `speaker_id`. Ask the user who speaks when, or treat the take as a single speaker.
+- No `(laughter)` / `(applause)` audio events and no `spacing` entries. Find reaction beats with `timeline_view.py` waveforms instead.
+- Fillers are best effort: a verbatim prompt keeps most "um"s, but stutter runs ("the, the, the") usually collapse into one long word, so do not promise filler removal until you have read `takes_packed.md`.
+- Word ends are as accurate as Scribe's; word starts are trimmed to the first audible energy so pauses are not folded into the next word. Keep the Hard Rule 7 padding either way.
+- The first run downloads about 1.6 GB of pinned weights; every later run is offline.
+
 Helpers (`helpers/transcribe.py`, `helpers/render.py`, etc.) live alongside this SKILL.md. Resolve their paths relative to the directory containing this file — the skill is typically symlinked at `~/.claude/skills/video-use/` or `~/.codex/skills/video-use/`.
 
 ## Helpers
 
-- **`transcribe.py <video>`** — single-file Scribe call. `--num-speakers N` optional. Cached.
-- **`transcribe_batch.py <videos_dir>`** — 4-worker parallel transcription. Use for multi-take.
+- **`transcribe.py <video>`** — single-file transcription with ElevenLabs Scribe or the local engine (`--engine`; default from `VIDEO_USE_TRANSCRIBER`, else Scribe when a key resolves). Prints the engine it used. `--num-speakers N` optional (Scribe only). Cached; `--force` redoes.
+- **`transcribe_batch.py <videos_dir>`** — 4-worker parallel transcription (one worker with the local engine). Use for multi-take.
+- **`local_stt.py probe`** — hardware probe for the local engine: which Whisper library this machine uses, whether it is installed, model size, free disk, install command. Run it before choosing local.
 - **`pack_transcripts.py --edit-dir <dir>`** — `transcripts/*.json` → `takes_packed.md` (phrase-level, break on silence ≥ 0.5s).
 - **`timeline_view.py <video> <start> <end>`** — filmstrip + waveform PNG. On-demand visual drill-down. **Not a scan tool** — use it at decision points, not constantly.
 - **`render.py <edl.json> -o <out>`** — per-segment extract → concat → overlays (PTS-shifted) → subtitles LAST. `--preview` for 720p fast. `--build-subtitles` to generate master.srt inline.
@@ -309,8 +320,8 @@ Things that consistently fail regardless of style:
 
 - **Hierarchical pre-computed codec formats** with USABILITY / tone tags / shot layers. Over-engineering. Derive from the transcript at decision time.
 - **Hand-tuned moment-scoring functions.** The LLM picks better than any heuristic you'll write.
-- **Whisper SRT / phrase-level output.** Loses sub-second gap data. Always word-level verbatim.
-- **Running Whisper locally on CPU.** Slow and it normalizes fillers. Use hosted Scribe.
+- **Phrase-level ASR output (SRT, the plain `whisper` CLI).** Loses sub-second gap data. Always word-level; `local_stt.py` is the only approved local path.
+- **Treating a local transcript like a Scribe one.** No speaker labels, no audio events, fillers only best effort. Read the `engine` key and plan the cut accordingly.
 - **Burning subtitles into base before compositing overlays.** Overlays hide them. (Hard Rule 1.)
 - **Single-pass filtergraph when you have overlays.** Double re-encodes. Use per-segment extract → concat.
 - **Linear animation easing.** Looks robotic. Always cubic.

--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -1,3 +1,7 @@
+# color grading helper that builds ffmpeg filter strings and applies them to a video
+# it ships a few named presets and an auto mode that samples frame stats to pick a small corrective eq
+# render py imports get_preset and auto_grade_for_clip and the cli wraps the same functions
+
 """Apply a color grade to a video via ffmpeg filter chain.
 
 Two modes:
@@ -63,6 +67,7 @@ PRESETS: dict[str, str] = {
 }
 
 
+# look up the ffmpeg filter string for a named preset and fail loudly on unknown names
 def get_preset(name: str) -> str:
     """Return the ffmpeg filter string for a preset name. Empty string for 'none'."""
     if name not in PRESETS:
@@ -75,6 +80,7 @@ def get_preset(name: str) -> str:
 # -------- Auto grade (data-driven, per-clip) --------------------------------
 
 
+# run ffmpeg signalstats over a sampled range and average the luma and saturation readings into normalized stats
 def _sample_frame_stats(
     video: Path,
     start: float,
@@ -121,6 +127,7 @@ def _sample_frame_stats(
         sat_avgs: list[float] = []
         bit_depth: int = 8
 
+        # pull the numeric value after the last equals sign on a metadata line
         def _parse_value(line: str) -> float | None:
             try:
                 return float(line.rsplit("=", 1)[1])
@@ -175,6 +182,7 @@ def _sample_frame_stats(
         Path(metadata_path).unlink(missing_ok=True)
 
 
+# analyze a clip range and derive a bounded corrective eq filter with no creative color shift
 def auto_grade_for_clip(
     video: Path,
     start: float = 0.0,
@@ -271,8 +279,10 @@ def auto_grade_for_clip(
     return filter_string, stats
 
 
+# run ffmpeg to write the graded output or stream copy when the filter is empty
 def apply_grade(input_path: Path, output_path: Path, filter_string: str) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    # an empty filter means no grade so copy streams without re encoding
     if not filter_string:
         cmd = [
             "ffmpeg", "-y", "-i", str(input_path),
@@ -291,6 +301,7 @@ def apply_grade(input_path: Path, output_path: Path, filter_string: str) -> None
     subprocess.run(cmd, check=True)
 
 
+# cli entry point that handles preset listing analysis and the normal grade run
 def main() -> None:
     ap = argparse.ArgumentParser(description="Apply a color grade via ffmpeg filter chain")
     ap.add_argument("input", type=Path, nargs="?", help="Input video")

--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -1,7 +1,3 @@
-# color grading helper that builds ffmpeg filter strings and applies them to a video
-# it ships a few named presets and an auto mode that samples frame stats to pick a small corrective eq
-# render py imports get_preset and auto_grade_for_clip and the cli wraps the same functions
-
 """Apply a color grade to a video via ffmpeg filter chain.
 
 Two modes:

--- a/helpers/local_stt.py
+++ b/helpers/local_stt.py
@@ -139,11 +139,18 @@ def install_command(library: str, cuda: bool = False) -> str:
     return f"uv sync --extra {extra}    (or: pip install -e '.[{extra}]')"
 
 
-# settle the library before any audio work so a missing install fails first
+# libraries already settled in this process keyed by the override that asked for them
+_PREFLIGHTED: dict[str | None, str] = {}
+
+
+# settle the library before any audio work so a missing install fails first and later calls are free
 def preflight(library: str | None = None) -> str:
-    library = choose_library(probe(), library)
-    require_library(library)
-    return library
+    if library not in _PREFLIGHTED:
+        info = probe()
+        chosen = choose_library(info, library)
+        require_library(chosen, info["cuda"])
+        _PREFLIGHTED[library] = chosen
+    return _PREFLIGHTED[library]
 
 
 # true only when ctranslate2 can see a cuda device with its runtime libraries loaded
@@ -157,14 +164,14 @@ def cuda_available() -> bool:
 
 
 # import the library or exit with the install command so nothing expensive starts
-def require_library(library: str):
+def require_library(library: str, cuda: bool = False):
     module = LIBRARY_INFO[library]["module"]
     try:
         return importlib.import_module(module)
     except ImportError:
         raise SystemExit(
             f"{library} is not installed. From the video-use repo run:\n"
-            f"  {install_command(library)}"
+            f"  {install_command(library, cuda)}"
         ) from None
 
 

--- a/helpers/local_stt.py
+++ b/helpers/local_stt.py
@@ -68,6 +68,8 @@ ONSET_FRAME_SECONDS = 0.01
 ONSET_RATIO = 0.2
 # a trimmed word always keeps at least this much duration
 ONSET_MIN_KEEP = 0.05
+# energy frames read per pass so a long take never sits in memory at once
+ENERGY_READ_FRAMES = 4096
 # no real word lasts this long so longer ones are decoder artifacts
 MAX_WORD_SECONDS = 3.0
 # the same word this many times in a row is a repetition loop
@@ -131,10 +133,27 @@ def choose_library(info: dict, override: str | None = None) -> str:
     return "mlx-whisper" if info.get("apple_silicon") else "faster-whisper"
 
 
-# the exact commands that add a library to this checkout
-def install_command(library: str) -> str:
-    extra = LIBRARY_INFO[library]["extra"]
+# the exact commands that add a library to this checkout with the cuda runtime libraries when a gpu is present
+def install_command(library: str, cuda: bool = False) -> str:
+    extra = "stt-cuda" if library == "faster-whisper" and cuda else LIBRARY_INFO[library]["extra"]
     return f"uv sync --extra {extra}    (or: pip install -e '.[{extra}]')"
+
+
+# settle the library before any audio work so a missing install fails first
+def preflight(library: str | None = None) -> str:
+    library = choose_library(probe(), library)
+    require_library(library)
+    return library
+
+
+# true only when ctranslate2 can see a cuda device with its runtime libraries loaded
+def cuda_available() -> bool:
+    try:
+        import ctranslate2
+
+        return ctranslate2.get_cuda_device_count() > 0
+    except (ImportError, RuntimeError):
+        return False
 
 
 # import the library or exit with the install command so nothing expensive starts
@@ -208,11 +227,14 @@ def run_faster_whisper(wav: Path, model_path: Path, language: str | None, prompt
     faster_whisper = require_library("faster-whisper")
     key = str(model_path)
     if key not in _FASTER_MODELS:
-        cuda = shutil.which("nvidia-smi") is not None
+        device = "cuda" if cuda_available() else "cpu"
+        if device == "cpu" and shutil.which("nvidia-smi") is not None:
+            print("  nvidia gpu found but the cuda runtime libraries are missing; running on cpu "
+                  f"({install_command('faster-whisper', cuda=True)})", flush=True)
         _FASTER_MODELS[key] = faster_whisper.WhisperModel(
             key,
-            device="cuda" if cuda else "cpu",
-            compute_type="float16" if cuda else "int8",
+            device=device,
+            compute_type="float16" if device == "cuda" else "int8",
         )
     model = _FASTER_MODELS[key]
     raw_segments, info = model.transcribe(
@@ -259,9 +281,9 @@ def words_from_segments(segments: list[dict], no_speech_threshold: float = NO_SP
     return words
 
 
-# lowercase alphanumeric form of a word for repeat and prompt echo checks
+# casefolded letters and digits of a word in any script for repeat and prompt echo checks
 def _plain(text: str) -> str:
-    return re.sub(r"[^a-z0-9']+", "", text.lower())
+    return re.sub(r"[^\w']+", "", text.casefold())
 
 
 # drop decoder artifacts that survive the segment filter
@@ -301,20 +323,27 @@ def remove_prompt_echo(words: list[dict], prompt: str) -> list[dict]:
     return [word for position, word in enumerate(words) if position not in drop]
 
 
-# root mean square energy of a mono sixteen bit wav in fixed frames
+# root mean square energy of a mono sixteen bit wav in fixed frames read in chunks so long takes never load at once
 def frame_energy(wav: Path, frame_seconds: float = ONSET_FRAME_SECONDS):
     import wave
 
     import numpy as np
 
+    chunks = []
     with wave.open(str(wav), "rb") as handle:
-        rate = handle.getframerate()
-        pcm = np.frombuffer(handle.readframes(handle.getnframes()), dtype=np.int16).astype(np.float32)
-    hop = max(1, int(rate * frame_seconds))
-    count = len(pcm) // hop
-    if count == 0:
+        if handle.getnchannels() != 1 or handle.getsampwidth() != 2:
+            raise ValueError(f"{wav} must be mono 16 bit pcm for onset trimming")
+        hop = max(1, int(handle.getframerate() * frame_seconds))
+        # every read is a whole number of frames so chunk edges never split a frame
+        while data := handle.readframes(hop * ENERGY_READ_FRAMES):
+            pcm = np.frombuffer(data, dtype=np.int16).astype(np.float32)
+            count = len(pcm) // hop
+            if count == 0:
+                break
+            chunks.append(np.sqrt(np.mean(pcm[: count * hop].reshape(count, hop) ** 2, axis=1)))
+    if not chunks:
         return np.zeros(0, dtype=np.float32)
-    return np.sqrt(np.mean(pcm[: count * hop].reshape(count, hop) ** 2, axis=1))
+    return np.concatenate(chunks)
 
 
 # move each word start forward to its first audible frame because whisper folds pauses into the next word
@@ -359,8 +388,7 @@ def transcribe_wav(
     model: str | None = None,
     verbatim: bool = True,
 ) -> dict:
-    library = choose_library(probe(), library)
-    require_library(library)
+    library = preflight(library)
     model_path, model_label = ensure_model(library, model)
     runner = RUNNERS[library]
     prompt = verbatim_prompt_for(language, verbatim)
@@ -370,7 +398,8 @@ def transcribe_wav(
         prompt = None
         segments, detected = runner(wav, model_path, detected, None)
     words = clean_words(words_from_segments(segments), prompt)
-    words = trim_onsets(words, frame_energy(wav))
+    if words:
+        words = trim_onsets(words, frame_energy(wav))
     return build_payload(library, model_label, language or detected, words)
 
 
@@ -394,7 +423,7 @@ def main() -> None:
         info["library"] = library
         info["model"] = MODELS[library]
         info["installed_for_library"] = info["installed"][library]
-        info["install_command"] = install_command(library)
+        info["install_command"] = install_command(library, info["cuda"])
         print(json.dumps(info, indent=2))
         return
 

--- a/helpers/local_stt.py
+++ b/helpers/local_stt.py
@@ -1,0 +1,416 @@
+"""Local speech to text for machines without an ElevenLabs key.
+
+Runs Whisper large-v3-turbo through mlx-whisper on Apple Silicon or through
+faster-whisper (CTranslate2) everywhere else, and returns the same transcript
+shape the rest of the pipeline reads: a top-level ``words`` list of
+``{"type": "word", "text", "start", "end", "speaker_id"}`` entries.
+
+The library is chosen from a hardware probe so a machine only downloads the
+one model it will use. Nothing here installs packages: a missing library exits
+with the exact install command, and model weights are fetched once, pinned to
+a commit, into the standard Hugging Face cache.
+
+What the local engine does not provide: speaker labels, audio event tags such
+as laughter, and ``spacing`` entries. Fillers are kept on a best effort basis
+through a verbatim prompt. Whisper reports word ends well but folds each pause
+into the start of the following word, so word starts are moved forward to the
+first audible energy frame before the transcript is written.
+
+Usage:
+    python helpers/local_stt.py probe
+    python helpers/local_stt.py transcribe <audio.wav> -o <out.json> [--language en]
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import json
+import os
+import platform
+import re
+import shutil
+import sys
+from pathlib import Path
+
+
+LIBRARIES = ("mlx-whisper", "faster-whisper")
+
+# import name and pyproject extra for each supported library
+LIBRARY_INFO = {
+    "mlx-whisper": {"module": "mlx_whisper", "extra": "stt-mlx"},
+    "faster-whisper": {"module": "faster_whisper", "extra": "stt-cpu"},
+}
+
+# one pinned whisper large v3 turbo conversion per library
+MODELS = {
+    "mlx-whisper": {
+        "repo": "mlx-community/whisper-large-v3-turbo",
+        "revision": "a4aaeec0636e6fef84abdcbe3544cb2bf7e9f6fb",
+        "size_gb": 1.6,
+    },
+    "faster-whisper": {
+        "repo": "deepdml/faster-whisper-large-v3-turbo-ct2",
+        "revision": "4df90f75321148c3a29a9e2351b7ddf8f5b115a8",
+        "size_gb": 1.6,
+    },
+}
+
+# a filler rich prompt nudges whisper toward verbatim output instead of a cleaned up transcript
+VERBATIM_PROMPT = "Umm, let me think like, hmm... Okay, here's what I'm, like, thinking."
+
+# segments whisper itself marks as probably silent are dropped above this probability
+NO_SPEECH_THRESHOLD = 0.6
+# onset trimming works on ten millisecond energy frames
+ONSET_FRAME_SECONDS = 0.01
+# a word starts where its energy first reaches this share of its own peak
+ONSET_RATIO = 0.2
+# a trimmed word always keeps at least this much duration
+ONSET_MIN_KEEP = 0.05
+# no real word lasts this long so longer ones are decoder artifacts
+MAX_WORD_SECONDS = 3.0
+# the same word this many times in a row is a repetition loop
+MAX_REPEATS = 4
+
+
+# describe the machine without importing any model library or touching the network
+def probe() -> dict:
+    system = platform.system()
+    machine = platform.machine()
+    installed = {
+        name: importlib.util.find_spec(info["module"]) is not None
+        for name, info in LIBRARY_INFO.items()
+    }
+    return {
+        "system": system,
+        "machine": machine,
+        "apple_silicon": system == "Darwin" and machine == "arm64",
+        "cuda": shutil.which("nvidia-smi") is not None,
+        "memory_gb": memory_gb(),
+        "free_disk_gb": free_disk_gb(hf_cache_dir()),
+        "python": platform.python_version(),
+        "installed": installed,
+    }
+
+
+# physical memory in gigabytes or none where the platform does not expose it
+def memory_gb() -> float | None:
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+    except (AttributeError, ValueError, OSError):
+        return None
+    return round(pages * page_size / 1024**3, 1)
+
+
+# free space in gigabytes at the nearest existing parent of a path
+def free_disk_gb(path: Path) -> float:
+    probe_path = path
+    while not probe_path.exists() and probe_path != probe_path.parent:
+        probe_path = probe_path.parent
+    return round(shutil.disk_usage(probe_path).free / 1024**3, 1)
+
+
+# where huggingface_hub stores snapshots honoring the usual environment overrides
+def hf_cache_dir() -> Path:
+    if os.environ.get("HF_HUB_CACHE"):
+        return Path(os.environ["HF_HUB_CACHE"]).expanduser()
+    home = os.environ.get("HF_HOME")
+    if home:
+        return Path(home).expanduser() / "hub"
+    return Path.home() / ".cache" / "huggingface" / "hub"
+
+
+# pick the library for this machine unless a cli override names one
+def choose_library(info: dict, override: str | None = None) -> str:
+    if override:
+        if override not in LIBRARIES:
+            raise SystemExit(f"unknown library {override!r}; choose from {', '.join(LIBRARIES)}")
+        return override
+    return "mlx-whisper" if info.get("apple_silicon") else "faster-whisper"
+
+
+# the exact commands that add a library to this checkout
+def install_command(library: str) -> str:
+    extra = LIBRARY_INFO[library]["extra"]
+    return f"uv sync --extra {extra}    (or: pip install -e '.[{extra}]')"
+
+
+# import the library or exit with the install command so nothing expensive starts
+def require_library(library: str):
+    module = LIBRARY_INFO[library]["module"]
+    try:
+        return importlib.import_module(module)
+    except ImportError:
+        raise SystemExit(
+            f"{library} is not installed. From the video-use repo run:\n"
+            f"  {install_command(library)}"
+        ) from None
+
+
+# download the pinned model once and return its local path and a label for the transcript
+def ensure_model(library: str, model: str | None = None) -> tuple[Path, str]:
+    if model and Path(model).expanduser().exists():
+        path = Path(model).expanduser().resolve()
+        return path, str(path)
+    if model:
+        repo, revision = model, None
+    else:
+        repo, revision = MODELS[library]["repo"], MODELS[library]["revision"]
+    from huggingface_hub import snapshot_download
+
+    path = Path(snapshot_download(repo_id=repo, revision=revision))
+    label = f"{repo}@{revision[:12]}" if revision else repo
+    return path, label
+
+
+# decide whether the verbatim prompt applies for the requested language
+def verbatim_prompt_for(language: str | None, enabled: bool) -> str | None:
+    if not enabled:
+        return None
+    if language is None or language.lower().startswith("en"):
+        return VERBATIM_PROMPT
+    return None
+
+
+# run mlx whisper and return plain segment dicts plus the detected language
+def run_mlx_whisper(wav: Path, model_path: Path, language: str | None, prompt: str | None) -> tuple[list[dict], str | None]:
+    mlx_whisper = require_library("mlx-whisper")
+    result = mlx_whisper.transcribe(
+        str(wav),
+        path_or_hf_repo=str(model_path),
+        language=language,
+        word_timestamps=True,
+        initial_prompt=prompt,
+        condition_on_previous_text=False,
+        verbose=None,
+    )
+    segments = [
+        {
+            "no_speech_prob": float(segment.get("no_speech_prob", 0.0)),
+            "words": [
+                {"text": w.get("word", ""), "start": w.get("start"), "end": w.get("end")}
+                for w in segment.get("words", [])
+            ],
+        }
+        for segment in result.get("segments", [])
+    ]
+    return segments, result.get("language")
+
+
+# faster whisper models are kept for the life of the process so batch runs load once
+_FASTER_MODELS: dict[str, object] = {}
+
+
+# run faster whisper and return plain segment dicts plus the detected language
+def run_faster_whisper(wav: Path, model_path: Path, language: str | None, prompt: str | None) -> tuple[list[dict], str | None]:
+    faster_whisper = require_library("faster-whisper")
+    key = str(model_path)
+    if key not in _FASTER_MODELS:
+        cuda = shutil.which("nvidia-smi") is not None
+        _FASTER_MODELS[key] = faster_whisper.WhisperModel(
+            key,
+            device="cuda" if cuda else "cpu",
+            compute_type="float16" if cuda else "int8",
+        )
+    model = _FASTER_MODELS[key]
+    raw_segments, info = model.transcribe(
+        str(wav),
+        language=language,
+        word_timestamps=True,
+        vad_filter=True,
+        initial_prompt=prompt,
+        condition_on_previous_text=False,
+    )
+    segments = [
+        {
+            "no_speech_prob": float(getattr(segment, "no_speech_prob", 0.0)),
+            "words": [
+                {"text": w.word, "start": w.start, "end": w.end}
+                for w in (segment.words or [])
+            ],
+        }
+        for segment in raw_segments
+    ]
+    return segments, getattr(info, "language", None)
+
+
+RUNNERS = {"mlx-whisper": run_mlx_whisper, "faster-whisper": run_faster_whisper}
+
+
+# turn library segments into the canonical word list dropping silent segments and empty words
+def words_from_segments(segments: list[dict], no_speech_threshold: float = NO_SPEECH_THRESHOLD) -> list[dict]:
+    words: list[dict] = []
+    for segment in segments:
+        if float(segment.get("no_speech_prob") or 0.0) > no_speech_threshold:
+            continue
+        for item in segment.get("words", []):
+            text = (item.get("text") or "").strip()
+            start = item.get("start")
+            end = item.get("end")
+            if not text or start is None or end is None:
+                continue
+            start = float(start)
+            end = float(end)
+            if end <= start:
+                continue
+            words.append({"type": "word", "text": text, "start": start, "end": end, "speaker_id": None})
+    return words
+
+
+# lowercase alphanumeric form of a word for repeat and prompt echo checks
+def _plain(text: str) -> str:
+    return re.sub(r"[^a-z0-9']+", "", text.lower())
+
+
+# drop decoder artifacts that survive the segment filter
+def clean_words(words: list[dict], prompt: str | None = None) -> list[dict]:
+    kept: list[dict] = []
+    repeats = 0
+    for word in words:
+        if word["end"] - word["start"] > MAX_WORD_SECONDS:
+            continue
+        if kept and _plain(word["text"]) == _plain(kept[-1]["text"]):
+            repeats += 1
+            if repeats >= MAX_REPEATS:
+                continue
+        else:
+            repeats = 0
+        kept.append(word)
+    if prompt:
+        kept = remove_prompt_echo(kept, prompt)
+    return kept
+
+
+# remove any run of words that repeats the verbatim prompt token for token
+def remove_prompt_echo(words: list[dict], prompt: str) -> list[dict]:
+    tokens = [_plain(token) for token in prompt.split()]
+    tokens = [token for token in tokens if token]
+    if not tokens:
+        return words
+    plain = [_plain(word["text"]) for word in words]
+    drop: set[int] = set()
+    index = 0
+    while index + len(tokens) <= len(plain):
+        if plain[index:index + len(tokens)] == tokens:
+            drop.update(range(index, index + len(tokens)))
+            index += len(tokens)
+        else:
+            index += 1
+    return [word for position, word in enumerate(words) if position not in drop]
+
+
+# root mean square energy of a mono sixteen bit wav in fixed frames
+def frame_energy(wav: Path, frame_seconds: float = ONSET_FRAME_SECONDS):
+    import wave
+
+    import numpy as np
+
+    with wave.open(str(wav), "rb") as handle:
+        rate = handle.getframerate()
+        pcm = np.frombuffer(handle.readframes(handle.getnframes()), dtype=np.int16).astype(np.float32)
+    hop = max(1, int(rate * frame_seconds))
+    count = len(pcm) // hop
+    if count == 0:
+        return np.zeros(0, dtype=np.float32)
+    return np.sqrt(np.mean(pcm[: count * hop].reshape(count, hop) ** 2, axis=1))
+
+
+# move each word start forward to its first audible frame because whisper folds pauses into the next word
+def trim_onsets(words: list[dict], energy, frame_seconds: float = ONSET_FRAME_SECONDS) -> list[dict]:
+    trimmed: list[dict] = []
+    for word in words:
+        start, end = word["start"], word["end"]
+        first = int(start / frame_seconds)
+        last = max(first + 1, int(end / frame_seconds))
+        window = [float(value) for value in energy[first:last]]
+        peak = max(window, default=0.0)
+        if peak <= 0.0:
+            trimmed.append(dict(word))
+            continue
+        threshold = peak * ONSET_RATIO
+        offset = next(index for index, value in enumerate(window) if value >= threshold)
+        onset = (first + offset) * frame_seconds
+        new_start = min(max(start, onset), end - ONSET_MIN_KEEP)
+        item = dict(word)
+        item["start"] = round(max(start, new_start), 3)
+        trimmed.append(item)
+    return trimmed
+
+
+# assemble the transcript payload the pipeline reads
+def build_payload(library: str, model_label: str, language: str | None, words: list[dict]) -> dict:
+    return {
+        "engine": "local",
+        "library": library,
+        "model": model_label,
+        "language_code": language,
+        "text": " ".join(word["text"] for word in words),
+        "words": words,
+    }
+
+
+# transcribe a mono wav with the chosen library and return the canonical payload
+def transcribe_wav(
+    wav: Path,
+    library: str | None = None,
+    language: str | None = None,
+    model: str | None = None,
+    verbatim: bool = True,
+) -> dict:
+    library = choose_library(probe(), library)
+    require_library(library)
+    model_path, model_label = ensure_model(library, model)
+    runner = RUNNERS[library]
+    prompt = verbatim_prompt_for(language, verbatim)
+    segments, detected = runner(wav, model_path, language, prompt)
+    # the english prompt biases language detection so a non english result is redone without it
+    if prompt and language is None and detected and not detected.lower().startswith("en"):
+        prompt = None
+        segments, detected = runner(wav, model_path, detected, None)
+    words = clean_words(words_from_segments(segments), prompt)
+    words = trim_onsets(words, frame_energy(wav))
+    return build_payload(library, model_label, language or detected, words)
+
+
+# cli entry point with a probe subcommand and a transcribe subcommand
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Local Whisper transcription")
+    sub = ap.add_subparsers(dest="command", required=True)
+    sub.add_parser("probe", help="Print the hardware probe and the library this machine would use")
+    run = sub.add_parser("transcribe", help="Transcribe a mono 16 kHz wav to transcript json")
+    run.add_argument("audio", type=Path)
+    run.add_argument("-o", "--output", type=Path, required=True)
+    run.add_argument("--language", default=None, help="ISO language code; omit to auto-detect")
+    run.add_argument("--library", choices=LIBRARIES, default=None, help="Override the probed library")
+    run.add_argument("--model", default=None, help="Hugging Face repo id or local model directory")
+    run.add_argument("--no-verbatim-prompt", action="store_true", help="Disable the filler-preserving prompt")
+    args = ap.parse_args()
+
+    if args.command == "probe":
+        info = probe()
+        library = choose_library(info)
+        info["library"] = library
+        info["model"] = MODELS[library]
+        info["installed_for_library"] = info["installed"][library]
+        info["install_command"] = install_command(library)
+        print(json.dumps(info, indent=2))
+        return
+
+    if not args.audio.exists():
+        sys.exit(f"audio not found: {args.audio}")
+    payload = transcribe_wav(
+        args.audio,
+        library=args.library,
+        language=args.language,
+        model=args.model,
+        verbatim=not args.no_verbatim_prompt,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2))
+    print(f"saved: {args.output} ({len(payload['words'])} words)")
+
+
+if __name__ == "__main__":
+    main()

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -1,3 +1,7 @@
+# packs scribe word level transcript json files into one phrase level markdown document
+# words are grouped into phrases split on long silences or speaker changes and each phrase carries a start and end stamp
+# the editor sub agent reads the result to pick cuts so it favors compactness over raw detail
+
 """Pack all Scribe transcripts in <edit>/transcripts/ into one readable markdown.
 
 Groups word-level entries into phrase-level lines, breaking on any silence
@@ -21,11 +25,13 @@ import sys
 from pathlib import Path
 
 
+# render seconds as a zero padded fixed width string so stamps line up in columns
 def format_time(seconds: float) -> str:
     """Format a time in seconds as "NNN.NN" with fixed 6-char width for alignment."""
     return f"{seconds:06.2f}"
 
 
+# render a duration as seconds or minutes plus seconds for the section headers
 def format_duration(seconds: float) -> str:
     """Format a duration as "Ms" or "Mm SSs"."""
     if seconds < 60:
@@ -35,6 +41,7 @@ def format_duration(seconds: float) -> str:
     return f"{m}m {s:04.1f}s"
 
 
+# walk scribe word entries and cut them into phrases on silence gaps or speaker changes
 def group_into_phrases(
     words: list[dict],
     silence_threshold: float = 0.5,
@@ -51,6 +58,7 @@ def group_into_phrases(
     current_start: float | None = None
     current_speaker: str | None = None
 
+    # emit the current phrase if it has any visible text then reset the accumulator
     def flush() -> None:
         nonlocal current_words, current_start, current_speaker
         if not current_words:
@@ -61,6 +69,7 @@ def group_into_phrases(
             raw = (w.get("text") or "").strip()
             if not raw:
                 continue
+            # wrap audio events in parentheses unless scribe already did
             if t == "audio_event":
                 if not raw.startswith("("):
                     raw = f"({raw})"
@@ -71,7 +80,9 @@ def group_into_phrases(
             current_speaker = None
             return
         text = " ".join(text_parts)
+        # glue punctuation tokens back onto the preceding word
         text = text.replace(" ,", ",").replace(" .", ".").replace(" ?", "?").replace(" !", "!")
+        # fall back through end then start then phrase start so a missing timestamp cannot break the flush
         end_time = current_words[-1].get("end", current_words[-1].get("start", current_start or 0.0))
         phrases.append({
             "start": current_start,
@@ -122,6 +133,7 @@ def group_into_phrases(
     return phrases
 
 
+# load one transcript json and return its name duration and phrase list
 def pack_one_file(json_path: Path, silence_threshold: float) -> tuple[str, float, list[dict]]:
     """Return (header_name, duration, phrases) for one transcript file."""
     data = json.loads(json_path.read_text())
@@ -134,6 +146,7 @@ def pack_one_file(json_path: Path, silence_threshold: float) -> tuple[str, float
     return json_path.stem, duration, phrases
 
 
+# build the markdown document with a header block and one section per transcript
 def render_markdown(entries: list[tuple[str, float, list[dict]]], silence_threshold: float) -> str:
     lines: list[str] = []
     lines.append("# Packed transcripts")
@@ -162,6 +175,7 @@ def render_markdown(entries: list[tuple[str, float, list[dict]]], silence_thresh
     return "\n".join(lines)
 
 
+# cli entry point that finds transcript json files packs them and writes takes_packed md
 def main() -> None:
     ap = argparse.ArgumentParser(description="Pack Scribe transcripts into takes_packed.md")
     ap.add_argument("--edit-dir", type=Path, required=True, help="Edit directory containing transcripts/")

--- a/helpers/pack_transcripts.py
+++ b/helpers/pack_transcripts.py
@@ -1,7 +1,3 @@
-# packs scribe word level transcript json files into one phrase level markdown document
-# words are grouped into phrases split on long silences or speaker changes and each phrase carries a start and end stamp
-# the editor sub agent reads the result to pick cuts so it favors compactness over raw detail
-
 """Pack all Scribe transcripts in <edit>/transcripts/ into one readable markdown.
 
 Groups word-level entries into phrase-level lines, breaking on any silence

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -1,7 +1,3 @@
-# the ffmpeg render pipeline that turns an edl into a finished video file
-# it extracts graded segments and concatenates them and then composites overlays and subtitles and normalizes loudness
-# it also builds the master srt from transcripts and holds the command line entry point
-
 """Render a video from an EDL.
 
 Implements the HEURISTICS render pipeline in the correct order:

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -1,3 +1,7 @@
+# the ffmpeg render pipeline that turns an edl into a finished video file
+# it extracts graded segments and concatenates them and then composites overlays and subtitles and normalizes loudness
+# it also builds the master srt from transcripts and holds the command line entry point
+
 """Render a video from an EDL.
 
 Implements the HEURISTICS render pipeline in the correct order:
@@ -32,9 +36,13 @@ from pathlib import Path
 try:
     from grade import get_preset, auto_grade_for_clip  # same directory
 except Exception:
+    # fallback that only knows the identity grade when the grade helper is unavailable
+    # fallback that only knows the identity grade when the grade helper is unavailable
     def get_preset(name: str) -> str:
         return ""
 
+    # fallback that skips auto grading when the grade helper is unavailable
+    # fallback that skips auto grading when the grade helper is unavailable
     def auto_grade_for_clip(video, start=0.0, duration=None, verbose=False):  # type: ignore
         return "eq=contrast=1.03:saturation=0.98", {}
 
@@ -59,12 +67,14 @@ SUB_FORCE_STYLE = (
 # -------- Helpers ------------------------------------------------------------
 
 
+# run a command with check and print an abbreviated version unless quiet
 def run(cmd: list[str], quiet: bool = False) -> None:
     if not quiet:
         print(f"  $ {' '.join(str(c) for c in cmd[:6])}{' …' if len(cmd) > 6 else ''}")
     subprocess.run(cmd, check=True)
 
 
+# turn the edl grade field into a filter string or the auto sentinel
 def resolve_grade_filter(grade_field: str | None) -> str:
     """The EDL's 'grade' field can be a preset name, a raw ffmpeg filter, or 'auto'.
 
@@ -85,6 +95,7 @@ def resolve_grade_filter(grade_field: str | None) -> str:
     return grade_field
 
 
+# resolve a path relative to base unless it is already absolute
 def resolve_path(maybe_path: str, base: Path) -> Path:
     """Resolve a path that may be absolute or relative to `base`."""
     p = Path(maybe_path)
@@ -118,6 +129,7 @@ TONEMAP_CHAIN = (
 )
 
 
+# detect pq or hlg transfer metadata on the first video stream
 def is_hdr_source(video: Path) -> bool:
     """Return True if the source uses a PQ or HLG transfer function."""
     try:
@@ -132,6 +144,7 @@ def is_hdr_source(video: Path) -> bool:
         return False
 
 
+# report whether the first video stream is taller than it is wide
 def is_portrait_source(video: Path) -> bool:
     """Return True if the displayed video is portrait, including rotation."""
     try:
@@ -172,6 +185,7 @@ def is_portrait_source(video: Path) -> bool:
         return False
 
 
+# validate an fps argument and return it as a reduced rational string
 def parse_fps(value: str) -> str:
     """Validate and canonicalize an ffmpeg frame rate."""
     text = value.strip()
@@ -198,6 +212,7 @@ def parse_fps(value: str) -> str:
     return f"{rate.numerator}/{rate.denominator}"
 
 
+# read the source frame rate from ffprobe preferring the average rate
 def probe_source_fps(video: Path) -> str | None:
     """Return an ffmpeg-ready source rate, preferring the average frame rate.
 
@@ -216,6 +231,7 @@ def probe_source_fps(video: Path) -> str | None:
         streams = json.loads(out.stdout).get("streams") or []
         if not streams:
             return None
+        # take the first usable rate and skip zero or unparsable values
         for field in ("avg_frame_rate", "r_frame_rate"):
             value = streams[0].get(field)
             if value and value != "0/0":
@@ -231,6 +247,7 @@ def probe_source_fps(video: Path) -> str | None:
 # -------- Per-segment extraction (Rule 2 + Rule 3) --------------------------
 
 
+# encode one edl range as its own mp4 with tone mapping scaling grade and audio fades applied
 def extract_segment(
     source: Path,
     seg_start: float,
@@ -253,12 +270,14 @@ def extract_segment(
     """
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
+    # scale by height for portrait sources so orientation is preserved
     portrait = is_portrait_source(source)
     if draft:
         scale = "scale=-2:1280" if portrait else "scale=1280:-2"
     else:
         scale = "scale=-2:1920" if portrait else "scale=1920:-2"
 
+    # tone map hdr first then scale then grade
     vf_parts: list[str] = []
     if is_hdr_source(source):
         vf_parts.append(TONEMAP_CHAIN)
@@ -300,6 +319,7 @@ def extract_segment(
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
 
+# extract every edl range into graded segment files sharing one output frame rate
 def extract_all_segments(
     edl: dict,
     edit_dir: Path,
@@ -368,10 +388,12 @@ def extract_all_segments(
 # -------- Lossless concat ----------------------------------------------------
 
 
+# join segment files losslessly with the concat demuxer
 def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -> None:
     """Lossless concat via the concat demuxer. No re-encode."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
     concat_list = edit_dir / "_concat.txt"
+    # the concat demuxer reads a text file listing each segment path
     concat_list.write_text("".join(f"file '{p.resolve()}'\n" for p in segment_paths))
 
     cmd = [
@@ -393,6 +415,7 @@ def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -
 PUNCT_BREAK = set(".,!?;:")
 
 
+# format seconds as an srt timestamp with millisecond precision
 def _srt_timestamp(seconds: float) -> str:
     total_ms = int(round(seconds * 1000))
     h, rem = divmod(total_ms, 3600_000)
@@ -401,6 +424,7 @@ def _srt_timestamp(seconds: float) -> str:
     return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
 
 
+# return transcript words that overlap the given source time range
 def _words_in_range(transcript: dict, t_start: float, t_end: float) -> list[dict]:
     out: list[dict] = []
     for w in transcript.get("words", []):
@@ -410,12 +434,14 @@ def _words_in_range(transcript: dict, t_start: float, t_end: float) -> list[dict
         we = w.get("end")
         if ws is None or we is None:
             continue
+        # keep only words that overlap the range
         if we <= t_start or ws >= t_end:
             continue
         out.append(w)
     return out
 
 
+# build an output timeline srt from per source transcripts using two word uppercase chunks
 def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
     """Build an output-timeline SRT from per-source transcripts.
 
@@ -461,6 +487,7 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
             chunks.append(current)
 
         for chunk in chunks:
+            # clamp chunk times to the segment then shift them onto the output timeline
             local_start = max(seg_start, chunk[0].get("start", seg_start))
             local_end = min(seg_end, chunk[-1].get("end", seg_end))
             out_start = max(0.0, local_start - seg_start) + seg_offset
@@ -498,6 +525,7 @@ LOUDNORM_TP = -1.0
 LOUDNORM_LRA = 11.0
 
 
+# run the loudnorm first pass and parse its json measurement from stderr
 def measure_loudness(video_path: Path) -> dict[str, str] | None:
     """Run ffmpeg loudnorm first pass and parse the JSON measurement.
 
@@ -532,6 +560,7 @@ def measure_loudness(video_path: Path) -> dict[str, str] | None:
     return data
 
 
+# normalize audio with two pass loudnorm or a one pass approximation in preview mode
 def apply_loudnorm_two_pass(
     input_path: Path,
     output_path: Path,
@@ -597,6 +626,7 @@ def apply_loudnorm_two_pass(
 # -------- Final compositing (Rule 1 + Rule 4) -------------------------------
 
 
+# composite overlays onto the base and burn subtitles last in one ffmpeg filter graph
 def build_final_composite(
     base_path: Path,
     overlays: list[dict],
@@ -676,6 +706,7 @@ def build_final_composite(
 # -------- Main ---------------------------------------------------------------
 
 
+# command line entry point that validates the edl and runs the full pipeline
 def main() -> None:
     ap = argparse.ArgumentParser(description="Render a video from an EDL")
     ap.add_argument("edl", type=Path, help="Path to edl.json")

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -1,7 +1,3 @@
-# renders a filmstrip and waveform composite png for a time range of a video
-# frames come from ffmpeg the audio envelope is a windowed rms over a temp wav and transcript words and silences are drawn over the ribbon
-# meant as an on demand drill down at cut decisions rather than a bulk index
-
 """Filmstrip + waveform composite PNG for a time range of a video.
 
 The only visual drill-down tool. Given a video and a [start, end] range,

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -54,7 +54,7 @@ def extract_frames(video: Path, start: float, end: float, n: int, dest_dir: Path
             "-i", str(video),
             "-frames:v", "1",
             "-q:v", "4",
-            "-vf", "scale=320:-2",
+            "-vf", "scale=320:-2,format=yuvj420p",
             str(out),
         ]
         subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/helpers/timeline_view.py
+++ b/helpers/timeline_view.py
@@ -1,3 +1,7 @@
+# renders a filmstrip and waveform composite png for a time range of a video
+# frames come from ffmpeg the audio envelope is a windowed rms over a temp wav and transcript words and silences are drawn over the ribbon
+# meant as an on demand drill down at cut decisions rather than a bulk index
+
 """Filmstrip + waveform composite PNG for a time range of a video.
 
 The only visual drill-down tool. Given a video and a [start, end] range,
@@ -34,11 +38,13 @@ from PIL import Image, ImageDraw, ImageFont
 # -------- Frame extraction ---------------------------------------------------
 
 
+# grab n evenly spaced jpeg frames from the range with ffmpeg and return their paths in order
 def extract_frames(video: Path, start: float, end: float, n: int, dest_dir: Path) -> list[Path]:
     """Extract N frames evenly spaced across [start, end]. Returns paths in order."""
     dest_dir.mkdir(parents=True, exist_ok=True)
     if n < 1:
         n = 1
+    # a single frame sits at the midpoint otherwise spread frames so the first and last land on the range edges
     if n == 1:
         times = [(start + end) / 2.0]
     else:
@@ -65,6 +71,7 @@ def extract_frames(video: Path, start: float, end: float, n: int, dest_dir: Path
 # -------- Audio envelope (librosa if available, ffmpeg fallback) ------------
 
 
+# dump the audio range to a mono wav and turn it into a normalized rms envelope of fixed length
 def compute_envelope(video: Path, start: float, end: float, samples: int = 2000) -> np.ndarray:
     """Extract the audio segment and return an RMS envelope of length `samples`.
 
@@ -100,6 +107,7 @@ def compute_envelope(video: Path, start: float, end: float, samples: int = 2000)
         usable = (n // window) * window
         reshaped = pcm[:usable].reshape(-1, window)
         env = np.sqrt(np.mean(reshaped ** 2, axis=1))
+        # pad or trim so the envelope always has exactly samples entries
         if env.size < samples:
             env = np.pad(env, (0, samples - env.size))
         elif env.size > samples:
@@ -115,6 +123,7 @@ def compute_envelope(video: Path, start: float, end: float, samples: int = 2000)
 # -------- Transcript word overlays ------------------------------------------
 
 
+# return transcript word entries that overlap the requested range
 def words_in_range(transcript_path: Path, start: float, end: float) -> list[dict]:
     if not transcript_path.exists():
         return []
@@ -126,12 +135,14 @@ def words_in_range(transcript_path: Path, start: float, end: float) -> list[dict
         we = w.get("end")
         if ws is None or we is None:
             continue
+        # skip tokens that end before the range or begin after it
         if we <= start or ws >= end:
             continue
         out.append(w)
     return out
 
 
+# scan kept tokens for gaps of at least threshold seconds and return them as time pairs
 def find_silences(words: list[dict], start: float, end: float, threshold: float = 0.4) -> list[tuple[float, float]]:
     """Find gaps >= threshold seconds inside [start, end] between kept tokens."""
     gaps: list[tuple[float, float]] = []
@@ -143,6 +154,7 @@ def find_silences(words: list[dict], start: float, end: float, threshold: float 
         if ws - prev_end >= threshold:
             gaps.append((prev_end, ws))
         prev_end = max(prev_end, w.get("end", ws))
+    # also report a trailing gap between the last token and the range end
     if end - prev_end >= threshold:
         gaps.append((prev_end, end))
     return gaps
@@ -160,6 +172,7 @@ FONT_CANDIDATES = [
 ]
 
 
+# try the known monospace and system font paths and fall back to the pillow default
 def load_font(size: int) -> ImageFont.ImageFont:
     for fp in FONT_CANDIDATES:
         if Path(fp).exists():
@@ -181,6 +194,7 @@ SILENCE = (50, 80, 120, 120)  # muted blue, semi-transparent
 WAVE = (140, 180, 255)
 
 
+# draw the full composite of header filmstrip silence bands waveform word labels and time ruler then save it
 def render_timeline(
     video: Path,
     start: float,
@@ -235,6 +249,7 @@ def render_timeline(
         # Filmstrip
         x = 50
         strip_width = canvas_width - 100
+        # paste frames at full size when they fit otherwise scale the whole strip down to the canvas width
         if total_frame_w <= strip_width:
             cursor = 50
             for img in imgs:
@@ -256,6 +271,7 @@ def render_timeline(
         strip_x1 = 50 + draw_width
         strip_span = strip_x1 - strip_x0
 
+        # map a timestamp inside the range onto a pixel column of the strip
         def time_to_x(t: float) -> int:
             frac = (t - start) / max(1e-6, (end - start))
             return int(strip_x0 + frac * strip_span)
@@ -277,6 +293,7 @@ def render_timeline(
         max_amp = wave_h // 2 - 8
         points_top: list[tuple[int, int]] = []
         points_bot: list[tuple[int, int]] = []
+        # mirror the envelope above and below the midline to draw a symmetric waveform
         for i, v in enumerate(env):
             xi = strip_x0 + int(i * strip_span / max(1, len(env) - 1))
             a = int(v * max_amp)
@@ -299,6 +316,7 @@ def render_timeline(
             text = (w.get("text") or "").strip()
             if not text or ws is None or we is None:
                 continue
+            # skip very short words and labels that would land within 28 px of the previous one
             if (we - ws) < 0.05:
                 continue
             cx = (time_to_x(ws) + time_to_x(we)) // 2
@@ -330,6 +348,7 @@ def render_timeline(
         print(f"saved: {out_path}  ({out_path.stat().st_size // 1024} KB)")
 
 
+# cli entry point that validates the range resolves the transcript and output paths and renders the png
 def main() -> None:
     ap = argparse.ArgumentParser(description="Filmstrip + waveform composite for a video range")
     ap.add_argument("video", type=Path, nargs="?", help="Source video")
@@ -372,6 +391,7 @@ def main() -> None:
         if auto.exists():
             transcript = auto
 
+    # default the output into the verify folder under the edit directory with the range in the file name
     out_path = args.output
     if out_path is None:
         out_dir = video.parent / "edit" / "verify"

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -1,3 +1,7 @@
+# transcribes a single video with elevenlabs scribe and caches the response as json
+# audio is extracted to a mono 16khz wav with ffmpeg then uploaded with diarization audio events and word timestamps
+# transcribe_batch imports load_api_key and transcribe_one to fan the same work out across files
+
 """Transcribe a video with ElevenLabs Scribe.
 
 Extracts mono 16kHz audio via ffmpeg, uploads to Scribe with verbatim +
@@ -33,9 +37,12 @@ import requests
 SCRIBE_URL = "https://api.elevenlabs.io/v1/speech-to-text"
 
 
+# read the elevenlabs api key from a dotenv file or the environment and exit if neither has it
 def load_api_key() -> str:
+    # check the repo root dotenv first then the working directory
     for candidate in [Path(__file__).resolve().parent.parent / ".env", Path(".env")]:
         if candidate.exists():
+            # parse key equals value lines and strip surrounding quotes from the value
             for line in candidate.read_text().splitlines():
                 line = line.strip()
                 if not line or line.startswith("#") or "=" not in line:
@@ -49,6 +56,7 @@ def load_api_key() -> str:
     return v
 
 
+# count the audio streams in a container so multi track recordings can be flagged
 def count_audio_tracks(video_path: Path) -> int:
     """How many audio streams the container holds."""
     out = subprocess.run(
@@ -59,6 +67,7 @@ def count_audio_tracks(video_path: Path) -> int:
     return len([ln for ln in out.stdout.splitlines() if ln.strip()])
 
 
+# measure the peak level of a wav in dbfs so a silent track is caught before upload
 def peak_dbfs(wav_path: Path) -> float:
     """Peak level of a 16-bit PCM wav, in dBFS. -inf for digital silence."""
     peak = 0
@@ -71,6 +80,7 @@ def peak_dbfs(wav_path: Path) -> float:
     return 20 * math.log10(peak / 32768) if peak > 0 else float("-inf")
 
 
+# use ffmpeg to write a mono 16khz pcm wav from the video
 def extract_audio(video_path: Path, dest: Path, audio_track: int = 0) -> None:
     cmd = [
         "ffmpeg", "-y", "-i", str(video_path),
@@ -81,6 +91,7 @@ def extract_audio(video_path: Path, dest: Path, audio_track: int = 0) -> None:
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
+# upload the wav to the scribe endpoint with verbatim settings and return the parsed json
 def call_scribe(
     audio_path: Path,
     api_key: str,
@@ -107,12 +118,14 @@ def call_scribe(
             timeout=1800,
         )
 
+    # any non 200 response is treated as a hard failure with a trimmed body for context
     if resp.status_code != 200:
         raise RuntimeError(f"Scribe returned {resp.status_code}: {resp.text[:500]}")
 
     return resp.json()
 
 
+# resolve where a transcript lands with the track number in the name for anything but track zero
 def transcript_path(edit_dir: Path, video: Path, audio_track: int = 0) -> Path:
     """Where a video's transcript lands.
 
@@ -125,6 +138,7 @@ def transcript_path(edit_dir: Path, video: Path, audio_track: int = 0) -> Path:
     return edit_dir / "transcripts" / f"{video.stem}{suffix}.json"
 
 
+# transcribe one video into the transcripts folder and return the json path reusing a cached file if present
 def transcribe_one(
     video: Path,
     edit_dir: Path,
@@ -189,6 +203,7 @@ def transcribe_one(
     return out_path
 
 
+# cli entry point that resolves the video and edit directory then runs a single transcription
 def main() -> None:
     ap = argparse.ArgumentParser(description="Transcribe a video with ElevenLabs Scribe")
     ap.add_argument("video", type=Path, help="Path to video file")

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -1,7 +1,3 @@
-# transcribes a single video with elevenlabs scribe and caches the response as json
-# audio is extracted to a mono 16khz wav with ffmpeg then uploaded with diarization audio events and word timestamps
-# transcribe_batch imports load_api_key and transcribe_one to fan the same work out across files
-
 """Transcribe a video with ElevenLabs Scribe.
 
 Extracts mono 16kHz audio via ffmpeg, uploads to Scribe with verbatim +

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -1,16 +1,25 @@
-"""Transcribe a video with ElevenLabs Scribe.
+"""Transcribe a video with ElevenLabs Scribe or a local Whisper engine.
 
-Extracts mono 16kHz audio via ffmpeg, uploads to Scribe with verbatim +
-diarize + audio events + word-level timestamps, writes the full response
-to <edit_dir>/transcripts/<video_stem>.json.
+Extracts mono 16kHz audio via ffmpeg, then either uploads to Scribe with
+verbatim + diarize + audio events + word-level timestamps, or runs the local
+engine from local_stt.py. Writes the transcript to
+<edit_dir>/transcripts/<video_stem>.json with a top-level "engine" key.
 
-Cached: if the output file already exists, the upload is skipped.
+Engine selection is explicit, never a silent fallback: --engine wins, then
+VIDEO_USE_TRANSCRIBER (elevenlabs or local) from .env or the environment, then
+elevenlabs when ELEVENLABS_API_KEY resolves. Every run prints the engine and
+where the choice came from.
+
+Cached: if the output file already exists it is reused, even when it was made
+by the other engine (a note is printed). --force re-transcribes and replaces
+the old file only after the new run succeeds.
 
 Usage:
     python helpers/transcribe.py <video_path>
     python helpers/transcribe.py <video_path> --edit-dir /custom/edit
     python helpers/transcribe.py <video_path> --language en
     python helpers/transcribe.py <video_path> --num-speakers 2
+    python helpers/transcribe.py <video_path> --engine local
 """
 
 from __future__ import annotations
@@ -31,25 +40,72 @@ import requests
 
 
 SCRIBE_URL = "https://api.elevenlabs.io/v1/speech-to-text"
+ENGINES = ("elevenlabs", "local")
+ENV_NAMES = ("ELEVENLABS_API_KEY", "VIDEO_USE_TRANSCRIBER")
 
 
-# read the elevenlabs api key from a dotenv file or the environment and exit if neither has it
-def load_api_key() -> str:
-    # check the repo root dotenv first then the working directory
-    for candidate in [Path(__file__).resolve().parent.parent / ".env", Path(".env")]:
-        if candidate.exists():
-            # parse key equals value lines and strip surrounding quotes from the value
-            for line in candidate.read_text().splitlines():
-                line = line.strip()
-                if not line or line.startswith("#") or "=" not in line:
-                    continue
-                k, v = line.split("=", 1)
-                if k.strip() == "ELEVENLABS_API_KEY":
-                    return v.strip().strip('"').strip("'")
-    v = os.environ.get("ELEVENLABS_API_KEY", "")
-    if not v:
-        sys.exit("ELEVENLABS_API_KEY not found in .env or environment")
-    return v
+# the dotenv files consulted in order with the repo root first then the working directory
+def dotenv_candidates() -> list[Path]:
+    return [Path(__file__).resolve().parent.parent / ".env", Path(".env")]
+
+
+# read the two settings this tool understands from dotenv files then the environment
+def load_env(candidates: list[Path] | None = None) -> dict[str, tuple[str, str]]:
+    """Map each known name to (value, source). A dotenv value wins over the environment."""
+    found: dict[str, tuple[str, str]] = {}
+    if candidates is None:
+        candidates = dotenv_candidates()
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        # parse key equals value lines and strip surrounding quotes from the value
+        for line in candidate.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            k = k.strip()
+            v = v.split("#", 1)[0].strip().strip('"').strip("'")
+            if k in ENV_NAMES and v and k not in found:
+                found[k] = (v, ".env")
+    for name in ENV_NAMES:
+        v = os.environ.get(name, "")
+        if v and name not in found:
+            found[name] = (v, "environment")
+    return found
+
+
+# decide which engine runs and say where that decision came from
+def resolve_engine(flag: str | None, env: dict[str, tuple[str, str]]) -> tuple[str, str]:
+    if flag:
+        if flag not in ENGINES:
+            raise SystemExit(f"unknown engine {flag!r}; choose from {', '.join(ENGINES)}")
+        return flag, "--engine"
+    setting = env.get("VIDEO_USE_TRANSCRIBER")
+    if setting:
+        value, source = setting
+        value = value.strip().lower()
+        if value not in ENGINES:
+            raise SystemExit(
+                f"VIDEO_USE_TRANSCRIBER={value!r} (from {source}) is not valid; "
+                f"use one of {', '.join(ENGINES)}"
+            )
+        return value, source
+    if "ELEVENLABS_API_KEY" in env:
+        return "elevenlabs", "ELEVENLABS_API_KEY present"
+    raise SystemExit(
+        "no transcription engine configured. Add one line to .env at the video-use repo root:\n"
+        "  ELEVENLABS_API_KEY=<your key>        hosted Scribe transcription\n"
+        "  VIDEO_USE_TRANSCRIBER=local         local Whisper, run helpers/local_stt.py probe first"
+    )
+
+
+# print the engine choice once so a run is never silently routed
+def announce_engine(engine: str, source: str, env: dict[str, tuple[str, str]]) -> None:
+    line = f"engine: {engine} (from {source})"
+    if engine == "local" and "ELEVENLABS_API_KEY" in env:
+        line += "; ELEVENLABS_API_KEY is present but unused"
+    print(line, flush=True)
 
 
 # count the audio streams in a container so multi track recordings can be flagged
@@ -121,6 +177,20 @@ def call_scribe(
     return resp.json()
 
 
+# run the local whisper engine on the extracted wav
+def call_local(audio_path: Path, language: str | None, local_options: dict) -> dict:
+    # imported here so the elevenlabs path never needs the local module or its libraries
+    import local_stt
+
+    return local_stt.transcribe_wav(
+        audio_path,
+        library=local_options.get("library"),
+        language=language,
+        model=local_options.get("model"),
+        verbatim=local_options.get("verbatim", True),
+    )
+
+
 # resolve where a transcript lands with the track number in the name for anything but track zero
 def transcript_path(edit_dir: Path, video: Path, audio_track: int = 0) -> Path:
     """Where a video's transcript lands.
@@ -134,28 +204,53 @@ def transcript_path(edit_dir: Path, video: Path, audio_track: int = 0) -> Path:
     return edit_dir / "transcripts" / f"{video.stem}{suffix}.json"
 
 
+# read which engine made a cached transcript treating files from before the key existed as scribe
+def cached_engine(path: Path) -> str:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return "unknown"
+    if not isinstance(payload, dict):
+        return "unknown"
+    return str(payload.get("engine", "elevenlabs"))
+
+
 # transcribe one video into the transcripts folder and return the json path reusing a cached file if present
 def transcribe_one(
     video: Path,
     edit_dir: Path,
-    api_key: str,
+    engine: str = "elevenlabs",
+    api_key: str | None = None,
     language: str | None = None,
     num_speakers: int | None = None,
     verbose: bool = True,
     audio_track: int = 0,
+    force: bool = False,
+    local_options: dict | None = None,
 ) -> Path:
     """Transcribe a single video. Returns path to transcript JSON.
 
-    Cached: returns existing path immediately if the transcript already exists.
+    Cached: returns the existing path immediately unless force is set. A cached file made by
+    the other engine is still reused; the note tells the agent how to redo it.
     """
+    if engine not in ENGINES:
+        raise ValueError(f"unknown engine {engine!r}")
+    if engine == "elevenlabs" and not api_key:
+        raise ValueError("elevenlabs engine needs an api key")
+
     transcripts_dir = edit_dir / "transcripts"
     transcripts_dir.mkdir(parents=True, exist_ok=True)
     out_path = transcript_path(edit_dir, video, audio_track)
 
     if out_path.exists():
+        previous = cached_engine(out_path)
+        if not force:
+            if verbose:
+                note = "" if previous == engine else f" (made by {previous}; --force to redo with {engine})"
+                print(f"cached: {out_path.name}{note}")
+            return out_path
         if verbose:
-            print(f"cached: {out_path.name}")
-        return out_path
+            print(f"  replacing {out_path.name} (made by {previous}) with a {engine} transcript", flush=True)
 
     if verbose:
         print(f"  extracting audio from {video.name}", flush=True)
@@ -176,18 +271,28 @@ def transcribe_one(
         if peak < -60.0:
             raise RuntimeError(
                 f"track {audio_track + 1} of {video.name} is silent "
-                f"(peak {peak:.1f} dBFS) - not uploading. "
+                f"(peak {peak:.1f} dBFS) - not transcribing. "
                 + (f"The file has {n_tracks} audio tracks; try --audio-track "
                    + " or ".join(str(i) for i in range(n_tracks) if i != audio_track) + "."
                    if n_tracks > 1 else "Check the source audio.")
             )
 
         size_mb = audio.stat().st_size / (1024 * 1024)
-        if verbose:
-            print(f"  uploading {video.stem}.wav ({size_mb:.1f} MB)", flush=True)
-        payload = call_scribe(audio, api_key, language, num_speakers)
+        if engine == "elevenlabs":
+            if verbose:
+                print(f"  uploading {video.stem}.wav ({size_mb:.1f} MB)", flush=True)
+            payload = call_scribe(audio, api_key, language, num_speakers)
+            if isinstance(payload, dict):
+                payload["engine"] = "elevenlabs"
+        else:
+            if verbose:
+                print(f"  transcribing {video.stem}.wav ({size_mb:.1f} MB) locally", flush=True)
+            payload = call_local(audio, language, local_options or {})
 
-    out_path.write_text(json.dumps(payload, indent=2))
+    # write beside the target and swap in so a failed run never destroys the old transcript
+    tmp_path = out_path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2))
+    os.replace(tmp_path, out_path)
     dt = time.time() - t0
 
     if verbose:
@@ -199,9 +304,45 @@ def transcribe_one(
     return out_path
 
 
+# add the engine flags shared by the single and batch entry points
+def add_engine_arguments(ap: argparse.ArgumentParser) -> None:
+    ap.add_argument(
+        "--engine",
+        choices=ENGINES,
+        default=None,
+        help="elevenlabs or local. Default: VIDEO_USE_TRANSCRIBER, else elevenlabs when a key resolves.",
+    )
+    ap.add_argument("--force", action="store_true", help="Re-transcribe even when a transcript is cached.")
+    ap.add_argument(
+        "--library",
+        choices=("mlx-whisper", "faster-whisper"),
+        default=None,
+        help="Local engine only: override the library chosen by the hardware probe.",
+    )
+    ap.add_argument(
+        "--model",
+        default=None,
+        help="Local engine only: Hugging Face repo id or local model directory.",
+    )
+    ap.add_argument(
+        "--no-verbatim-prompt",
+        action="store_true",
+        help="Local engine only: disable the filler-preserving prompt.",
+    )
+
+
+# gather the local engine options from parsed arguments
+def local_options_from(args: argparse.Namespace) -> dict:
+    return {
+        "library": args.library,
+        "model": args.model,
+        "verbatim": not args.no_verbatim_prompt,
+    }
+
+
 # cli entry point that resolves the video and edit directory then runs a single transcription
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Transcribe a video with ElevenLabs Scribe")
+    ap = argparse.ArgumentParser(description="Transcribe a video with ElevenLabs Scribe or a local engine")
     ap.add_argument("video", type=Path, help="Path to video file")
     ap.add_argument(
         "--edit-dir",
@@ -219,7 +360,7 @@ def main() -> None:
         "--num-speakers",
         type=int,
         default=None,
-        help="Optional number of speakers when known. Improves diarization accuracy.",
+        help="Optional number of speakers when known. Improves diarization accuracy (elevenlabs only).",
     )
     ap.add_argument(
         "--audio-track",
@@ -229,6 +370,7 @@ def main() -> None:
              "and the mic on track 1; without this ffmpeg applies its default audio "
              "stream selection, which picks the track with the most channels.",
     )
+    add_engine_arguments(ap)
     args = ap.parse_args()
 
     video = args.video.resolve()
@@ -236,15 +378,23 @@ def main() -> None:
         sys.exit(f"video not found: {video}")
 
     edit_dir = (args.edit_dir or (video.parent / "edit")).resolve()
-    api_key = load_api_key()
+    env = load_env()
+    engine, source = resolve_engine(args.engine, env)
+    announce_engine(engine, source, env)
+    api_key = env["ELEVENLABS_API_KEY"][0] if "ELEVENLABS_API_KEY" in env else None
+    if engine == "elevenlabs" and not api_key:
+        sys.exit("ELEVENLABS_API_KEY not found in .env or environment")
 
     transcribe_one(
         video=video,
         edit_dir=edit_dir,
+        engine=engine,
         api_key=api_key,
         language=args.language,
         num_speakers=args.num_speakers,
         audio_track=args.audio_track,
+        force=args.force,
+        local_options=local_options_from(args),
     )
 
 

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -49,6 +49,15 @@ def dotenv_candidates() -> list[Path]:
     return [Path(__file__).resolve().parent.parent / ".env", Path(".env")]
 
 
+# unwrap a quoted dotenv value keeping any hash inside the quotes or drop a trailing comment from a bare one
+def dotenv_value(raw: str) -> str:
+    raw = raw.strip()
+    quote = raw[:1]
+    if quote in ('"', "'") and raw.find(quote, 1) > 0:
+        return raw[1:raw.index(quote, 1)]
+    return raw.split("#", 1)[0].strip()
+
+
 # read the two settings this tool understands from dotenv files then the environment
 def load_env(candidates: list[Path] | None = None) -> dict[str, tuple[str, str]]:
     """Map each known name to (value, source). A dotenv value wins over the environment."""
@@ -65,7 +74,7 @@ def load_env(candidates: list[Path] | None = None) -> dict[str, tuple[str, str]]
                 continue
             k, v = line.split("=", 1)
             k = k.strip()
-            v = v.split("#", 1)[0].strip().strip('"').strip("'")
+            v = dotenv_value(v)
             if k in ENV_NAMES and v and k not in found:
                 found[k] = (v, ".env")
     for name in ENV_NAMES:
@@ -177,6 +186,13 @@ def call_scribe(
     return resp.json()
 
 
+# make sure the local library is installed before any audio is extracted
+def preflight_local(local_options: dict) -> str:
+    import local_stt
+
+    return local_stt.preflight(local_options.get("library"))
+
+
 # run the local whisper engine on the extracted wav
 def call_local(audio_path: Path, language: str | None, local_options: dict) -> dict:
     # imported here so the elevenlabs path never needs the local module or its libraries
@@ -219,19 +235,22 @@ def cached_engine(path: Path) -> str:
 def transcribe_one(
     video: Path,
     edit_dir: Path,
-    engine: str = "elevenlabs",
     api_key: str | None = None,
     language: str | None = None,
     num_speakers: int | None = None,
     verbose: bool = True,
     audio_track: int = 0,
+    *,
+    engine: str = "elevenlabs",
     force: bool = False,
     local_options: dict | None = None,
 ) -> Path:
     """Transcribe a single video. Returns path to transcript JSON.
 
-    Cached: returns the existing path immediately unless force is set. A cached file made by
-    the other engine is still reused; the note tells the agent how to redo it.
+    The positional parameters keep their historical order so older callers still work; the
+    engine controls are keyword only. Cached: returns the existing path immediately unless
+    force is set. A cached file made by the other engine is still reused; the note tells the
+    agent how to redo it.
     """
     if engine not in ENGINES:
         raise ValueError(f"unknown engine {engine!r}")
@@ -251,6 +270,10 @@ def transcribe_one(
             return out_path
         if verbose:
             print(f"  replacing {out_path.name} (made by {previous}) with a {engine} transcript", flush=True)
+
+    # a missing local library must fail here not after minutes of audio extraction
+    if engine == "local":
+        preflight_local(local_options or {})
 
     if verbose:
         print(f"  extracting audio from {video.name}", flush=True)

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -1,3 +1,7 @@
+# batch transcribes every video in a directory using a thread pool of scribe workers
+# it reuses transcribe_one so per file caching still applies and only pending sources are uploaded
+# failures are collected and reported at the end with a non zero exit
+
 """Batch-transcribe every video in a directory with 4 parallel workers.
 
 Walks <videos_dir> for common video extensions, runs ElevenLabs Scribe on
@@ -26,6 +30,7 @@ from transcribe import load_api_key, transcribe_one, transcript_path
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
 
 
+# list files in the directory whose suffix is a known video extension in sorted order
 def find_videos(videos_dir: Path) -> list[Path]:
     videos = sorted(
         p for p in videos_dir.iterdir()
@@ -34,6 +39,7 @@ def find_videos(videos_dir: Path) -> list[Path]:
     return videos
 
 
+# cli entry point that splits videos into cached and pending sets then transcribes the pending ones in parallel
 def main() -> None:
     ap = argparse.ArgumentParser(description="Parallel batch transcription of a videos directory")
     ap.add_argument("videos_dir", type=Path, help="Directory containing source videos")

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -28,6 +28,7 @@ from transcribe import (
     announce_engine,
     load_env,
     local_options_from,
+    preflight_local,
     resolve_engine,
     transcribe_one,
     transcript_path,
@@ -111,6 +112,11 @@ def main() -> None:
         print("nothing to do")
         return
 
+    # settle the local library once here so a missing install exits with its message instead of failing every worker
+    local_options = local_options_from(args)
+    if engine == "local":
+        preflight_local(local_options)
+
     workers = worker_count(engine, args.workers)
     if workers != args.workers:
         print(f"local engine runs one file at a time (requested {args.workers} workers)")
@@ -131,7 +137,7 @@ def main() -> None:
                 verbose=False,
                 audio_track=args.audio_track,
                 force=args.force,
-                local_options=local_options_from(args),
+                local_options=local_options,
             ): v
             for v in pending
         }

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -1,7 +1,3 @@
-# batch transcribes every video in a directory using a thread pool of scribe workers
-# it reuses transcribe_one so per file caching still applies and only pending sources are uploaded
-# failures are collected and reported at the end with a non zero exit
-
 """Batch-transcribe every video in a directory with 4 parallel workers.
 
 Walks <videos_dir> for common video extensions, runs ElevenLabs Scribe on

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -1,15 +1,18 @@
-"""Batch-transcribe every video in a directory with 4 parallel workers.
+"""Batch-transcribe every video in a directory with parallel workers.
 
-Walks <videos_dir> for common video extensions, runs ElevenLabs Scribe on
-each, writes transcripts to <videos_dir>/edit/transcripts/<name>.json.
+Walks <videos_dir> for common video extensions, runs ElevenLabs Scribe or the
+local engine on each, writes transcripts to <videos_dir>/edit/transcripts/<name>.json.
 
 Cached per-file: any source that already has a transcript is skipped.
+The local engine runs one file at a time because it loads a single model
+into this process; Scribe uploads run four at a time by default.
 
 Usage:
     python helpers/transcribe_batch.py <videos_dir>
     python helpers/transcribe_batch.py <videos_dir> --workers 4
     python helpers/transcribe_batch.py <videos_dir> --num-speakers 2
     python helpers/transcribe_batch.py <videos_dir> --edit-dir /custom/edit
+    python helpers/transcribe_batch.py <videos_dir> --engine local
 """
 
 from __future__ import annotations
@@ -20,7 +23,15 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from transcribe import load_api_key, transcribe_one, transcript_path
+from transcribe import (
+    add_engine_arguments,
+    announce_engine,
+    load_env,
+    local_options_from,
+    resolve_engine,
+    transcribe_one,
+    transcript_path,
+)
 
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
@@ -35,6 +46,11 @@ def find_videos(videos_dir: Path) -> list[Path]:
     return videos
 
 
+# the local engine holds one model per process so more than one worker only contends
+def worker_count(engine: str, requested: int) -> int:
+    return 1 if engine == "local" else requested
+
+
 # cli entry point that splits videos into cached and pending sets then transcribes the pending ones in parallel
 def main() -> None:
     ap = argparse.ArgumentParser(description="Parallel batch transcription of a videos directory")
@@ -45,7 +61,7 @@ def main() -> None:
         default=None,
         help="Edit output directory (default: <videos_dir>/edit)",
     )
-    ap.add_argument("--workers", type=int, default=4, help="Parallel workers (default: 4)")
+    ap.add_argument("--workers", type=int, default=4, help="Parallel workers (default: 4, local engine always 1)")
     ap.add_argument(
         "--language",
         type=str,
@@ -56,7 +72,7 @@ def main() -> None:
         "--num-speakers",
         type=int,
         default=None,
-        help="Optional number of speakers. Improves diarization when known.",
+        help="Optional number of speakers. Improves diarization when known (elevenlabs only).",
     )
     ap.add_argument(
         "--audio-track",
@@ -64,11 +80,20 @@ def main() -> None:
         default=0,
         help="Zero-based audio track to transcribe (OBS: 0 = game, 1 = mic).",
     )
+    add_engine_arguments(ap)
     args = ap.parse_args()
 
     videos_dir = args.videos_dir.resolve()
     if not videos_dir.is_dir():
         sys.exit(f"not a directory: {videos_dir}")
+
+    # the engine is settled before any work so even a fully cached run reports it
+    env = load_env()
+    engine, source = resolve_engine(args.engine, env)
+    announce_engine(engine, source, env)
+    api_key = env["ELEVENLABS_API_KEY"][0] if "ELEVENLABS_API_KEY" in env else None
+    if engine == "elevenlabs" and not api_key:
+        sys.exit("ELEVENLABS_API_KEY not found in .env or environment")
 
     edit_dir = (args.edit_dir or (videos_dir / "edit")).resolve()
     (edit_dir / "transcripts").mkdir(parents=True, exist_ok=True)
@@ -79,30 +104,34 @@ def main() -> None:
 
     already_cached = [v for v in videos
                       if transcript_path(edit_dir, v, args.audio_track).exists()]
-    pending = [v for v in videos if v not in already_cached]
+    pending = videos if args.force else [v for v in videos if v not in already_cached]
 
     print(f"found {len(videos)} videos ({len(already_cached)} cached, {len(pending)} to transcribe)")
     if not pending:
         print("nothing to do")
         return
 
-    api_key = load_api_key()
-
-    print(f"transcribing {len(pending)} files with {args.workers} parallel workers")
+    workers = worker_count(engine, args.workers)
+    if workers != args.workers:
+        print(f"local engine runs one file at a time (requested {args.workers} workers)")
+    print(f"transcribing {len(pending)} files with {workers} parallel workers")
     t0 = time.time()
 
     errors: list[tuple[Path, str]] = []
-    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+    with ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {
             pool.submit(
                 transcribe_one,
                 video=v,
                 edit_dir=edit_dir,
+                engine=engine,
                 api_key=api_key,
                 language=args.language,
                 num_speakers=args.num_speakers,
                 verbose=False,
                 audio_track=args.audio_track,
+                force=args.force,
+                local_options=local_options_from(args),
             ): v
             for v in pending
         }

--- a/install.md
+++ b/install.md
@@ -101,9 +101,10 @@ Configuration is one line in `~/Developer/video-use/.env`: either `ELEVENLABS_AP
 1. Check existing state in this order and stop at the first hit:
 
     ```bash
-    # a) local engine already chosen
-    grep -q '^VIDEO_USE_TRANSCRIBER=local' ~/Developer/video-use/.env 2>/dev/null && echo "local"
-    # b) env var already exported
+    # a) local engine already chosen in .env or exported (either one wins over a key at runtime)
+    grep -q '^VIDEO_USE_TRANSCRIBER=local' ~/Developer/video-use/.env 2>/dev/null && echo "local (.env)"
+    [ "$VIDEO_USE_TRANSCRIBER" = "local" ] && echo "local (env)"
+    # b) key already exported
     [ -n "$ELEVENLABS_API_KEY" ] && echo "env"
     # c) .env at repo root already has a key
     grep -q '^ELEVENLABS_API_KEY=..' ~/Developer/video-use/.env 2>/dev/null && echo "dotenv"
@@ -139,9 +140,12 @@ Configuration is one line in `~/Developer/video-use/.env`: either `ELEVENLABS_AP
     The probe prints the library for this machine (`mlx-whisper` on Apple Silicon, `faster-whisper` on CPU-only or NVIDIA), whether it is already installed, free disk, the model size, and the exact install command. Tell the user the download size, then after confirmation run the printed command — one of:
 
     ```bash
-    uv sync --extra stt-mlx        # Apple Silicon        (or: pip install -e '.[stt-mlx]')
-    uv sync --extra stt-cpu        # CPU-only or NVIDIA   (or: pip install -e '.[stt-cpu]')
+    uv sync --extra stt-mlx        # Apple Silicon   (or: pip install -e '.[stt-mlx]')
+    uv sync --extra stt-cpu        # CPU-only        (or: pip install -e '.[stt-cpu]')
+    uv sync --extra stt-cuda       # NVIDIA: adds the CUDA 12 cuBLAS and cuDNN 9 wheels faster-whisper needs on the GPU
     ```
+
+    On an NVIDIA machine without those runtime libraries the engine still works, on the CPU, and prints the `stt-cuda` command.
 
     Then persist the choice:
 
@@ -163,18 +167,19 @@ ffprobe -version | head -1
 
 A Scribe transcription test is optional at install time — it burns credits. Better to wait until the user hands you their first clip.
 
-If the local engine was chosen, prove it once on a synthetic clip instead — no credits involved, and it triggers the one-time model download while the user is still around:
+If the local engine was chosen, prove it once on a synthetic clip instead — no credits involved. This first run downloads the ~1.6 GB model weights, so ask the user to confirm the download before running it (the probe already showed the size and free disk). Use the repo's interpreter: `uv run python` when the deps were installed with `uv sync`, or plain `python` from the environment where `pip install -e` ran.
 
 ```bash
+cd ~/Developer/video-use
 say -o /tmp/vu_check.aiff "local transcription check one two three" \
   && ffmpeg -y -loglevel error -f lavfi -i color=c=black:s=320x240:r=25 -i /tmp/vu_check.aiff \
        -shortest -c:v libx264 -c:a aac /tmp/vu_check.mp4 \
-  && python ~/Developer/video-use/helpers/transcribe.py /tmp/vu_check.mp4 --edit-dir /tmp/vu_check_edit \
-  && python ~/Developer/video-use/helpers/pack_transcripts.py --edit-dir /tmp/vu_check_edit \
+  && uv run python helpers/transcribe.py /tmp/vu_check.mp4 --edit-dir /tmp/vu_check_edit \
+  && uv run python helpers/pack_transcripts.py --edit-dir /tmp/vu_check_edit \
   && cat /tmp/vu_check_edit/takes_packed.md
 ```
 
-`say` is macOS only; on Linux skip the synthetic clip and verify on the user's first real file.
+`say` is macOS only; on Linux skip the synthetic clip and verify on the user's first real file, again after confirming the download.
 
 ### 7. Hand off
 

--- a/install.md
+++ b/install.md
@@ -1,6 +1,6 @@
 ---
 name: video-use-install
-description: Install video-use into the current agent (Claude Code, Codex, Hermes, Openclaw, etc.) and wire up ffmpeg + the ElevenLabs API key so the user can start editing immediately.
+description: Install video-use into the current agent (Claude Code, Codex, Hermes, Openclaw, etc.) and wire up ffmpeg plus transcription (an ElevenLabs API key or the local Whisper engine) so the user can start editing immediately.
 ---
 
 # video-use install
@@ -15,7 +15,7 @@ Three things must exist on this machine:
 
 1. The `video-use` repo cloned somewhere stable.
 2. `ffmpeg` on `$PATH` (plus optional `yt-dlp` for online sources).
-3. An ElevenLabs API key in `.env` at the repo root (for Scribe transcription).
+3. Transcription configured in `.env` at the repo root: an ElevenLabs API key for Scribe, or `VIDEO_USE_TRANSCRIBER=local` with one Whisper library installed.
 
 And one thing must be true about the current agent:
 
@@ -23,7 +23,7 @@ And one thing must be true about the current agent:
 
 ## Install prompt contract
 
-- Do everything yourself. Only ask the user for things you cannot generate — the ElevenLabs API key, and confirmation before `brew install`.
+- Do everything yourself. Only ask the user for things you cannot generate — the choice between an ElevenLabs key and local transcription, the key itself, and confirmation before `brew install` or a model download.
 - Prefer a stable clone path like `~/Developer/video-use` (not `/tmp`, not `~/Downloads`).
 - The skill references helpers by bare name (`transcribe.py`, `render.py`). That works because SKILL.md and `helpers/` ship together — keep them as siblings when you register the skill.
 - After install, verify by running one real command against one real file. Don't declare success on file-existence checks alone.
@@ -89,33 +89,38 @@ Figure out which agent you are running under, and register once. A symlink of th
 
 If you can't tell which agent you're in, ask the user once: "which agent am I running under — Claude Code, Codex, or something else?" Then pick the right target.
 
-### 5. ElevenLabs API key
+### 5. Transcription: ElevenLabs key or local engine
 
-Scribe (ElevenLabs) does all transcription. Without a key, nothing transcribes.
+Every edit starts from a word-level transcript. Two engines can produce it:
+
+- **ElevenLabs Scribe** (hosted, needs an API key): word timestamps, speaker labels, audio events such as `(laughter)`, verbatim fillers. Best quality; costs credits.
+- **Local Whisper** (`helpers/local_stt.py`, no key): word timestamps only, runs on the user's machine after a one-time ~1.6 GB model download. No speaker labels or audio events; fillers are best effort.
+
+Configuration is one line in `~/Developer/video-use/.env`: either `ELEVENLABS_API_KEY=...` or `VIDEO_USE_TRANSCRIBER=local`. Values in `.env` win over exported environment variables, and every transcription run prints which engine it used and why, so the choice is never silent.
 
 1. Check existing state in this order and stop at the first hit:
 
     ```bash
-    # a) env var already exported
+    # a) local engine already chosen
+    grep -q '^VIDEO_USE_TRANSCRIBER=local' ~/Developer/video-use/.env 2>/dev/null && echo "local"
+    # b) env var already exported
     [ -n "$ELEVENLABS_API_KEY" ] && echo "env"
-    # b) .env at repo root already has it
+    # c) .env at repo root already has a key
     grep -q '^ELEVENLABS_API_KEY=..' ~/Developer/video-use/.env 2>/dev/null && echo "dotenv"
     ```
 
-2. If neither is set, ask the user exactly once:
+2. If nothing is set, ask the user exactly once:
 
-    > I need an ElevenLabs API key for transcription (word-level timestamps, speaker diarization, filler tagging). Grab one at https://elevenlabs.io/app/settings/api-keys and paste it here — I'll write it to `~/Developer/video-use/.env`. Or if you already have it exported as `ELEVENLABS_API_KEY`, say "use env" and I'll skip.
+    > Transcription needs either an ElevenLabs API key (best quality: word timestamps, speaker labels, laughter/applause tags — grab one at https://elevenlabs.io/app/settings/api-keys and paste it here) or a local Whisper model (free, runs on this machine, word timestamps only, one-time ~1.6 GB download). Which do you want? If you already have the key exported as `ELEVENLABS_API_KEY`, say "use env".
 
-    When the user pastes a key, write it to `~/Developer/video-use/.env`:
+3. **If the user pastes a key**, write it to `~/Developer/video-use/.env`:
 
     ```bash
     printf 'ELEVENLABS_API_KEY=%s\n' "$KEY" > ~/Developer/video-use/.env
     chmod 600 ~/Developer/video-use/.env
     ```
 
-    Never echo the key back in tool output. Never commit `.env`.
-
-3. Sanity check with a cheap, quota-free call:
+    Never echo the key back in tool output. Never commit `.env`. Then sanity check with a cheap, quota-free call:
 
     ```bash
     curl -s -o /dev/null -w '%{http_code}\n' \
@@ -124,6 +129,28 @@ Scribe (ElevenLabs) does all transcription. Without a key, nothing transcribes.
     ```
 
     `200` means the key works. `401` means the user pasted a wrong/expired key — ask once more and stop. Anything else (network, 5xx), move on and verify during first real transcription.
+
+4. **If the user chooses local**, probe the machine first so only the right library gets installed:
+
+    ```bash
+    cd ~/Developer/video-use && python helpers/local_stt.py probe
+    ```
+
+    The probe prints the library for this machine (`mlx-whisper` on Apple Silicon, `faster-whisper` on CPU-only or NVIDIA), whether it is already installed, free disk, the model size, and the exact install command. Tell the user the download size, then after confirmation run the printed command — one of:
+
+    ```bash
+    uv sync --extra stt-mlx        # Apple Silicon        (or: pip install -e '.[stt-mlx]')
+    uv sync --extra stt-cpu        # CPU-only or NVIDIA   (or: pip install -e '.[stt-cpu]')
+    ```
+
+    Then persist the choice:
+
+    ```bash
+    printf 'VIDEO_USE_TRANSCRIBER=local\n' >> ~/Developer/video-use/.env
+    chmod 600 ~/Developer/video-use/.env
+    ```
+
+    The model weights download on the first transcription into the standard Hugging Face cache (`~/.cache/huggingface`, or `HF_HOME`), pinned to a fixed revision. Warn the user that the first clip takes a few extra minutes.
 
 ### 6. Verify end-to-end
 
@@ -134,7 +161,20 @@ python ~/Developer/video-use/helpers/timeline_view.py --help >/dev/null && echo 
 ffprobe -version | head -1
 ```
 
-Full transcription test is optional at install time — it burns Scribe credits. Better to wait until the user hands you their first clip.
+A Scribe transcription test is optional at install time — it burns credits. Better to wait until the user hands you their first clip.
+
+If the local engine was chosen, prove it once on a synthetic clip instead — no credits involved, and it triggers the one-time model download while the user is still around:
+
+```bash
+say -o /tmp/vu_check.aiff "local transcription check one two three" \
+  && ffmpeg -y -loglevel error -f lavfi -i color=c=black:s=320x240:r=25 -i /tmp/vu_check.aiff \
+       -shortest -c:v libx264 -c:a aac /tmp/vu_check.mp4 \
+  && python ~/Developer/video-use/helpers/transcribe.py /tmp/vu_check.mp4 --edit-dir /tmp/vu_check_edit \
+  && python ~/Developer/video-use/helpers/pack_transcripts.py --edit-dir /tmp/vu_check_edit \
+  && cat /tmp/vu_check_edit/takes_packed.md
+```
+
+`say` is macOS only; on Linux skip the synthetic clip and verify on the user's first real file.
 
 ### 7. Hand off
 
@@ -158,5 +198,6 @@ Tell the user, in one short message:
 - `yt-dlp` is optional. Don't block install on it; install lazily the first time a user asks to pull from a URL.
 - Node.js/npm are only needed for HyperFrames or Remotion slots. HyperFrames currently requires Node.js 22+.
 - HyperFrames, Remotion, and Manim are optional animation engines. Don't install or prefer one globally during setup; pick the engine per animation slot in `SKILL.md`. HyperFrames can run through `npx --yes hyperframes ...` in the slot directory. Remotion can be scaffolded with `npx create-video@latest` or installed inside the slot before rendering.
-- Never run transcription as part of install verification unless the user explicitly asks — Scribe costs real money.
+- Never run a Scribe transcription as part of install verification unless the user explicitly asks — it costs real money. The local engine is free to verify; the synthetic clip in step 6 is the right check.
+- `VIDEO_USE_TRANSCRIBER` is the only transcription setting. Which Whisper library runs is decided by `helpers/local_stt.py probe`, not by the user, and never belongs in `.env`.
 - If the user is on Linux without a package manager Claude recognizes, print the manual `ffmpeg` install URL and wait rather than guessing.

--- a/install.md
+++ b/install.md
@@ -167,15 +167,16 @@ ffprobe -version | head -1
 
 A Scribe transcription test is optional at install time — it burns credits. Better to wait until the user hands you their first clip.
 
-If the local engine was chosen, prove it once on a synthetic clip instead — no credits involved. This first run downloads the ~1.6 GB model weights, so ask the user to confirm the download before running it (the probe already showed the size and free disk). Use the repo's interpreter: `uv run python` when the deps were installed with `uv sync`, or plain `python` from the environment where `pip install -e` ran.
+If the local engine was chosen, prove it once on a synthetic clip instead — no credits involved. This first run downloads the ~1.6 GB model weights, so ask the user to confirm the download before running it (the probe already showed the size and free disk). Pick the interpreter that matches step 2: `uv run --no-sync python` when the deps came from `uv sync` (`--no-sync` keeps the extra you just installed), or plain `python` from the environment where `pip install -e` ran.
 
 ```bash
 cd ~/Developer/video-use
+PY="uv run --no-sync python"        # pip path: PY=python
 say -o /tmp/vu_check.aiff "local transcription check one two three" \
   && ffmpeg -y -loglevel error -f lavfi -i color=c=black:s=320x240:r=25 -i /tmp/vu_check.aiff \
        -shortest -c:v libx264 -c:a aac /tmp/vu_check.mp4 \
-  && uv run python helpers/transcribe.py /tmp/vu_check.mp4 --edit-dir /tmp/vu_check_edit \
-  && uv run python helpers/pack_transcripts.py --edit-dir /tmp/vu_check_edit \
+  && $PY helpers/transcribe.py /tmp/vu_check.mp4 --edit-dir /tmp/vu_check_edit \
+  && $PY helpers/pack_transcripts.py --edit-dir /tmp/vu_check_edit \
   && cat /tmp/vu_check_edit/takes_packed.md
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ animations = ["manim"]
 # local transcription: one of these per machine, chosen by helpers/local_stt.py probe
 stt-mlx = ["mlx-whisper>=0.4.3"]
 stt-cpu = ["faster-whisper>=1.2.1"]
+stt-cuda = ["faster-whisper>=1.2.1", "nvidia-cublas-cu12", "nvidia-cudnn-cu12>=9"]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
 
 [project.optional-dependencies]
 animations = ["manim"]
+# local transcription: one of these per machine, chosen by helpers/local_stt.py probe
+stt-mlx = ["mlx-whisper>=0.4.3"]
+stt-cpu = ["faster-whisper>=1.2.1"]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "video-use"
 version = "0.1.0"
-description = "Conversation-driven video editor skill for Claude Code"
+description = "Conversation-driven video production framework for coding agents"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
@@ -21,3 +21,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 py-modules = []
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -4,14 +4,16 @@ comments must not carry punctuation so they stay short and readable at a glance
 """
 
 import ast
+import io
 import re
+import tokenize
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKIP_DIRS = {".venv", "venv", "node_modules", "__pycache__", ".git", "media", "edit"}
 PUNCTUATION = re.compile(r"[.,:;()\"'`]")
-DEFINITION = re.compile(r"\s*(async def|def|class) \w")
+DEFINITIONS = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
 
 
 # yield every python file in the repo that is not inside a skipped directory
@@ -30,24 +32,39 @@ def audit(text):
     if first and first[0].startswith("#"):
         problems.append("hash comment header should be a module docstring")
     try:
-        if ast.get_docstring(ast.parse(text)) is None:
-            problems.append("missing module docstring")
+        tree = ast.parse(text)
     except SyntaxError:
         problems.append("file does not parse")
-    for index, line in enumerate(lines):
-        if not DEFINITION.match(line):
+        return problems
+    if ast.get_docstring(tree) is None:
+        problems.append("missing module docstring")
+    comments = real_comments(text)
+    for node in sorted(definitions(tree), key=lambda item: item.lineno):
+        # decorators sit between the comment and the definition so look above the first decorator
+        start = min([node.lineno, *[item.lineno for item in node.decorator_list]])
+        above = start - 1
+        if above not in comments:
+            problems.append(f"line {node.lineno} has no comment above {node.name}")
             continue
-        above = index - 1
-        # decorators sit between the comment and the definition
-        while above >= 0 and lines[above].strip().startswith("@"):
-            above -= 1
-        if above < 0 or not lines[above].strip().startswith("#"):
-            problems.append(f"line {index + 1} has no comment above {line.strip()[:40]}")
-            continue
-        comment = lines[above].strip().lstrip("#").strip()
-        if PUNCTUATION.search(comment):
-            problems.append(f"line {above + 1} comment contains punctuation")
+        if PUNCTUATION.search(comments[above]):
+            problems.append(f"line {above} comment contains punctuation")
     return problems
+
+
+# yield every function and class node in the tree so text inside strings never counts as a definition
+def definitions(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, DEFINITIONS):
+            yield node
+
+
+# map line number to comment text for lines that hold nothing but a real comment token
+def real_comments(text):
+    comments = {}
+    for token in tokenize.generate_tokens(io.StringIO(text).readline):
+        if token.type == tokenize.COMMENT and token.line.strip().startswith("#"):
+            comments[token.start[0]] = token.string.lstrip("#").strip()
+    return comments
 
 
 # one test that scans the whole repo so a single failure lists every offending file

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -43,7 +43,7 @@ def audit(text):
         # decorators sit between the comment and the definition so look above the first decorator
         start = min([node.lineno, *[item.lineno for item in node.decorator_list]])
         above = start - 1
-        if above not in comments:
+        if above not in comments or not comments[above]:
             problems.append(f"line {node.lineno} has no comment above {node.name}")
             continue
         if PUNCTUATION.search(comments[above]):

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -1,0 +1,58 @@
+# guards the comment convention across every python file in the repo
+# each file starts with a plain header block and every def or class has one plain comment line above it
+# comments must not carry punctuation so they stay short and readable at a glance
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {".venv", "venv", "node_modules", "__pycache__", ".git", "media", "edit"}
+PUNCTUATION = re.compile(r"[.,:;()\"'`]")
+DEFINITION = re.compile(r"\s*(async def|def|class) \w")
+
+
+# yield every python file in the repo that is not inside a skipped directory
+def python_files():
+    for path in ROOT.rglob("*.py"):
+        if not any(part in SKIP_DIRS for part in path.relative_to(ROOT).parts):
+            yield path
+
+
+# return the problems found in one file as short strings
+def audit(text):
+    lines = text.splitlines()
+    problems = []
+    first = [line for line in lines[:6] if line.strip() and not line.startswith("#!")]
+    if not first or not first[0].startswith("#"):
+        problems.append("missing header comment block")
+    for index, line in enumerate(lines):
+        if not DEFINITION.match(line):
+            continue
+        above = index - 1
+        # decorators sit between the comment and the definition
+        while above >= 0 and lines[above].strip().startswith("@"):
+            above -= 1
+        if above < 0 or not lines[above].strip().startswith("#"):
+            problems.append(f"line {index + 1} has no comment above {line.strip()[:40]}")
+            continue
+        comment = lines[above].strip().lstrip("#").strip()
+        if PUNCTUATION.search(comment):
+            problems.append(f"line {above + 1} comment contains punctuation")
+    return problems
+
+
+# one test that scans the whole repo so a single failure lists every offending file
+class CommentStyleTests(unittest.TestCase):
+    # every python file must satisfy the header and per definition comment rules
+    def test_every_python_file_follows_the_convention(self):
+        failures = {}
+        for path in python_files():
+            problems = audit(path.read_text(encoding="utf-8"))
+            if problems:
+                failures[str(path.relative_to(ROOT))] = problems[:5]
+        self.assertEqual(failures, {}, "comment convention violations")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_comment_style.py
+++ b/tests/test_comment_style.py
@@ -1,7 +1,9 @@
-# guards the comment convention across every python file in the repo
-# each file starts with a plain header block and every def or class has one plain comment line above it
-# comments must not carry punctuation so they stay short and readable at a glance
+"""guards the comment convention across every python file in the repo
+each file opens with a module docstring and every def or class has one plain comment line above it
+comments must not carry punctuation so they stay short and readable at a glance
+"""
 
+import ast
 import re
 import unittest
 from pathlib import Path
@@ -23,9 +25,15 @@ def python_files():
 def audit(text):
     lines = text.splitlines()
     problems = []
+    # the file opens with a docstring and not with a block of hash comments
     first = [line for line in lines[:6] if line.strip() and not line.startswith("#!")]
-    if not first or not first[0].startswith("#"):
-        problems.append("missing header comment block")
+    if first and first[0].startswith("#"):
+        problems.append("hash comment header should be a module docstring")
+    try:
+        if ast.get_docstring(ast.parse(text)) is None:
+            problems.append("missing module docstring")
+    except SyntaxError:
+        problems.append("file does not parse")
     for index, line in enumerate(lines):
         if not DEFINITION.match(line):
             continue

--- a/tests/test_local_stt.py
+++ b/tests/test_local_stt.py
@@ -60,10 +60,23 @@ class ChooseLibraryTests(unittest.TestCase):
 
 # missing libraries and pinned downloads
 class InstallAndModelTests(unittest.TestCase):
-    # the install command names the extra for the library
+    # the install command names the extra for the library and the cuda extra when a gpu is present
     def test_install_command_names_extra(self):
         self.assertIn("stt-mlx", local_stt.install_command("mlx-whisper"))
         self.assertIn("stt-cpu", local_stt.install_command("faster-whisper"))
+        self.assertIn("stt-cuda", local_stt.install_command("faster-whisper", cuda=True))
+        self.assertIn("stt-mlx", local_stt.install_command("mlx-whisper", cuda=True))
+
+    # without ctranslate2 or a visible device the cuda check is false instead of raising
+    def test_cuda_available_is_false_without_runtime(self):
+        with patch.dict(sys.modules, {"ctranslate2": None}):
+            self.assertFalse(local_stt.cuda_available())
+        fake = types.SimpleNamespace(get_cuda_device_count=lambda: 0)
+        with patch.dict(sys.modules, {"ctranslate2": fake}):
+            self.assertFalse(local_stt.cuda_available())
+        fake = types.SimpleNamespace(get_cuda_device_count=lambda: 1)
+        with patch.dict(sys.modules, {"ctranslate2": fake}):
+            self.assertTrue(local_stt.cuda_available())
 
     # a missing library exits with the install command instead of a traceback
     def test_require_library_exits_with_install_command(self):
@@ -164,6 +177,20 @@ class CleanWordsTests(unittest.TestCase):
         kept = local_stt.clean_words(words)
         self.assertEqual(len(kept), local_stt.MAX_REPEATS)
 
+    # distinct words in a non latin script are never mistaken for a repetition loop
+    def test_non_latin_words_are_kept(self):
+        texts = ["これ", "は", "テスト", "です", "ね", "Привет", "мир"]
+        words = [
+            {"type": "word", "text": t, "start": i * 0.3, "end": i * 0.3 + 0.2, "speaker_id": None}
+            for i, t in enumerate(texts)
+        ]
+        self.assertEqual([w["text"] for w in local_stt.clean_words(words)], texts)
+        repeated = [
+            {"type": "word", "text": "はい", "start": i * 0.3, "end": i * 0.3 + 0.2, "speaker_id": None}
+            for i in range(10)
+        ]
+        self.assertEqual(len(local_stt.clean_words(repeated)), local_stt.MAX_REPEATS)
+
     # a run of words that repeats the prompt is removed and everything else stays
     def test_removes_prompt_echo(self):
         prompt = "Umm, let me think"
@@ -218,6 +245,41 @@ class TrimOnsetsTests(unittest.TestCase):
         self.assertEqual(len(energy), 20)
         self.assertEqual(float(energy[0]), 0.0)
         self.assertGreater(float(energy[-1]), 1000.0)
+
+    # anything but mono sixteen bit pcm is rejected instead of producing wrong energies
+    def test_frame_energy_rejects_other_formats(self):
+        import wave
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "stereo.wav"
+            with wave.open(str(path), "wb") as handle:
+                handle.setnchannels(2)
+                handle.setsampwidth(2)
+                handle.setframerate(16000)
+                handle.writeframes(b"\x00\x00" * 3200)
+            with self.assertRaises(ValueError):
+                local_stt.frame_energy(path)
+
+    # chunked reading gives the same frames as one pass over a file longer than a single read
+    def test_frame_energy_chunks_match(self):
+        import wave
+
+        import numpy as np
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "long.wav"
+            rng = np.random.default_rng(0)
+            samples = (rng.standard_normal(16000 * 3) * 3000).astype(np.int16)
+            with wave.open(str(path), "wb") as handle:
+                handle.setnchannels(1)
+                handle.setsampwidth(2)
+                handle.setframerate(16000)
+                handle.writeframes(samples.tobytes())
+            with patch.object(local_stt, "ENERGY_READ_FRAMES", 7):
+                energy = local_stt.frame_energy(path)
+        expected = np.sqrt(np.mean(samples[: 300 * 160].reshape(300, 160).astype(np.float32) ** 2, axis=1))
+        self.assertEqual(len(energy), 300)
+        self.assertTrue(np.allclose(energy, expected))
 
 
 # when the verbatim prompt applies

--- a/tests/test_local_stt.py
+++ b/tests/test_local_stt.py
@@ -87,7 +87,27 @@ class InstallAndModelTests(unittest.TestCase):
         with patch.object(local_stt.importlib, "import_module", missing):
             with self.assertRaises(SystemExit) as ctx:
                 local_stt.require_library("faster-whisper")
+            with self.assertRaises(SystemExit) as gpu:
+                local_stt.require_library("faster-whisper", cuda=True)
         self.assertIn("uv sync --extra stt-cpu", str(ctx.exception))
+        self.assertIn("uv sync --extra stt-cuda", str(gpu.exception))
+
+    # the preflight probes and imports once per process and hands back the same library afterwards
+    def test_preflight_settles_once(self):
+        calls = []
+
+        # count how often the probe runs
+        def counting_probe():
+            calls.append(1)
+            return fake_probe(False, cuda=True)
+
+        with patch.object(local_stt, "probe", counting_probe), \
+             patch.object(local_stt, "require_library", lambda _lib, _cuda: None), \
+             patch.dict(local_stt._PREFLIGHTED, {}, clear=True):
+            first = local_stt.preflight()
+            second = local_stt.preflight()
+        self.assertEqual((first, second), ("faster-whisper", "faster-whisper"))
+        self.assertEqual(len(calls), 1)
 
     # the default model is downloaded at its pinned revision and the label records it
     def test_ensure_model_pins_revision(self):
@@ -308,9 +328,10 @@ class TranscribeWavTests(unittest.TestCase):
             return segments, "de"
 
         with patch.object(local_stt, "probe", lambda: fake_probe(True)), \
-             patch.object(local_stt, "require_library", lambda _lib: None), \
+             patch.object(local_stt, "require_library", lambda _lib, _cuda: None), \
              patch.object(local_stt, "ensure_model", lambda _lib, _model: (Path("/m"), "repo@abc")), \
              patch.object(local_stt, "frame_energy", lambda _wav: [1.0] * 100), \
+             patch.dict(local_stt._PREFLIGHTED, {}, clear=True), \
              patch.dict(local_stt.RUNNERS, {"mlx-whisper": runner}):
             payload = local_stt.transcribe_wav(Path("clip.wav"))
         self.assertEqual(calls, [(None, local_stt.VERBATIM_PROMPT), ("de", None)])

--- a/tests/test_local_stt.py
+++ b/tests/test_local_stt.py
@@ -1,0 +1,279 @@
+"""unit tests for the local whisper engine in helpers local_stt py
+they cover library choice install messages pinned downloads word normalization the hallucination guards and the payload contract
+no model is loaded and no network call is made
+"""
+
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+# load a helper straight from its file path under a private module name
+def load_helper(name: str, alias: str):
+    path = Path(__file__).parents[1] / "helpers" / name
+    spec = importlib.util.spec_from_file_location(alias, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+local_stt = load_helper("local_stt.py", "video_use_local_stt")
+render = load_helper("render.py", "video_use_render_for_stt")
+pack_transcripts = load_helper("pack_transcripts.py", "video_use_pack_for_stt")
+
+
+# a probe result for a given machine shape
+def fake_probe(apple_silicon: bool, cuda: bool = False) -> dict:
+    return {"apple_silicon": apple_silicon, "cuda": cuda, "installed": {}}
+
+
+# library selection follows the machine and only a cli override changes it
+class ChooseLibraryTests(unittest.TestCase):
+    # apple silicon gets mlx whisper
+    def test_apple_silicon_uses_mlx(self):
+        self.assertEqual(local_stt.choose_library(fake_probe(True)), "mlx-whisper")
+
+    # a cpu only linux box gets faster whisper
+    def test_cpu_uses_faster_whisper(self):
+        self.assertEqual(local_stt.choose_library(fake_probe(False)), "faster-whisper")
+
+    # a cuda box also gets faster whisper which handles the gpu itself
+    def test_cuda_uses_faster_whisper(self):
+        self.assertEqual(local_stt.choose_library(fake_probe(False, cuda=True)), "faster-whisper")
+
+    # the override wins over the probe
+    def test_override_wins(self):
+        self.assertEqual(local_stt.choose_library(fake_probe(True), "faster-whisper"), "faster-whisper")
+
+    # an unknown override exits with the valid names
+    def test_unknown_override_exits(self):
+        with self.assertRaises(SystemExit) as ctx:
+            local_stt.choose_library(fake_probe(True), "whisperx")
+        self.assertIn("mlx-whisper", str(ctx.exception))
+
+
+# missing libraries and pinned downloads
+class InstallAndModelTests(unittest.TestCase):
+    # the install command names the extra for the library
+    def test_install_command_names_extra(self):
+        self.assertIn("stt-mlx", local_stt.install_command("mlx-whisper"))
+        self.assertIn("stt-cpu", local_stt.install_command("faster-whisper"))
+
+    # a missing library exits with the install command instead of a traceback
+    def test_require_library_exits_with_install_command(self):
+        # raise the way a missing package would
+        def missing(_name):
+            raise ImportError("no module")
+
+        with patch.object(local_stt.importlib, "import_module", missing):
+            with self.assertRaises(SystemExit) as ctx:
+                local_stt.require_library("faster-whisper")
+        self.assertIn("uv sync --extra stt-cpu", str(ctx.exception))
+
+    # the default model is downloaded at its pinned revision and the label records it
+    def test_ensure_model_pins_revision(self):
+        calls = []
+
+        # stand in for huggingface_hub snapshot_download
+        def snapshot_download(**kwargs):
+            calls.append(kwargs)
+            return "/tmp/fake-snapshot"
+
+        fake_hub = types.SimpleNamespace(snapshot_download=snapshot_download)
+        with patch.dict(sys.modules, {"huggingface_hub": fake_hub}):
+            path, label = local_stt.ensure_model("mlx-whisper")
+        expected = local_stt.MODELS["mlx-whisper"]
+        self.assertEqual(calls[0]["repo_id"], expected["repo"])
+        self.assertEqual(calls[0]["revision"], expected["revision"])
+        self.assertEqual(path, Path("/tmp/fake-snapshot"))
+        self.assertTrue(label.startswith(expected["repo"] + "@"))
+
+    # a local model directory is used as is without any download
+    def test_ensure_model_accepts_local_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hub = types.SimpleNamespace(snapshot_download=lambda **_: self.fail("downloaded"))
+            with patch.dict(sys.modules, {"huggingface_hub": fake_hub}):
+                path, label = local_stt.ensure_model("faster-whisper", tmp)
+        self.assertEqual(path, Path(tmp).resolve())
+        self.assertEqual(label, str(Path(tmp).resolve()))
+
+
+# normalizing library output into the canonical word list
+class WordsFromSegmentsTests(unittest.TestCase):
+    # words keep their order carry the canonical fields and lose surrounding whitespace
+    def test_canonical_shape(self):
+        segments = [
+            {"no_speech_prob": 0.1, "words": [
+                {"text": " Hello", "start": 0.5, "end": 0.9},
+                {"text": " world.", "start": "1.0", "end": "1.4"},
+            ]},
+        ]
+        words = local_stt.words_from_segments(segments)
+        self.assertEqual([w["text"] for w in words], ["Hello", "world."])
+        for word in words:
+            self.assertEqual(word["type"], "word")
+            self.assertIsInstance(word["start"], float)
+            self.assertIsInstance(word["end"], float)
+            self.assertIsNone(word["speaker_id"])
+
+    # empty text missing times and zero length words are dropped
+    def test_drops_unusable_words(self):
+        segments = [
+            {"no_speech_prob": 0.0, "words": [
+                {"text": "  ", "start": 0.0, "end": 0.2},
+                {"text": "no-start", "start": None, "end": 0.2},
+                {"text": "zero", "start": 1.0, "end": 1.0},
+                {"text": "keep", "start": 2.0, "end": 2.3},
+            ]},
+        ]
+        words = local_stt.words_from_segments(segments)
+        self.assertEqual([w["text"] for w in words], ["keep"])
+
+    # a segment whisper marks as silence contributes nothing
+    def test_drops_silent_segments(self):
+        segments = [
+            {"no_speech_prob": 0.95, "words": [{"text": "Thanks", "start": 0.0, "end": 0.4}]},
+            {"no_speech_prob": 0.2, "words": [{"text": "real", "start": 1.0, "end": 1.3}]},
+        ]
+        words = local_stt.words_from_segments(segments)
+        self.assertEqual([w["text"] for w in words], ["real"])
+
+
+# the guards that remove decoder artifacts
+class CleanWordsTests(unittest.TestCase):
+    # a word longer than any spoken word is an artifact
+    def test_drops_overlong_words(self):
+        words = [
+            {"type": "word", "text": "ok", "start": 0.0, "end": 0.3, "speaker_id": None},
+            {"type": "word", "text": "stuck", "start": 0.3, "end": 9.0, "speaker_id": None},
+        ]
+        self.assertEqual([w["text"] for w in local_stt.clean_words(words)], ["ok"])
+
+    # a repetition loop is capped at the allowed run length
+    def test_collapses_repetition_loops(self):
+        words = [
+            {"type": "word", "text": "the", "start": i * 0.2, "end": i * 0.2 + 0.1, "speaker_id": None}
+            for i in range(10)
+        ]
+        kept = local_stt.clean_words(words)
+        self.assertEqual(len(kept), local_stt.MAX_REPEATS)
+
+    # a run of words that repeats the prompt is removed and everything else stays
+    def test_removes_prompt_echo(self):
+        prompt = "Umm, let me think"
+        texts = ["Hi", "Umm,", "let", "me", "think", "again", "later"]
+        words = [
+            {"type": "word", "text": t, "start": i * 0.3, "end": i * 0.3 + 0.2, "speaker_id": None}
+            for i, t in enumerate(texts)
+        ]
+        kept = local_stt.clean_words(words, prompt)
+        self.assertEqual([w["text"] for w in kept], ["Hi", "again", "later"])
+
+
+# moving word starts to the first audible frame
+class TrimOnsetsTests(unittest.TestCase):
+    # a word that begins with silence starts where the energy rises
+    def test_leading_silence_is_trimmed(self):
+        energy = [0.0] * 50 + [1000.0] * 30
+        words = [{"type": "word", "text": "hi", "start": 0.0, "end": 0.8, "speaker_id": None}]
+        trimmed = local_stt.trim_onsets(words, energy)
+        self.assertAlmostEqual(trimmed[0]["start"], 0.5)
+        self.assertEqual(trimmed[0]["end"], 0.8)
+        self.assertEqual(words[0]["start"], 0.0)
+
+    # a word that is loud from its first frame keeps its start
+    def test_loud_word_is_unchanged(self):
+        energy = [900.0] * 80
+        words = [{"type": "word", "text": "hi", "start": 0.1, "end": 0.6, "speaker_id": None}]
+        self.assertEqual(local_stt.trim_onsets(words, energy)[0]["start"], 0.1)
+
+    # the start never crosses the minimum duration before the end and never moves backward
+    def test_start_is_bounded(self):
+        energy = [0.0] * 79 + [1000.0]
+        words = [{"type": "word", "text": "hi", "start": 0.2, "end": 0.8, "speaker_id": None}]
+        self.assertAlmostEqual(local_stt.trim_onsets(words, energy)[0]["start"], 0.8 - local_stt.ONSET_MIN_KEEP)
+        silent = [0.0] * 80
+        self.assertEqual(local_stt.trim_onsets(words, silent)[0]["start"], 0.2)
+
+    # frame energy of a synthetic wav has one value per ten milliseconds and is zero in silence
+    def test_frame_energy_reads_wav(self):
+        import wave
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tone.wav"
+            with wave.open(str(path), "wb") as handle:
+                handle.setnchannels(1)
+                handle.setsampwidth(2)
+                handle.setframerate(16000)
+                silence = b"\x00\x00" * 1600
+                tone = b"".join((5000 if (i // 8) % 2 == 0 else -5000).to_bytes(2, "little", signed=True) for i in range(1600))
+                handle.writeframes(silence + tone)
+            energy = local_stt.frame_energy(path)
+        self.assertEqual(len(energy), 20)
+        self.assertEqual(float(energy[0]), 0.0)
+        self.assertGreater(float(energy[-1]), 1000.0)
+
+
+# when the verbatim prompt applies
+class VerbatimPromptTests(unittest.TestCase):
+    # english and auto detect both get the prompt
+    def test_english_and_auto_get_prompt(self):
+        self.assertEqual(local_stt.verbatim_prompt_for("en", True), local_stt.VERBATIM_PROMPT)
+        self.assertEqual(local_stt.verbatim_prompt_for(None, True), local_stt.VERBATIM_PROMPT)
+
+    # other languages and the off switch get none
+    def test_other_languages_and_off_get_none(self):
+        self.assertIsNone(local_stt.verbatim_prompt_for("de", True))
+        self.assertIsNone(local_stt.verbatim_prompt_for("en", False))
+
+
+# the full local path with a fake runner
+class TranscribeWavTests(unittest.TestCase):
+    # a non english detection repeats the pass without the english prompt
+    def test_redoes_non_english_without_prompt(self):
+        calls = []
+
+        # fake runner that reports german the first time
+        def runner(wav, model_path, language, prompt):
+            calls.append((language, prompt))
+            segments = [{"no_speech_prob": 0.0, "words": [{"text": "Hallo", "start": 0.0, "end": 0.4}]}]
+            return segments, "de"
+
+        with patch.object(local_stt, "probe", lambda: fake_probe(True)), \
+             patch.object(local_stt, "require_library", lambda _lib: None), \
+             patch.object(local_stt, "ensure_model", lambda _lib, _model: (Path("/m"), "repo@abc")), \
+             patch.object(local_stt, "frame_energy", lambda _wav: [1.0] * 100), \
+             patch.dict(local_stt.RUNNERS, {"mlx-whisper": runner}):
+            payload = local_stt.transcribe_wav(Path("clip.wav"))
+        self.assertEqual(calls, [(None, local_stt.VERBATIM_PROMPT), ("de", None)])
+        self.assertEqual(payload["engine"], "local")
+        self.assertEqual(payload["library"], "mlx-whisper")
+        self.assertEqual(payload["model"], "repo@abc")
+        self.assertEqual(payload["language_code"], "de")
+        self.assertEqual(payload["text"], "Hallo")
+
+    # the payload satisfies the strictest consumers on this branch
+    def test_payload_passes_render_and_packer(self):
+        segments = [{"no_speech_prob": 0.0, "words": [
+            {"text": " Hello", "start": 0.1, "end": 0.5},
+            {"text": " there", "start": 0.6, "end": 0.9},
+            {"text": " friend", "start": 2.0, "end": 2.4},
+        ]}]
+        words = local_stt.clean_words(local_stt.words_from_segments(segments))
+        payload = local_stt.build_payload("faster-whisper", "repo@abc", "en", words)
+        self.assertEqual(len(render._words_in_range(payload, 0.0, 3.0)), 3)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "clip.json"
+            path.write_text(json.dumps(payload))
+            _name, _duration, phrases = pack_transcripts.pack_one_file(path, 0.5)
+        self.assertEqual([p["text"] for p in phrases], ["Hello there", "friend"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_render_fps.py
+++ b/tests/test_render_fps.py
@@ -1,3 +1,7 @@
+# unit tests for the frame rate handling in helpers render py
+# they cover parse_fps canonical forms probe_source_fps ffprobe parsing and the rate resolution in extract_all_segments
+# render py is loaded by file path so the tests do not depend on it being importable as a package
+
 import argparse
 import contextlib
 import importlib.util
@@ -10,6 +14,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 
+# load render py straight from its file path under a private module name
 MODULE_PATH = Path(__file__).parents[1] / "helpers" / "render.py"
 SPEC = importlib.util.spec_from_file_location("video_use_render", MODULE_PATH)
 assert SPEC and SPEC.loader
@@ -17,7 +22,9 @@ render = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(render)
 
 
+# tests for parse_fps which turns user supplied rates into canonical rational strings
 class ParseFpsTests(unittest.TestCase):
+    # integer decimal and rational inputs all canonicalize to the expected fraction
     def test_accepts_integer_decimal_and_rational_rates(self):
         expected = {
             "60": "60/1",
@@ -28,12 +35,14 @@ class ParseFpsTests(unittest.TestCase):
             with self.subTest(value=value):
                 self.assertEqual(render.parse_fps(value), canonical)
 
+    # feeding a canonical rate back through parse_fps returns it unchanged
     def test_canonical_rates_are_idempotent(self):
         for value in ("60", "29.97", "30000/1001"):
             with self.subTest(value=value):
                 canonical = render.parse_fps(value)
                 self.assertEqual(render.parse_fps(canonical), canonical)
 
+    # malformed zero negative or oversized inputs raise an argparse type error
     def test_rejects_invalid_or_non_positive_rates(self):
         for value in (
             "",
@@ -51,7 +60,9 @@ class ParseFpsTests(unittest.TestCase):
                     render.parse_fps(value)
 
 
+# tests for probe_source_fps with ffprobe replaced by canned completed process results
 class ProbeSourceFpsTests(unittest.TestCase):
+    # build a fake ffprobe result whose json carries the given average and nominal rates
     @staticmethod
     def _probe_result(avg: str, nominal: str) -> subprocess.CompletedProcess:
         stdout = json.dumps({
@@ -59,28 +70,34 @@ class ProbeSourceFpsTests(unittest.TestCase):
         })
         return subprocess.CompletedProcess([], 0, stdout=stdout, stderr="")
 
+    # the average frame rate wins when ffprobe reports a usable one
     def test_prefers_average_rate(self):
         result = self._probe_result("30000/1001", "30/1")
         with patch.object(render.subprocess, "run", return_value=result):
             self.assertEqual(render.probe_source_fps(Path("source.mp4")), "30000/1001")
 
+    # a zero average rate falls back to the nominal r_frame_rate
     def test_falls_back_to_nominal_rate(self):
         result = self._probe_result("0/0", "60/1")
         with patch.object(render.subprocess, "run", return_value=result):
             self.assertEqual(render.probe_source_fps(Path("source.mp4")), "60/1")
 
+    # an empty streams list yields none instead of a rate
     def test_returns_none_for_unusable_probe_output(self):
         result = subprocess.CompletedProcess([], 0, stdout='{"streams": []}', stderr="")
         with patch.object(render.subprocess, "run", return_value=result):
             self.assertIsNone(render.probe_source_fps(Path("source.mp4")))
 
+    # an ffprobe process error yields none rather than propagating
     def test_returns_none_when_ffprobe_fails(self):
         error = subprocess.CalledProcessError(1, ["ffprobe"])
         with patch.object(render.subprocess, "run", side_effect=error):
             self.assertIsNone(render.probe_source_fps(Path("source.mp4")))
 
 
+# tests for how extract_all_segments chooses one rate for every segment
 class RenderRateTests(unittest.TestCase):
+    # minimal two source edl with one range per source
     @staticmethod
     def _edl() -> dict:
         return {
@@ -91,6 +108,7 @@ class RenderRateTests(unittest.TestCase):
             ],
         }
 
+    # only the first source is probed and its rate is applied to every segment
     def test_multi_source_render_resolves_one_rate_from_first_source(self):
         edl = self._edl()
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -105,6 +123,7 @@ class RenderRateTests(unittest.TestCase):
         probe.assert_called_once_with((edit_dir / "first.mp4").resolve())
         self.assertEqual([call.kwargs["rate"] for call in extract.call_args_list], ["60/1", "60/1"])
 
+    # an explicit fps argument skips probing and is canonicalized for every segment
     def test_explicit_rate_skips_probe_and_applies_to_every_segment(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             with (
@@ -122,6 +141,7 @@ class RenderRateTests(unittest.TestCase):
             ["30/1", "30/1"],
         )
 
+    # when probing fails every segment falls back to the 24 default
     def test_failed_probe_falls_back_to_24_for_every_segment(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             with (

--- a/tests/test_render_fps.py
+++ b/tests/test_render_fps.py
@@ -1,6 +1,7 @@
-# unit tests for the frame rate handling in helpers render py
-# they cover parse_fps canonical forms probe_source_fps ffprobe parsing and the rate resolution in extract_all_segments
-# render py is loaded by file path so the tests do not depend on it being importable as a package
+"""unit tests for the frame rate handling in helpers render py
+they cover parse_fps canonical forms probe_source_fps ffprobe parsing and the rate resolution in extract_all_segments
+render py is loaded by file path so the tests do not depend on it being importable as a package
+"""
 
 import argparse
 import contextlib

--- a/tests/test_render_orientation.py
+++ b/tests/test_render_orientation.py
@@ -1,3 +1,6 @@
+# tests for portrait detection in the render helper including rotation side data
+# it loads the helper from its file path and patches ffprobe so no real media is needed
+
 import importlib.util
 import json
 import subprocess
@@ -13,7 +16,9 @@ render = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(render)
 
 
+# portrait detection must honor display rotation but ignore plain rotate tags
 class PortraitDetectionTests(unittest.TestCase):
+    # run the detector against a fake ffprobe json stream
     def _is_portrait(self, stream: dict) -> bool:
         result = subprocess.CompletedProcess(
             [], 0, stdout=json.dumps({"streams": [stream]}), stderr=""
@@ -26,12 +31,15 @@ class PortraitDetectionTests(unittest.TestCase):
         self.assertNotIn("stream_tags=rotate", show_entries)
         return portrait
 
+    # taller than wide with no rotation is portrait
     def test_native_portrait_dimensions(self):
         self.assertTrue(self._is_portrait({"width": 1080, "height": 1920}))
 
+    # wider than tall with no rotation is landscape
     def test_native_landscape_dimensions(self):
         self.assertFalse(self._is_portrait({"width": 1920, "height": 1080}))
 
+    # a quarter turn in display side data flips a coded landscape into portrait
     def test_side_data_rotation_turns_coded_landscape_into_portrait(self):
         stream = {
             "width": 1920,
@@ -40,10 +48,12 @@ class PortraitDetectionTests(unittest.TestCase):
         }
         self.assertTrue(self._is_portrait(stream))
 
+    # a rotate tag without side data does not change the answer
     def test_plain_rotation_tag_without_side_data_is_ignored(self):
         stream = {"width": 1920, "height": 1080, "tags": {"rotate": "270"}}
         self.assertFalse(self._is_portrait(stream))
 
+    # a quarter turn can also flip a coded portrait into landscape
     def test_rotation_can_turn_coded_portrait_into_landscape(self):
         stream = {
             "width": 1080,
@@ -52,6 +62,7 @@ class PortraitDetectionTests(unittest.TestCase):
         }
         self.assertFalse(self._is_portrait(stream))
 
+    # unreadable probe output falls back to landscape
     def test_invalid_probe_output_falls_back_to_landscape(self):
         result = subprocess.CompletedProcess([], 0, stdout="not json", stderr="")
         with patch.object(render.subprocess, "run", return_value=result):

--- a/tests/test_render_orientation.py
+++ b/tests/test_render_orientation.py
@@ -1,5 +1,6 @@
-# tests for portrait detection in the render helper including rotation side data
-# it loads the helper from its file path and patches ffprobe so no real media is needed
+"""tests for portrait detection in the render helper including rotation side data
+it loads the helper from its file path and patches ffprobe so no real media is needed
+"""
 
 import importlib.util
 import json

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -1,3 +1,7 @@
+# tests that guard the public editing contract documented in skill md
+# they check that the numbered hard rules stay present and in order and that every referenced helper or reference path exists
+# the hard rules list is append only so new rules go at the end
+
 """Guard the public editing contract in SKILL.md.
 
 Two failure modes this protects against when several agents edit the file:
@@ -28,21 +32,28 @@ HARD_RULES = [
     "All session outputs in `<videos_dir>/edit/`.",
 ]
 
+# matches backticked paths under references helpers or skills
 PATH_PATTERN = re.compile(r"`((?:references|helpers|skills)/[A-Za-z0-9_./-]+)`")
 
 
+# slice out the body of the hard rules section up to the next second level heading
 def hard_rules_section(text: str) -> str:
+    # dotall plus multiline so the lazy group spans lines and the heading anchors match at line starts
     match = re.search(r"^## Hard Rules.*?$(.*?)^## ", text, re.S | re.M)
     assert match, "SKILL.md must contain a '## Hard Rules' section"
     return match.group(1)
 
 
+# test case that reads skill md once per test and checks its contract
 class SkillContractTests(unittest.TestCase):
+    # load the skill md text for each test
     def setUp(self) -> None:
         self.text = SKILL.read_text(encoding="utf-8")
 
+    # numbered bold rule titles must be consecutive and each expected rule must still sit at its index
     def test_hard_rules_are_present_in_order(self):
         section = hard_rules_section(self.text)
+        # capture the number and bold title of each numbered list item
         items = re.findall(r"^(\d+)\. \*\*(.+?)\*\*", section, re.M)
         numbers = [int(number) for number, _ in items]
         self.assertEqual(numbers, list(range(1, len(numbers) + 1)), "rules must be numbered consecutively")
@@ -50,6 +61,7 @@ class SkillContractTests(unittest.TestCase):
         for index, expected in enumerate(HARD_RULES):
             self.assertIn(expected, items[index][1], f"rule {index + 1} changed or moved")
 
+    # every backticked helper or reference path in skill md must exist on disk
     def test_referenced_paths_exist(self):
         missing = sorted(
             path

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -1,7 +1,3 @@
-# tests that guard the public editing contract documented in skill md
-# they check that the numbered hard rules stay present and in order and that every referenced helper or reference path exists
-# the hard rules list is append only so new rules go at the end
-
 """Guard the public editing contract in SKILL.md.
 
 Two failure modes this protects against when several agents edit the file:

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -1,0 +1,63 @@
+"""Guard the public editing contract in SKILL.md.
+
+Two failure modes this protects against when several agents edit the file:
+a hard rule silently disappears or gets renumbered, and a helper or reference
+path is documented but no longer exists in the tree.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "SKILL.md"
+
+# Append-only. Add new rules to the end of this list when SKILL.md gains one.
+HARD_RULES = [
+    "Subtitles are applied LAST in the filter chain",
+    "Per-segment extract",
+    "30ms audio fades at every segment boundary",
+    "Overlays use `setpts=PTS-STARTPTS+T/TB`",
+    "Master SRT uses output-timeline offsets",
+    "Never cut inside a word.",
+    "Pad every cut edge.",
+    "Word-level verbatim ASR only.",
+    "Cache transcripts per source.",
+    "Parallel sub-agents for multiple animations.",
+    "Strategy confirmation before execution.",
+    "All session outputs in `<videos_dir>/edit/`.",
+]
+
+PATH_PATTERN = re.compile(r"`((?:references|helpers|skills)/[A-Za-z0-9_./-]+)`")
+
+
+def hard_rules_section(text: str) -> str:
+    match = re.search(r"^## Hard Rules.*?$(.*?)^## ", text, re.S | re.M)
+    assert match, "SKILL.md must contain a '## Hard Rules' section"
+    return match.group(1)
+
+
+class SkillContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.text = SKILL.read_text(encoding="utf-8")
+
+    def test_hard_rules_are_present_in_order(self):
+        section = hard_rules_section(self.text)
+        items = re.findall(r"^(\d+)\. \*\*(.+?)\*\*", section, re.M)
+        numbers = [int(number) for number, _ in items]
+        self.assertEqual(numbers, list(range(1, len(numbers) + 1)), "rules must be numbered consecutively")
+        self.assertGreaterEqual(len(items), len(HARD_RULES), "a hard rule was removed")
+        for index, expected in enumerate(HARD_RULES):
+            self.assertIn(expected, items[index][1], f"rule {index + 1} changed or moved")
+
+    def test_referenced_paths_exist(self):
+        missing = sorted(
+            path
+            for path in set(PATH_PATTERN.findall(self.text))
+            if not (ROOT / path).exists()
+        )
+        self.assertEqual(missing, [], "SKILL.md names paths that do not exist")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -30,6 +30,8 @@ HARD_RULES = [
 
 # matches backticked paths under references helpers or skills
 PATH_PATTERN = re.compile(r"`((?:references|helpers|skills)/[A-Za-z0-9_./-]+)`")
+# matches a bare helper script name at the start of a backticked command
+HELPER_PATTERN = re.compile(r"`([A-Za-z0-9_]+\.py)\b")
 
 
 # slice out the body of the hard rules section up to the next second level heading
@@ -65,6 +67,15 @@ class SkillContractTests(unittest.TestCase):
             if not (ROOT / path).exists()
         )
         self.assertEqual(missing, [], "SKILL.md names paths that do not exist")
+
+    # every bare helper script named in a backticked command must exist under helpers
+    def test_bare_helper_names_exist(self):
+        missing = sorted(
+            name
+            for name in set(HELPER_PATTERN.findall(self.text))
+            if not (ROOT / "helpers" / name).exists()
+        )
+        self.assertEqual(missing, [], "SKILL.md names helper scripts that do not exist")
 
 
 if __name__ == "__main__":

--- a/tests/test_transcribe_engine.py
+++ b/tests/test_transcribe_engine.py
@@ -1,0 +1,231 @@
+"""unit tests for engine selection and caching in helpers transcribe py
+they cover dotenv precedence the printed engine line invalid values the provider boundary backwards compatibility and force
+no upload runs and no model loads
+"""
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+from unittest.mock import patch
+
+
+HELPERS = Path(__file__).parents[1] / "helpers"
+sys.path.insert(0, str(HELPERS))
+
+
+# load a helper straight from its file path under a private module name
+def load_helper(name: str, alias: str):
+    spec = importlib.util.spec_from_file_location(alias, HELPERS / name)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+transcribe = load_helper("transcribe.py", "video_use_transcribe")
+transcribe_batch = load_helper("transcribe_batch.py", "video_use_transcribe_batch")
+
+
+# an env mapping in the shape load_env returns
+def env_with(**names) -> dict:
+    return {name: (value, "test") for name, value in names.items()}
+
+
+# write a short audible wav so the silent track guard passes
+def write_tone(dest: Path) -> None:
+    with wave.open(str(dest), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(16000)
+        frames = bytearray()
+        for i in range(16000):
+            sample = 8000 if (i // 8) % 2 == 0 else -8000
+            frames += int(sample).to_bytes(2, "little", signed=True)
+        w.writeframes(bytes(frames))
+
+
+# stand in for ffmpeg extraction that writes the tone instead
+def fake_extract(_video, dest, _track=0):
+    write_tone(dest)
+
+
+# reading the two settings from dotenv files and the environment
+class LoadEnvTests(unittest.TestCase):
+    # a dotenv value wins over the environment and records its source
+    def test_dotenv_wins_over_environment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dotenv = Path(tmp) / ".env"
+            dotenv.write_text('VIDEO_USE_TRANSCRIBER="local"  # chosen at install\n')
+            with patch.dict(os.environ, {"VIDEO_USE_TRANSCRIBER": "elevenlabs"}):
+                env = transcribe.load_env([dotenv])
+        self.assertEqual(env["VIDEO_USE_TRANSCRIBER"], ("local", ".env"))
+
+    # the environment fills in anything the dotenv files leave out
+    def test_environment_fills_gaps(self):
+        with patch.dict(os.environ, {"ELEVENLABS_API_KEY": "k"}, clear=False):
+            env = transcribe.load_env([])
+        self.assertEqual(env["ELEVENLABS_API_KEY"], ("k", "environment"))
+
+    # an empty assignment counts as unset
+    def test_empty_value_is_unset(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dotenv = Path(tmp) / ".env"
+            dotenv.write_text("ELEVENLABS_API_KEY=\n")
+            with patch.dict(os.environ, {}, clear=True):
+                env = transcribe.load_env([dotenv])
+        self.assertNotIn("ELEVENLABS_API_KEY", env)
+
+
+# which engine runs and what gets printed about it
+class ResolveEngineTests(unittest.TestCase):
+    # the flag beats every setting
+    def test_flag_wins(self):
+        engine, source = transcribe.resolve_engine("local", env_with(ELEVENLABS_API_KEY="k"))
+        self.assertEqual((engine, source), ("local", "--engine"))
+
+    # the setting beats a present key and the announcement says the key is unused
+    def test_setting_beats_key_and_is_announced(self):
+        env = {"ELEVENLABS_API_KEY": ("k", ".env"), "VIDEO_USE_TRANSCRIBER": ("local", ".env")}
+        engine, source = transcribe.resolve_engine(None, env)
+        self.assertEqual((engine, source), ("local", ".env"))
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            transcribe.announce_engine(engine, source, env)
+        self.assertIn("engine: local (from .env)", out.getvalue())
+        self.assertIn("present but unused", out.getvalue())
+
+    # a key alone selects elevenlabs
+    def test_key_alone_selects_elevenlabs(self):
+        engine, source = transcribe.resolve_engine(None, env_with(ELEVENLABS_API_KEY="k"))
+        self.assertEqual(engine, "elevenlabs")
+        self.assertIn("ELEVENLABS_API_KEY", source)
+
+    # nothing configured exits naming both options
+    def test_nothing_configured_exits_with_both_options(self):
+        with self.assertRaises(SystemExit) as ctx:
+            transcribe.resolve_engine(None, {})
+        message = str(ctx.exception)
+        self.assertIn("ELEVENLABS_API_KEY=", message)
+        self.assertIn("VIDEO_USE_TRANSCRIBER=local", message)
+
+    # a bad setting or flag exits before any subprocess runs
+    def test_invalid_values_exit_before_work(self):
+        with patch.object(transcribe.subprocess, "run", side_effect=AssertionError("ran a subprocess")):
+            with self.assertRaises(SystemExit):
+                transcribe.resolve_engine(None, env_with(VIDEO_USE_TRANSCRIBER="bogus"))
+            with self.assertRaises(SystemExit):
+                transcribe.resolve_engine("whisperx", {})
+            with tempfile.TemporaryDirectory() as tmp:
+                with self.assertRaises(ValueError):
+                    transcribe.transcribe_one(Path("clip.mp4"), Path(tmp), engine="bogus")
+
+
+# a fake http response for the scribe call
+class FakeResponse:
+    status_code = 200
+    text = ""
+
+    # the parsed body scribe would have returned
+    def json(self):
+        return {"words": [{"type": "word", "text": "Hello", "start": 0.1, "end": 0.5}]}
+
+
+# caching provenance and the provider boundary
+class TranscribeOneTests(unittest.TestCase):
+    # patch the media probes so no ffmpeg runs
+    def setUp(self):
+        self.patches = [
+            patch.object(transcribe, "extract_audio", fake_extract),
+            patch.object(transcribe, "count_audio_tracks", lambda _video: 1),
+        ]
+        for item in self.patches:
+            item.start()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.edit_dir = Path(self.tmp.name)
+        self.video = Path("clip.mp4")
+        self.out = transcribe.transcript_path(self.edit_dir, self.video)
+
+    # undo the patches and remove the temp dir
+    def tearDown(self):
+        for item in self.patches:
+            item.stop()
+        self.tmp.cleanup()
+
+    # with a key the scribe endpoint is called once and the file records the engine
+    def test_elevenlabs_path_calls_scribe_once(self):
+        with patch.object(transcribe.requests, "post", return_value=FakeResponse()) as post:
+            with contextlib.redirect_stdout(io.StringIO()):
+                transcribe.transcribe_one(self.video, self.edit_dir, engine="elevenlabs", api_key="k")
+        self.assertEqual(post.call_count, 1)
+        self.assertEqual(post.call_args.kwargs["headers"], {"xi-api-key": "k"})
+        payload = json.loads(self.out.read_text())
+        self.assertEqual(payload["engine"], "elevenlabs")
+        self.assertEqual(payload["words"][0]["text"], "Hello")
+
+    # the local path never touches the network and records the engine
+    def test_local_path_never_posts(self):
+        fake = {"engine": "local", "library": "x", "model": "y", "language_code": "en", "text": "hi", "words": []}
+        with patch.object(transcribe.requests, "post", side_effect=AssertionError("posted")), \
+             patch.object(transcribe, "call_local", lambda *_args: fake):
+            with contextlib.redirect_stdout(io.StringIO()):
+                transcribe.transcribe_one(self.video, self.edit_dir, engine="local")
+        self.assertEqual(json.loads(self.out.read_text())["engine"], "local")
+
+    # a transcript from before the engine key existed is reused without a mismatch note
+    def test_old_transcript_without_engine_is_reused(self):
+        self.out.parent.mkdir(parents=True)
+        original = json.dumps({"words": []})
+        self.out.write_text(original)
+        out = io.StringIO()
+        with patch.object(transcribe, "extract_audio", side_effect=AssertionError("extracted")):
+            with contextlib.redirect_stdout(out):
+                transcribe.transcribe_one(self.video, self.edit_dir, engine="elevenlabs", api_key="k")
+        self.assertEqual(self.out.read_text(), original)
+        self.assertIn("cached:", out.getvalue())
+        self.assertNotIn("made by", out.getvalue())
+
+    # a cached file from the other engine is reused with an advisory note
+    def test_cross_engine_cache_note(self):
+        self.out.parent.mkdir(parents=True)
+        self.out.write_text(json.dumps({"engine": "local", "words": []}))
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            transcribe.transcribe_one(self.video, self.edit_dir, engine="elevenlabs", api_key="k")
+        self.assertIn("made by local", out.getvalue())
+        self.assertIn("--force", out.getvalue())
+
+    # force keeps the old file when the new run fails and replaces it when the run succeeds
+    def test_force_replaces_only_on_success(self):
+        self.out.parent.mkdir(parents=True)
+        original = json.dumps({"engine": "elevenlabs", "words": [{"type": "word", "text": "paid"}]})
+        self.out.write_text(original)
+        with patch.object(transcribe, "call_local", side_effect=RuntimeError("model crashed")):
+            with contextlib.redirect_stdout(io.StringIO()):
+                with self.assertRaises(RuntimeError):
+                    transcribe.transcribe_one(self.video, self.edit_dir, engine="local", force=True)
+        self.assertEqual(self.out.read_text(), original)
+        self.assertEqual(list(self.out.parent.glob("*.tmp")), [])
+        fake = {"engine": "local", "words": []}
+        with patch.object(transcribe, "call_local", lambda *_args: fake):
+            with contextlib.redirect_stdout(io.StringIO()):
+                transcribe.transcribe_one(self.video, self.edit_dir, engine="local", force=True)
+        self.assertEqual(json.loads(self.out.read_text())["engine"], "local")
+
+
+# batch specific behavior
+class BatchTests(unittest.TestCase):
+    # the local engine runs one file at a time whatever was requested
+    def test_local_engine_forces_one_worker(self):
+        self.assertEqual(transcribe_batch.worker_count("local", 4), 1)
+        self.assertEqual(transcribe_batch.worker_count("elevenlabs", 4), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transcribe_engine.py
+++ b/tests/test_transcribe_engine.py
@@ -73,6 +73,13 @@ class LoadEnvTests(unittest.TestCase):
             env = transcribe.load_env([])
         self.assertEqual(env["ELEVENLABS_API_KEY"], ("k", "environment"))
 
+    # a hash inside quotes is part of the value and a bare trailing comment is not
+    def test_quoted_hash_is_kept(self):
+        self.assertEqual(transcribe.dotenv_value('"abc#def"'), "abc#def")
+        self.assertEqual(transcribe.dotenv_value("'abc#def'  # note"), "abc#def")
+        self.assertEqual(transcribe.dotenv_value("abc # note"), "abc")
+        self.assertEqual(transcribe.dotenv_value("  plain  "), "plain")
+
     # an empty assignment counts as unset
     def test_empty_value_is_unset(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -173,10 +180,27 @@ class TranscribeOneTests(unittest.TestCase):
     def test_local_path_never_posts(self):
         fake = {"engine": "local", "library": "x", "model": "y", "language_code": "en", "text": "hi", "words": []}
         with patch.object(transcribe.requests, "post", side_effect=AssertionError("posted")), \
+             patch.object(transcribe, "preflight_local", lambda _options: "mlx-whisper"), \
              patch.object(transcribe, "call_local", lambda *_args: fake):
             with contextlib.redirect_stdout(io.StringIO()):
                 transcribe.transcribe_one(self.video, self.edit_dir, engine="local")
         self.assertEqual(json.loads(self.out.read_text())["engine"], "local")
+
+    # a missing local library stops the run before any audio is extracted
+    def test_missing_library_fails_before_extraction(self):
+        with patch.object(transcribe, "preflight_local", side_effect=SystemExit("install it")), \
+             patch.object(transcribe, "extract_audio", side_effect=AssertionError("extracted")):
+            with self.assertRaises(SystemExit):
+                transcribe.transcribe_one(self.video, self.edit_dir, engine="local")
+        self.assertFalse(self.out.exists())
+
+    # callers from before the engine flag still pass the key as the third positional argument
+    def test_legacy_positional_api_key(self):
+        with patch.object(transcribe.requests, "post", return_value=FakeResponse()) as post:
+            with contextlib.redirect_stdout(io.StringIO()):
+                transcribe.transcribe_one(self.video, self.edit_dir, "k", None, None, False, 0)
+        self.assertEqual(post.call_args.kwargs["headers"], {"xi-api-key": "k"})
+        self.assertEqual(json.loads(self.out.read_text())["engine"], "elevenlabs")
 
     # a transcript from before the engine key existed is reused without a mismatch note
     def test_old_transcript_without_engine_is_reused(self):
@@ -206,14 +230,16 @@ class TranscribeOneTests(unittest.TestCase):
         self.out.parent.mkdir(parents=True)
         original = json.dumps({"engine": "elevenlabs", "words": [{"type": "word", "text": "paid"}]})
         self.out.write_text(original)
-        with patch.object(transcribe, "call_local", side_effect=RuntimeError("model crashed")):
+        with patch.object(transcribe, "preflight_local", lambda _options: "mlx-whisper"), \
+             patch.object(transcribe, "call_local", side_effect=RuntimeError("model crashed")):
             with contextlib.redirect_stdout(io.StringIO()):
                 with self.assertRaises(RuntimeError):
                     transcribe.transcribe_one(self.video, self.edit_dir, engine="local", force=True)
         self.assertEqual(self.out.read_text(), original)
         self.assertEqual(list(self.out.parent.glob("*.tmp")), [])
         fake = {"engine": "local", "words": []}
-        with patch.object(transcribe, "call_local", lambda *_args: fake):
+        with patch.object(transcribe, "preflight_local", lambda _options: "mlx-whisper"), \
+             patch.object(transcribe, "call_local", lambda *_args: fake):
             with contextlib.redirect_stdout(io.StringIO()):
                 transcribe.transcribe_one(self.video, self.edit_dir, engine="local", force=True)
         self.assertEqual(json.loads(self.out.read_text())["engine"], "local")


### PR DESCRIPTION
Lets people edit without an ElevenLabs account. Transcription is the first step of every session and used to hard-exit when `ELEVENLABS_API_KEY` was missing, even though the rest of the pipeline is ffmpeg and PIL.

Builds on the agent guidance PR; its commits show here until that PR merges.

**What changes**

- `helpers/local_stt.py`: local Whisper large-v3-turbo through `mlx-whisper` on Apple Silicon or `faster-whisper` (CTranslate2, int8 on CPU, float16 on CUDA) elsewhere. A hardware probe (`local_stt.py probe`) picks the library, reports install state, free disk, and model size, and prints the one install command, so a machine downloads only the model it will use. Weights come from `huggingface_hub.snapshot_download` pinned to a commit and land in the standard Hugging Face cache. A missing library exits with the exact install command; nothing here runs pip.
- `helpers/transcribe.py` and `transcribe_batch.py`: explicit engine selection, never a silent fallback. `--engine` wins, then `VIDEO_USE_TRANSCRIBER` (`elevenlabs` or `local`) from `.env` or the environment, then ElevenLabs when a key resolves. Every run prints `engine: <name> (from <source>)`, and says when a key is present but unused. Transcripts gain a top-level `engine` key; files from before the key exist are treated as ElevenLabs and reused untouched. `--force` re-transcribes and swaps the file in only after the new run succeeds, so a paid Scribe transcript is never lost to a failed local run. The batch helper runs one worker for the local engine (one model per process).
- The local transcript keeps the shape every consumer reads (`words` with `type`, `text`, `start`, `end`, `speaker_id`), so `pack_transcripts.py`, `render.py`, and the EDL validators work unchanged.
- Decoder artifacts are guarded without a VAD dependency: segments Whisper marks as silent are dropped, words over 3 s are dropped, repetition loops are capped, and any echo of the filler-preserving prompt is removed. Whisper folds each pause into the start of the next word, so word starts are moved forward to the first audible energy frame (10 ms RMS frames, 20 % of the word's peak).
- One user-facing setting, `VIDEO_USE_TRANSCRIBER`. Which library runs is an implementation detail with developer-only `--library` and `--model` overrides. `pyproject.toml` adds two extras, `stt-mlx` and `stt-cpu`; core dependencies are unchanged.
- `install.md` step 5 asks once for a key or the local engine and persists the choice; `SKILL.md` gets a "Local transcription" subsection stating what the local engine does not provide (speaker labels, audio events, `spacing` entries; fillers best effort) and rewrites the two Whisper anti-pattern lines; `README.md` mentions the option.

**Measured on an M2 MacBook Air, 8 GB, with the pinned fp16 turbo model**

Two minutes of a keynote recording against the cached Scribe transcript for the same audio, comparing only words inside runs of three or more consecutive matches so a repeated phrase cannot pair with the wrong occurrence:

| | onset median | onset p90 | onset after a pause ≥ 0.4 s | word end median |
|---|---|---|---|---|
| raw Whisper word times | 100 ms | 560 ms | 480 ms | 40 ms |
| shipped (onset trim) | 80 ms | 400 ms | 45 ms | 40 ms |

Remaining outliers are stutter runs ("the, the, the transformation") that Whisper collapses into one long word; Scribe keeps each repetition. That is the verbatim gap the docs now warn about. The 2 min sample transcribes in about 2.5 min on this machine after a one-time 1.6 GB download.

**Tests**

`python -m pytest -q` (57 tests). New coverage: library choice per machine, missing-library message, pinned download, word normalization, each artifact guard, onset trimming, verbatim prompt gating, dotenv precedence, the printed engine line, invalid values failing before any subprocess, the ElevenLabs path calling Scribe exactly once, an old transcript without `engine` being reused, and `--force` keeping the old file when the new run raises. No test loads a model or touches the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WF63xJ295MfvG1f2BTKQnx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Users without an ElevenLabs key can now transcribe and edit videos with a local Whisper engine. Transcription previously hard-exited when `ELEVENLABS_API_KEY` was missing, even though the rest of the pipeline is ffmpeg and PIL.

**New Features**
- Adds a local Whisper engine (`mlx-whisper` on Apple Silicon, `faster-whisper` elsewhere) with a hardware probe that prints the one CUDA-aware install command, downloads only the needed model, and preflights the environment before a run.
- Makes engine selection explicit: `--engine` wins, then `VIDEO_USE_TRANSCRIBER`, then the API key, and each run prints the engine and its source; quoted dotenv values are honored.
- Keeps the local transcript in the same word shape consumers read, so existing helpers and EDL validators work unchanged.
- Guards decoder artifacts without VAD: drops silent segments, words over 3 s, repetition loops (including non-Latin scripts), and prompt echoes, and trims word starts to the first audible energy frame using streamed onset detection.
- Adds a top-level `engine` key to transcripts; files without it are reused as ElevenLabs, and `--force` replaces a transcript only after success.

**Migration**
- Set `VIDEO_USE_TRANSCRIBER=local` in `.env` and install the `stt-mlx`, `stt-cpu`, or `stt-cuda` extra; install now asks once for a key or the local engine.
- The local engine lacks speaker labels, audio events, and `spacing` entries, and fillers are best effort.

<sup>Written for commit 961f3d41546c95c3de9741a78b9cc12af29f67c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

