### PR TITLE
feat(transcribe): add BW Labs STT as optional provider alongside ElevenLabs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,10 @@
 ELEVENLABS_API_KEY=
+
+# Optional: BW Labs STT — get a key at https://labs.bandwidth.com/
+# API docs: https://labs.bandwidth.com/docs/speech-to-text
+# Install:  pip install websockets  (or: pip install "video-use[bw-stt]")
+BW_STT_API_KEY=
+
+# Optional: default transcription provider ("elevenlabs" or "bw_stt").
+# If unset, auto-detects from whichever key is present (ElevenLabs wins if both).
+# TRANSCRIBE_PROVIDER=elevenlabs

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -295,8 +295,9 @@ def cached_provider(path: Path) -> str:
 
     Files written before the provider field existed came from ElevenLabs
     (the only backend at the time), so a missing field means "elevenlabs".
-    An unreadable or corrupt file returns "" so it never matches a provider
-    and gets re-transcribed.
+    An unreadable or corrupt file — including a provider value that is not a
+    known provider name — returns "" so it never matches a provider and gets
+    re-transcribed.
     """
     try:
         payload = json.loads(path.read_text())
@@ -304,7 +305,8 @@ def cached_provider(path: Path) -> str:
         return ""
     if not isinstance(payload, dict):
         return ""
-    return payload.get("provider", "elevenlabs")
+    prov = payload.get("provider", "elevenlabs")
+    return prov if prov in PROVIDERS else ""
 
 
 def transcribe_one(

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -231,6 +231,7 @@ def _call_bw_stt(audio: Path, api_key: str) -> dict:
         sender = threading.Thread(target=_send_audio, daemon=True)
         sender.start()
 
+        session_closed = False
         for raw in ws:
             msg = json.loads(raw)
             if msg["type"] == "Segment":
@@ -245,6 +246,7 @@ def _call_bw_stt(audio: Path, api_key: str) -> dict:
                     })
             elif msg["type"] == "SessionClosed":
                 audio_duration = msg.get("audio_duration_seconds", 0.0)
+                session_closed = True
                 break
             elif msg["type"] == "Error":
                 raise RuntimeError(f"BW STT error {msg['code']}: {msg['message']}")
@@ -252,6 +254,13 @@ def _call_bw_stt(audio: Path, api_key: str) -> dict:
         sender.join(timeout=10)
         if send_error:
             raise RuntimeError(f"BW STT send failed: {send_error[0]}") from send_error[0]
+        if not session_closed:
+            # A clean socket close ends the iterator without raising; returning
+            # here would cache a truncated transcript as final output.
+            raise RuntimeError(
+                f"BW STT session ended without SessionClosed — transcript incomplete "
+                f"({len(all_words)} words received). Not caching; retry the transcription."
+            )
 
     return {
         "words": all_words,

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -291,7 +291,7 @@ def cached_provider(path: Path) -> str:
     """
     try:
         payload = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return ""
     if not isinstance(payload, dict):
         return ""

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -1,16 +1,37 @@
-"""Transcribe a video with ElevenLabs Scribe.
+"""Transcribe a video with ElevenLabs Scribe (default) or BW Labs STT.
 
-Extracts mono 16kHz audio via ffmpeg, uploads to Scribe with verbatim +
-diarize + audio events + word-level timestamps, writes the full response
-to <edit_dir>/transcripts/<video_stem>.json.
+ElevenLabs Scribe: HTTP multipart upload, word-level timestamps, speaker
+diarization, and audio events.  Requires ELEVENLABS_API_KEY.
 
-Cached: if the output file already exists, the upload is skipped.
+BW Labs STT: WebSocket streaming, no duration limit, no speaker diarization,
+no language selection.  Requires BW_STT_API_KEY and the websockets library.
+  Get a key:  https://labs.bandwidth.com/
+  API docs:   https://labs.bandwidth.com/docs/speech-to-text
+  Install:    pip install websockets
+         or:  pip install "video-use[bw-stt]"
+
+Provider selection (highest priority first):
+  1. --provider {elevenlabs,bw_stt} CLI flag
+  2. TRANSCRIBE_PROVIDER environment variable or .env entry
+  3. Auto-detect: whichever API key is present (ElevenLabs wins if both)
+
+Output JSON schema (both providers):
+  {"words": [{"type": "word", "text": "...", "start": 0.0, "end": 0.0,
+              "speaker_id": "speaker_0"}, ...],
+   "text": "...", "audio_duration_seconds": 0.0}
+
+ElevenLabs responses also include "spacing" and "audio_event" word entries.
+pack_transcripts.py handles all three types.
+
+Cached: if the output file already exists, the API call is skipped.
 
 Usage:
     python helpers/transcribe.py <video_path>
     python helpers/transcribe.py <video_path> --edit-dir /custom/edit
     python helpers/transcribe.py <video_path> --language en
     python helpers/transcribe.py <video_path> --num-speakers 2
+    python helpers/transcribe.py <video_path> --provider bw_stt
+    python helpers/transcribe.py <video_path> --audio-track 1
 """
 
 from __future__ import annotations
@@ -31,9 +52,11 @@ import requests
 
 
 SCRIBE_URL = "https://api.elevenlabs.io/v1/speech-to-text"
+PROVIDERS = ("elevenlabs", "bw_stt")
 
 
-def load_api_key() -> str:
+def _find_env_value(key_name: str) -> str:
+    """Return the value of *key_name* from .env or environment, or '' if absent."""
     for candidate in [Path(__file__).resolve().parent.parent / ".env", Path(".env")]:
         if candidate.exists():
             for line in candidate.read_text().splitlines():
@@ -41,12 +64,52 @@ def load_api_key() -> str:
                 if not line or line.startswith("#") or "=" not in line:
                     continue
                 k, v = line.split("=", 1)
-                if k.strip() == "ELEVENLABS_API_KEY":
+                if k.strip() == key_name:
                     return v.strip().strip('"').strip("'")
-    v = os.environ.get("ELEVENLABS_API_KEY", "")
+    return os.environ.get(key_name, "")
+
+
+def load_api_key(provider: str = "elevenlabs") -> str:
+    env_var = "ELEVENLABS_API_KEY" if provider == "elevenlabs" else "BW_STT_API_KEY"
+    v = _find_env_value(env_var)
     if not v:
-        sys.exit("ELEVENLABS_API_KEY not found in .env or environment")
+        sys.exit(f"{env_var} not found in .env or environment")
     return v
+
+
+def detect_provider() -> str:
+    """Return the provider whose API key is available; ElevenLabs wins if both are set."""
+    if _find_env_value("ELEVENLABS_API_KEY"):
+        return "elevenlabs"
+    if _find_env_value("BW_STT_API_KEY"):
+        return "bw_stt"
+    sys.exit(
+        "No transcription API key found. "
+        "Set ELEVENLABS_API_KEY (ElevenLabs Scribe) or BW_STT_API_KEY (BW Labs STT) "
+        "in .env or the environment."
+    )
+
+
+def resolve_provider(provider: str | None = None) -> str:
+    """Resolve the provider using the three-tier priority order.
+
+    1. *provider* argument (from --provider CLI flag)
+    2. TRANSCRIBE_PROVIDER in .env or environment
+    3. Auto-detection from available API keys
+    """
+    if provider is not None:
+        if provider not in PROVIDERS:
+            sys.exit(f"Unknown provider '{provider}'. Choose from: {', '.join(PROVIDERS)}")
+        return provider
+    env_prov = _find_env_value("TRANSCRIBE_PROVIDER")
+    if env_prov:
+        if env_prov not in PROVIDERS:
+            sys.exit(
+                f"TRANSCRIBE_PROVIDER='{env_prov}' is not valid. "
+                f"Choose from: {', '.join(PROVIDERS)}"
+            )
+        return env_prov
+    return detect_provider()
 
 
 def count_audio_tracks(video_path: Path) -> int:
@@ -113,6 +176,90 @@ def call_scribe(
     return resp.json()
 
 
+def _call_bw_stt(audio: Path, api_key: str) -> dict:
+    """Stream *audio* to BW Labs STT via WebSocket; return a normalised transcript dict.
+
+    Uses the public WebSocket API directly — no SDK required, only websockets (PyPI).
+    API docs: https://labs.bandwidth.com/docs/speech-to-text
+    """
+    try:
+        import websockets.sync.client as ws_sync
+    except ImportError:
+        sys.exit(
+            "websockets is required for BW Labs STT.\n"
+            "Install it: pip install websockets\n"
+            '       or: pip install "video-use[bw-stt]"'
+        )
+
+    import threading
+
+    ENDPOINT = (
+        "wss://api.labs.bandwidth.com/audio/v1/listen"
+        "?encoding=linear16&sample_rate=16000&channels=1&mode=instant"
+    )
+    FRAMES_PER_CHUNK = 2560  # 160ms × 16 kHz mono (2560 samples × 2 bytes = 5120 bytes)
+    MIN_FRAME_BYTES = 640    # API minimum frame duration is 20ms = 320 samples × 2 bytes
+
+    all_words: list[dict] = []
+    text_parts: list[str] = []
+    audio_duration = 0.0
+
+    with ws_sync.connect(ENDPOINT, additional_headers={"X-BW-LABS-API-KEY": api_key}) as ws:
+        msg = json.loads(ws.recv())
+        if msg["type"] != "SessionOpened":
+            raise RuntimeError(f"unexpected opening message: {msg['type']}")
+
+        # Send from a separate thread so the main thread drains Segment messages
+        # as they stream in. The server transcribes while audio uploads; reading
+        # only after sending everything would stall long files once the client's
+        # receive buffer fills.
+        send_error: list[BaseException] = []
+
+        def _send_audio() -> None:
+            try:
+                # wave.open strips the WAV header; readframes() returns raw PCM
+                with wave.open(str(audio), "rb") as wf:
+                    while frames := wf.readframes(FRAMES_PER_CHUNK):
+                        if len(frames) < MIN_FRAME_BYTES:
+                            # Pad a short tail with silence to the 20ms API minimum
+                            frames += b"\x00" * (MIN_FRAME_BYTES - len(frames))
+                        ws.send(frames)
+                ws.send(json.dumps({"type": "CloseStream"}))
+            except BaseException as e:  # surfaced after the recv loop ends
+                send_error.append(e)
+
+        sender = threading.Thread(target=_send_audio, daemon=True)
+        sender.start()
+
+        for raw in ws:
+            msg = json.loads(raw)
+            if msg["type"] == "Segment":
+                text_parts.append(msg["text"])
+                for w in msg.get("words", []):
+                    all_words.append({
+                        "type": "word",
+                        "text": w["word"],
+                        "start": w["start"],
+                        "end": w["end"],
+                        "speaker_id": "speaker_0",
+                    })
+            elif msg["type"] == "SessionClosed":
+                audio_duration = msg.get("audio_duration_seconds", 0.0)
+                break
+            elif msg["type"] == "Error":
+                raise RuntimeError(f"BW STT error {msg['code']}: {msg['message']}")
+
+        sender.join(timeout=10)
+        if send_error:
+            raise RuntimeError(f"BW STT send failed: {send_error[0]}") from send_error[0]
+
+    return {
+        "words": all_words,
+        "text": "".join(text_parts),
+        "audio_duration_seconds": audio_duration,
+    }
+
+
 def transcript_path(edit_dir: Path, video: Path, audio_track: int = 0) -> Path:
     """Where a video's transcript lands.
 
@@ -133,6 +280,7 @@ def transcribe_one(
     num_speakers: int | None = None,
     verbose: bool = True,
     audio_track: int = 0,
+    provider: str = "elevenlabs",
 ) -> Path:
     """Transcribe a single video. Returns path to transcript JSON.
 
@@ -173,9 +321,23 @@ def transcribe_one(
             )
 
         size_mb = audio.stat().st_size / (1024 * 1024)
-        if verbose:
-            print(f"  uploading {video.stem}.wav ({size_mb:.1f} MB)", flush=True)
-        payload = call_scribe(audio, api_key, language, num_speakers)
+
+        if provider == "elevenlabs":
+            if verbose:
+                print(f"  uploading {video.stem}.wav ({size_mb:.1f} MB) to ElevenLabs Scribe",
+                      flush=True)
+            payload = call_scribe(audio, api_key, language, num_speakers)
+        else:  # bw_stt
+            if verbose:
+                if language:
+                    print("  note: BW Labs STT auto-detects language; --language is ignored",
+                          flush=True)
+                if num_speakers:
+                    print("  note: BW Labs STT is single-channel; --num-speakers is ignored",
+                          flush=True)
+                print(f"  streaming {video.stem}.wav ({size_mb:.1f} MB) to BW Labs STT",
+                      flush=True)
+            payload = _call_bw_stt(audio, api_key)
 
     out_path.write_text(json.dumps(payload, indent=2))
     dt = time.time() - t0
@@ -190,7 +352,9 @@ def transcribe_one(
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Transcribe a video with ElevenLabs Scribe")
+    ap = argparse.ArgumentParser(
+        description="Transcribe a video with ElevenLabs Scribe or BW Labs STT"
+    )
     ap.add_argument("video", type=Path, help="Path to video file")
     ap.add_argument(
         "--edit-dir",
@@ -202,13 +366,13 @@ def main() -> None:
         "--language",
         type=str,
         default=None,
-        help="Optional ISO language code (e.g., 'en'). Omit to auto-detect.",
+        help="ISO language code (e.g., 'en'). ElevenLabs only; omit to auto-detect.",
     )
     ap.add_argument(
         "--num-speakers",
         type=int,
         default=None,
-        help="Optional number of speakers when known. Improves diarization accuracy.",
+        help="Number of speakers when known. ElevenLabs only; improves diarization.",
     )
     ap.add_argument(
         "--audio-track",
@@ -218,6 +382,16 @@ def main() -> None:
              "and the mic on track 1; without this ffmpeg applies its default audio "
              "stream selection, which picks the track with the most channels.",
     )
+    ap.add_argument(
+        "--provider",
+        choices=PROVIDERS,
+        default=None,
+        help=(
+            "Transcription backend (default: auto-detect from available API keys; "
+            "ElevenLabs wins if both are set). Override globally with "
+            "TRANSCRIBE_PROVIDER env var."
+        ),
+    )
     args = ap.parse_args()
 
     video = args.video.resolve()
@@ -225,7 +399,8 @@ def main() -> None:
         sys.exit(f"video not found: {video}")
 
     edit_dir = (args.edit_dir or (video.parent / "edit")).resolve()
-    api_key = load_api_key()
+    provider = resolve_provider(args.provider)
+    api_key = load_api_key(provider)
 
     transcribe_one(
         video=video,
@@ -234,6 +409,7 @@ def main() -> None:
         language=args.language,
         num_speakers=args.num_speakers,
         audio_track=args.audio_track,
+        provider=provider,
     )
 
 

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -281,6 +281,23 @@ def transcript_path(edit_dir: Path, video: Path, audio_track: int = 0) -> Path:
     return edit_dir / "transcripts" / f"{video.stem}{suffix}.json"
 
 
+def cached_provider(path: Path) -> str:
+    """Which provider produced the transcript at *path*.
+
+    Files written before the provider field existed came from ElevenLabs
+    (the only backend at the time), so a missing field means "elevenlabs".
+    An unreadable or corrupt file returns "" so it never matches a provider
+    and gets re-transcribed.
+    """
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    return payload.get("provider", "elevenlabs")
+
+
 def transcribe_one(
     video: Path,
     edit_dir: Path,
@@ -293,16 +310,24 @@ def transcribe_one(
 ) -> Path:
     """Transcribe a single video. Returns path to transcript JSON.
 
-    Cached: returns existing path immediately if the transcript already exists.
+    Cached: returns existing path immediately if a transcript from the same
+    provider already exists. A cached file from a different provider is
+    re-transcribed and overwritten.
     """
     transcripts_dir = edit_dir / "transcripts"
     transcripts_dir.mkdir(parents=True, exist_ok=True)
     out_path = transcript_path(edit_dir, video, audio_track)
 
     if out_path.exists():
+        prev = cached_provider(out_path)
+        if prev == provider:
+            if verbose:
+                print(f"cached: {out_path.name}")
+            return out_path
         if verbose:
-            print(f"cached: {out_path.name}")
-        return out_path
+            print(f"  cached {out_path.name} is from "
+                  f"{prev or 'an unreadable file'}; re-transcribing with {provider}",
+                  flush=True)
 
     if verbose:
         print(f"  extracting audio from {video.name}", flush=True)
@@ -347,6 +372,9 @@ def transcribe_one(
                 print(f"  streaming {video.stem}.wav ({size_mb:.1f} MB) to BW Labs STT",
                       flush=True)
             payload = _call_bw_stt(audio, api_key)
+
+    if isinstance(payload, dict):
+        payload["provider"] = provider  # cache identity — see cached_provider()
 
     out_path.write_text(json.dumps(payload, indent=2))
     dt = time.time() - t0

--- a/helpers/transcribe.py
+++ b/helpers/transcribe.py
@@ -90,12 +90,11 @@ def detect_provider() -> str:
     )
 
 
-def resolve_provider(provider: str | None = None) -> str:
-    """Resolve the provider using the three-tier priority order.
+def explicit_provider(provider: str | None = None) -> str | None:
+    """Provider explicitly requested via CLI flag or TRANSCRIBE_PROVIDER, or None.
 
-    1. *provider* argument (from --provider CLI flag)
-    2. TRANSCRIBE_PROVIDER in .env or environment
-    3. Auto-detection from available API keys
+    Unlike resolve_provider(), never falls back to key auto-detection, so it
+    can be answered without any API key configured.
     """
     if provider is not None:
         if provider not in PROVIDERS:
@@ -109,7 +108,17 @@ def resolve_provider(provider: str | None = None) -> str:
                 f"Choose from: {', '.join(PROVIDERS)}"
             )
         return env_prov
-    return detect_provider()
+    return None
+
+
+def resolve_provider(provider: str | None = None) -> str:
+    """Resolve the provider using the three-tier priority order.
+
+    1. *provider* argument (from --provider CLI flag)
+    2. TRANSCRIBE_PROVIDER in .env or environment
+    3. Auto-detection from available API keys
+    """
+    return explicit_provider(provider) or detect_provider()
 
 
 def count_audio_tracks(video_path: Path) -> int:

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from transcribe import (
     PROVIDERS,
     cached_provider,
+    explicit_provider,
     load_api_key,
     resolve_provider,
     transcribe_one,
@@ -91,14 +92,18 @@ def main() -> None:
     if not videos:
         sys.exit(f"no videos found in {videos_dir}")
 
-    # Resolved before the cache check: a transcript only counts as cached
-    # when it was produced by the same provider.
-    provider = resolve_provider(args.provider)
-    print(f"provider: {provider}")
+    # An explicitly requested provider (flag or TRANSCRIBE_PROVIDER) means a
+    # transcript only counts as cached when that provider produced it. Without
+    # one, any readable transcript counts, and key auto-detection waits until
+    # there is work to do — an all-cached rerun must not require an API key.
+    provider = explicit_provider(args.provider)
 
     def _is_cached(v: Path) -> bool:
         p = transcript_path(edit_dir, v, args.audio_track)
-        return p.exists() and cached_provider(p) == provider
+        if not p.exists():
+            return False
+        src = cached_provider(p)
+        return src == provider if provider else src != ""
 
     already_cached = [v for v in videos if _is_cached(v)]
     pending = [v for v in videos if v not in already_cached]
@@ -108,6 +113,9 @@ def main() -> None:
         print("nothing to do")
         return
 
+    if provider is None:
+        provider = resolve_provider()  # auto-detect; needs an API key
+    print(f"provider: {provider}")
     api_key = load_api_key(provider)
     print(f"transcribing {len(pending)} files with {args.workers} parallel workers")
     t0 = time.time()

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -1,7 +1,9 @@
-"""Batch-transcribe every video in a directory with 4 parallel workers.
+"""Batch-transcribe every video in a directory with parallel workers.
 
-Walks <videos_dir> for common video extensions, runs ElevenLabs Scribe on
-each, writes transcripts to <videos_dir>/edit/transcripts/<name>.json.
+Walks <videos_dir> for common video extensions, transcribes each via the
+configured provider (ElevenLabs Scribe by default, or BW Labs STT via
+--provider / TRANSCRIBE_PROVIDER), writes transcripts to
+<videos_dir>/edit/transcripts/<name>.json.
 
 Cached per-file: any source that already has a transcript is skipped.
 
@@ -10,6 +12,7 @@ Usage:
     python helpers/transcribe_batch.py <videos_dir> --workers 4
     python helpers/transcribe_batch.py <videos_dir> --num-speakers 2
     python helpers/transcribe_batch.py <videos_dir> --edit-dir /custom/edit
+    python helpers/transcribe_batch.py <videos_dir> --provider bw_stt
 """
 
 from __future__ import annotations
@@ -20,7 +23,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from transcribe import load_api_key, transcribe_one, transcript_path
+from transcribe import PROVIDERS, load_api_key, resolve_provider, transcribe_one, transcript_path
 
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
@@ -62,6 +65,12 @@ def main() -> None:
         default=0,
         help="Zero-based audio track to transcribe (OBS: 0 = game, 1 = mic).",
     )
+    ap.add_argument(
+        "--provider",
+        choices=PROVIDERS,
+        default=None,
+        help="Transcription backend (default: auto-detect from available API keys).",
+    )
     args = ap.parse_args()
 
     videos_dir = args.videos_dir.resolve()
@@ -84,8 +93,9 @@ def main() -> None:
         print("nothing to do")
         return
 
-    api_key = load_api_key()
-
+    provider = resolve_provider(args.provider)
+    api_key = load_api_key(provider)
+    print(f"provider: {provider}")
     print(f"transcribing {len(pending)} files with {args.workers} parallel workers")
     t0 = time.time()
 
@@ -101,6 +111,7 @@ def main() -> None:
                 num_speakers=args.num_speakers,
                 verbose=False,
                 audio_track=args.audio_track,
+                provider=provider,
             ): v
             for v in pending
         }

--- a/helpers/transcribe_batch.py
+++ b/helpers/transcribe_batch.py
@@ -23,7 +23,14 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from transcribe import PROVIDERS, load_api_key, resolve_provider, transcribe_one, transcript_path
+from transcribe import (
+    PROVIDERS,
+    cached_provider,
+    load_api_key,
+    resolve_provider,
+    transcribe_one,
+    transcript_path,
+)
 
 
 VIDEO_EXTS = {".mp4", ".MP4", ".mov", ".MOV", ".mkv", ".MKV", ".avi", ".AVI", ".m4v"}
@@ -84,8 +91,16 @@ def main() -> None:
     if not videos:
         sys.exit(f"no videos found in {videos_dir}")
 
-    already_cached = [v for v in videos
-                      if transcript_path(edit_dir, v, args.audio_track).exists()]
+    # Resolved before the cache check: a transcript only counts as cached
+    # when it was produced by the same provider.
+    provider = resolve_provider(args.provider)
+    print(f"provider: {provider}")
+
+    def _is_cached(v: Path) -> bool:
+        p = transcript_path(edit_dir, v, args.audio_track)
+        return p.exists() and cached_provider(p) == provider
+
+    already_cached = [v for v in videos if _is_cached(v)]
     pending = [v for v in videos if v not in already_cached]
 
     print(f"found {len(videos)} videos ({len(already_cached)} cached, {len(pending)} to transcribe)")
@@ -93,9 +108,7 @@ def main() -> None:
         print("nothing to do")
         return
 
-    provider = resolve_provider(args.provider)
     api_key = load_api_key(provider)
-    print(f"provider: {provider}")
     print(f"transcribing {len(pending)} files with {args.workers} parallel workers")
     t0 = time.time()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 
 [project.optional-dependencies]
 animations = ["manim"]
+bw-stt = ["websockets>=12"]
 
 [build-system]
 requires = ["setuptools>=61.0"]


### PR DESCRIPTION
## Summary

Adds [BW Labs STT](https://labs.bandwidth.com/) as an optional second transcription provider alongside ElevenLabs Scribe.

- **ElevenLabs remains the default** — zero breaking changes for existing users
- Calls the BW Labs **WebSocket API directly** — the only new dependency is `websockets` (PyPI), declared as an optional extra
- Provider selected via `--provider {elevenlabs,bw_stt}`, `TRANSCRIBE_PROVIDER` env var, or auto-detected from whichever API key is present (ElevenLabs wins if both are set)

## Usage

```bash
pip install websockets            # or: pip install "video-use[bw-stt]"
export BW_STT_API_KEY=bwa_key_... # get one at https://labs.bandwidth.com/
python helpers/transcribe.py clip.mp4 --provider bw_stt
python helpers/transcribe_batch.py raw_videos/ --provider bw_stt
```

## Differences vs ElevenLabs

| | ElevenLabs Scribe | BW Labs STT |
|--|--|--|
| Pricing | Paid (per-minute credits) | Free |
| Transport | HTTP multipart | WebSocket streaming |
| Duration limit | ~2h | None |
| Speaker diarization | Yes | No (all words → `speaker_0`) |
| Audio events | Yes (`(laughter)`, …) | No |
| Language selection | Yes | Auto-detect only |
| Docs | elevenlabs.io | [labs.bandwidth.com/docs/speech-to-text](https://labs.bandwidth.com/docs/speech-to-text) |

`--language` / `--num-speakers` still work for ElevenLabs and print a note when ignored by BW STT.

## Implementation notes

- `_call_bw_stt()` streams raw PCM over the socket from a background thread while the main thread drains `Segment` messages — reading only after sending would stall long files once the client receive buffer fills
- Final audio chunk is padded with silence to the API's 20ms frame minimum
- `websockets` is lazy-imported with a clear install hint, so ElevenLabs users are unaffected
- Output JSON is normalized to the same schema `pack_transcripts.py` already consumes (`type`/`text`/`start`/`end`/`speaker_id`)

## Testing

- Existing test suite: 16 passed, no regressions
- Live transcription of a 5-minute clip: 1200 words, timestamps covering full duration, packed cleanly by `pack_transcripts.py`
- Verified provider auto-detection, `TRANSCRIBE_PROVIDER` override, and CLI flags on both helpers
- Verified `helpers/transcribe.py` imports fine without `websockets` installed (ElevenLabs path untouched)

## Known API quirk

BW STT occasionally emits sub-word tokens in `words[]` (e.g. `"bel"` + `"ieve"`). Timestamps remain correct so phrase-boundary detection works; noted here for anyone doing exact word matching.

## Files changed

- `helpers/transcribe.py` — provider dispatch (`resolve_provider`, `detect_provider`), `_call_bw_stt()`
- `helpers/transcribe_batch.py` — `--provider` flag, passed through to workers
- `pyproject.toml` — `bw-stt = ["websockets>=12"]` optional extra
- `.env.example` — documents `BW_STT_API_KEY` and `TRANSCRIBE_PROVIDER`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds BW Labs STT as an optional transcription provider alongside ElevenLabs, which remains the default; existing ElevenLabs users are unaffected.

**Behavior changes**
- Provider is chosen via `--provider {elevenlabs,bw_stt}`, `TRANSCRIBE_PROVIDER`, or auto-detected from whichever API key is present (ElevenLabs wins if both are set).
- BW STT streams over WebSocket with no duration limit, but skips speaker diarization (all words tagged `speaker_0`), audio events, and language selection (auto-detect only).
- `--language` and `--num-speakers` still work for ElevenLabs and print a note when BW STT ignores them.
- Output JSON is normalized to the same schema `pack_transcripts.py` already consumes; BW STT may emit sub-word tokens in `words[]` with correct timestamps.
- If a BW STT WebSocket session closes before the server sends `SessionClosed`, the run raises an error instead of caching a partial transcript.
- Transcripts now record the provider that produced them; cached transcripts from a different provider are re-transcribed, legacy files without the field count as ElevenLabs, and files with unknown, corrupt, or unreadable provider values are re-transcribed. Batch mode treats any readable transcript as cached when no provider is explicitly set, so an all-cached rerun never needs an API key.

**Dependencies**
- Adds optional extra `bw-stt = ["websockets>=12"]`; `websockets` is lazy-imported, so ElevenLabs users don't need it.

<sup>Written for commit e1c754bd4a89eb767e457c7788d2c774ac59e9cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




