### PR TITLE
feat(render): mixed-orientation canvas + music-bed montage support

### DIFF
--- a/helpers/grade.py
+++ b/helpers/grade.py
@@ -75,6 +75,25 @@ def get_preset(name: str) -> str:
 # -------- Auto grade (data-driven, per-clip) --------------------------------
 
 
+# Codecs ffprobe reports for single-frame image inputs. A still must be looped
+# to be analyzable: seeking into one frame yields no samples at all, and the
+# analysis then silently falls back to neutral defaults — so every photo in a
+# montage gets the same canned correction regardless of how it actually looks.
+STILL_IMAGE_CODECS = {"mjpeg", "png", "bmp", "tiff", "webp", "gif", "jpeg2000", "ppm"}
+
+
+def _is_still_image(path: Path) -> bool:
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=codec_name", "-of", "csv=p=0", str(path)],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip().lower()
+        return out in STILL_IMAGE_CODECS
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
 def _sample_frame_stats(
     video: Path,
     start: float,
@@ -101,11 +120,18 @@ def _sample_frame_stats(
         metadata_path = f.name
 
     try:
-        cmd = [
-            "ffmpeg", "-y", "-hide_banner", "-nostats",
-            "-ss", f"{start:.3f}",
-            "-i", str(video),
-            "-t", f"{duration:.3f}",
+        if _is_still_image(video):
+            # One frame, looped: no seek (there is no timeline to seek into).
+            cmd = [
+                "ffmpeg", "-y", "-hide_banner", "-nostats",
+                "-loop", "1", "-i", str(video), "-t", f"{duration:.3f}",
+            ]
+        else:
+            cmd = [
+                "ffmpeg", "-y", "-hide_banner", "-nostats",
+                "-ss", f"{start:.3f}", "-i", str(video), "-t", f"{duration:.3f}",
+            ]
+        cmd += [
             "-vf", f"fps={fps:.2f},signalstats,metadata=print:file={metadata_path}",
             "-f", "null", "-",
         ]

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -172,6 +172,57 @@ def is_portrait_source(video: Path) -> bool:
         return False
 
 
+# -------- Blurred-fill canvas (mixed-orientation montages) -------------------
+#
+# The default scale preserves each source's own orientation, so a portrait clip
+# becomes 1080x1920 while a landscape clip becomes 1920x1080. Segments with
+# different dimensions cannot be concatenated with `-c copy` (Rule 2), so a
+# montage mixing phone verticals with landscape footage has no lossless path.
+#
+# The fix is to render EVERY segment onto one fixed canvas: a zoomed, blurred
+# copy of the frame fills the canvas edge-to-edge, and the sharp aspect-correct
+# frame sits centred on top. Landscape fills it completely; portrait gets a
+# blurred pillarbox instead of black bars. Same dimensions for every segment, so
+# the lossless concat still works.
+
+CANVAS_BLUR_SIGMA = 20
+
+
+def blurred_fill_chain(width: int, height: int, sigma: int = CANVAS_BLUR_SIGMA) -> str:
+    """Filter chain fitting ANY source aspect onto a fixed width x height canvas.
+
+    Single video in, single video out, so it drops straight into a `-vf` chain.
+    `increase` scales the background to cover the canvas (then crops the
+    overflow); `decrease` fits the foreground inside it without distortion.
+    """
+    return (
+        f"split=2[cvbg][cvfg];"
+        f"[cvbg]scale={width}:{height}:force_original_aspect_ratio=increase,"
+        f"crop={width}:{height},gblur=sigma={sigma}[cvbgb];"
+        f"[cvfg]scale={width}:{height}:force_original_aspect_ratio=decrease[cvfgs];"
+        f"[cvbgb][cvfgs]overlay=(W-w)/2:(H-h)/2"
+    )
+
+
+def has_audio_stream(video: Path) -> bool:
+    """True if the file carries at least one audio stream.
+
+    Montage sources are routinely silent — an exported photo, a muted phone
+    clip. Those must still get an audio stream in their segment, or the `-c copy`
+    concat yields a file whose audio timeline has holes and the music mix has no
+    `[0:a]` to duck under.
+    """
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "a",
+             "-show_entries", "stream=index", "-of", "csv=p=0", str(video)],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        return bool(out)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
 def parse_fps(value: str) -> str:
     """Validate and canonicalize an ffmpeg frame rate."""
     text = value.strip()
@@ -240,11 +291,20 @@ def extract_segment(
     preview: bool = False,
     draft: bool = False,
     rate: str | None = None,
+    canvas: bool = False,
+    mute: bool = False,
 ) -> None:
     """Extract a cut range as its own MP4 with grade + 30ms audio fades baked in.
 
     `-ss` before `-i` for fast accurate seeking. Scale to 1080p from 4K.
     Portrait sources (height > width) are scaled by height to preserve orientation.
+
+    With `canvas=True`, every segment is instead composited onto one fixed
+    landscape canvas via `blurred_fill_chain`, so mixed-orientation sources share
+    dimensions and stay losslessly concat-able.
+
+    With `mute=True`, the segment's natural audio is silenced (but the stream is
+    kept, so the concat stays uniform) — used when a music bed covers the clip.
 
     Quality ladder:
       - final (default): 1080p libx264 fast CRF 20
@@ -253,11 +313,15 @@ def extract_segment(
     """
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    portrait = is_portrait_source(source)
-    if draft:
-        scale = "scale=-2:1280" if portrait else "scale=1280:-2"
+    if canvas:
+        cw, ch = (1280, 720) if draft else (1920, 1080)
+        scale = blurred_fill_chain(cw, ch)
     else:
-        scale = "scale=-2:1920" if portrait else "scale=1920:-2"
+        portrait = is_portrait_source(source)
+        if draft:
+            scale = "scale=-2:1280" if portrait else "scale=1280:-2"
+        else:
+            scale = "scale=-2:1920" if portrait else "scale=1920:-2"
 
     vf_parts: list[str] = []
     if is_hdr_source(source):
@@ -270,6 +334,10 @@ def extract_segment(
     # 30ms audio fades at both edges (Rule 3) — prevent pops
     fade_out_start = max(0.0, duration - 0.03)
     af = f"afade=t=in:st=0:d=0.03,afade=t=out:st={fade_out_start:.3f}:d=0.03"
+    if mute:
+        # Silence rather than drop: every segment must keep an audio stream or
+        # the `-c copy` concat produces a file with gaps in its audio timeline.
+        af = "volume=0," + af
 
     if draft:
         preset, crf = "ultrafast", "28"
@@ -284,13 +352,21 @@ def extract_segment(
     # own rate; fall back to 24 only if it can't be probed.
     out_rate = rate if rate is not None else (probe_source_fps(source) or "24")
 
-    cmd = [
-        "ffmpeg", "-y",
-        "-ss", f"{seg_start:.3f}",
-        "-i", str(source),
-        "-t", f"{duration:.3f}",
-        "-vf", vf,
-        "-af", af,
+    cmd = ["ffmpeg", "-y", "-ss", f"{seg_start:.3f}", "-i", str(source)]
+
+    # A silent source still needs an audio stream in its segment — synthesize
+    # one, so every segment is uniform for the concat and the music bed has
+    # something to mix against.
+    silent_source = not has_audio_stream(source)
+    if silent_source:
+        cmd += ["-f", "lavfi", "-i",
+                "anullsrc=channel_layout=stereo:sample_rate=48000",
+                "-map", "0:v", "-map", "1:a"]
+
+    cmd += ["-t", f"{duration:.3f}", "-vf", vf]
+    if not silent_source:
+        cmd += ["-af", af]
+    cmd += [
         "-c:v", "libx264", "-preset", preset, "-crf", crf,
         "-pix_fmt", "yuv420p", "-r", out_rate,
         "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
@@ -316,6 +392,9 @@ def extract_all_segments(
     """
     resolved = resolve_grade_filter(edl.get("grade"))
     is_auto = resolved == "__AUTO__"
+    # Opt-in: EDL `"canvas": "fill"` renders every segment onto one fixed
+    # landscape canvas so mixed-orientation sources can still concat losslessly.
+    canvas = str(edl.get("canvas") or "").lower() in ("fill", "blur", "blurred_fill")
     clips_dir = edit_dir / (
         "clips_draft" if draft else ("clips_preview" if preview else "clips_graded")
     )
@@ -340,6 +419,9 @@ def extract_all_segments(
     seg_paths: list[Path] = []
     print(f"extracting {len(ranges)} segment(s) → {clips_dir.name}/  @ {out_rate} fps"
           f"{' (forced)' if fps is not None else ' (from source)'}")
+    if canvas:
+        print(f"  (blurred-fill canvas: {'1280x720' if draft else '1920x1080'} "
+              f"— mixed orientations share one canvas)")
     if is_auto:
         print("  (auto-grade per segment: analyzing each range)")
     for i, r in enumerate(ranges):
@@ -355,11 +437,14 @@ def extract_all_segments(
         else:
             seg_filter = resolved
 
+        mute = bool(r.get("mute"))
         note = r.get("beat") or r.get("note") or ""
-        print(f"  [{i:02d}] {src_name}  {start:7.2f}-{end:7.2f}  ({duration:5.2f}s)  {note}")
+        flag = "  [muted]" if mute else ""
+        print(f"  [{i:02d}] {src_name}  {start:7.2f}-{end:7.2f}  ({duration:5.2f}s)  {note}{flag}")
         if is_auto:
             print(f"        grade: {seg_filter or '(none)'}")
-        extract_segment(src_path, start, duration, seg_filter, out_path, preview=preview, draft=draft, rate=out_rate)
+        extract_segment(src_path, start, duration, seg_filter, out_path, preview=preview, draft=draft, rate=out_rate,
+                        canvas=canvas, mute=mute)
         seg_paths.append(out_path)
 
     return seg_paths
@@ -385,6 +470,101 @@ def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -
     print(f"concat → {out_path.name}")
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
     concat_list.unlink(missing_ok=True)
+
+
+# -------- Music bed ----------------------------------------------------------
+#
+# For montages the music is the spine and the natural audio is texture under it.
+# Mixed AFTER the lossless concat and BEFORE loudnorm, with `-c:v copy` so the
+# video is never re-encoded for the sake of audio (Rule 2's no-double-encode
+# principle applied to the audio side).
+
+MUSIC_GAIN = 0.85           # music bed, primary
+MUSIC_NATURAL_GAIN = 0.5    # natural/crowd audio, ducked under it
+MUSIC_FADE_OUT = 3.0        # seconds of fade at the tail
+
+
+def probe_duration(path: Path) -> float | None:
+    """Container duration in seconds, or None if it can't be probed."""
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=nw=1:nk=1", str(path)],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        return float(out)
+    except (subprocess.CalledProcessError, ValueError, FileNotFoundError):
+        return None
+
+
+def mix_music_bed(
+    video_path: Path,
+    music_cfg: dict,
+    out_path: Path,
+    edit_dir: Path,
+) -> None:
+    """Mix a music bed under the video's existing audio. Video is stream-copied.
+
+    EDL shape:
+        "music": {
+            "source": "bed.mp3",   # relative to the EDL, or absolute
+            "gain": 0.85,          # music level
+            "natural_gain": 0.5,   # existing audio ducked under the music
+            "fade_out": 3.0        # tail fade, seconds
+        }
+
+    The bed is looped if it is shorter than the video and cut to video length if
+    longer (`duration=first`). `normalize=0` on amix is essential — without it
+    amix rescales every input by 1/n and the explicit gains above stop meaning
+    anything.
+    """
+    src = resolve_path(str(music_cfg["source"]), edit_dir)
+    if not src.exists():
+        print(f"warning: music source does not exist, skipping bed: {src}")
+        return
+
+    gain = float(music_cfg.get("gain", MUSIC_GAIN))
+    natural = float(music_cfg.get("natural_gain", MUSIC_NATURAL_GAIN))
+    fade = float(music_cfg.get("fade_out", MUSIC_FADE_OUT))
+
+    duration = probe_duration(video_path)
+    music_chain = f"volume={gain}"
+    if duration and fade > 0:
+        fade_start = max(0.0, duration - fade)
+        music_chain += f",afade=t=out:st={fade_start:.3f}:d={fade:.3f}"
+
+    # A base with no audio at all (every source silent) has no [0:a] to mix —
+    # use the bed alone rather than failing the render. That path needs
+    # `-shortest`, because amix's `duration=first` is what otherwise stops the
+    # infinitely looped bed at the video's length.
+    base_has_audio = has_audio_stream(video_path)
+    if base_has_audio:
+        filt = (
+            f"[0:a]volume={natural}[nat];"
+            f"[1:a]{music_chain}[bed];"
+            f"[nat][bed]amix=inputs=2:duration=first:dropout_transition=0:normalize=0[aout]"
+        )
+        natural_note = f"natural {natural}"
+    else:
+        filt = f"[1:a]{music_chain}[aout]"
+        natural_note = "no natural audio"
+
+    print(f"music bed → {src.name}  (music {gain}, {natural_note}, "
+          f"{fade:.1f}s tail fade)")
+    cmd = [
+        "ffmpeg", "-y",
+        "-i", str(video_path),
+        "-stream_loop", "-1", "-i", str(src),
+        "-filter_complex", filt,
+        "-map", "0:v", "-map", "[aout]",
+        "-c:v", "copy",
+        "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
+        "-movflags", "+faststart",
+    ]
+    if not base_has_audio:
+        cmd.append("-shortest")
+    cmd.append(str(out_path))
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
 
 # -------- Master SRT (Rule 5) ------------------------------------------------
@@ -701,6 +881,11 @@ def main() -> None:
         help="Skip subtitles even if the EDL references one",
     )
     ap.add_argument(
+        "--no-music",
+        action="store_true",
+        help="Skip the music bed even if the EDL defines one",
+    )
+    ap.add_argument(
         "--no-loudnorm",
         action="store_true",
         help="Skip audio loudness normalization. Default is on (-14 LUFS, -1 dBTP, LRA 11).",
@@ -737,6 +922,15 @@ def main() -> None:
         base_name = "base.mp4"
     base_path = edit_dir / base_name
     concat_segments(segment_paths, base_path, edit_dir)
+
+    # 2b. Music bed (montages): mix under the concatenated natural audio.
+    # Video is stream-copied here, so this costs no extra video encode.
+    music_cfg = edl.get("music")
+    if music_cfg and not args.no_music:
+        mixed_path = base_path.with_name(base_path.stem + "_music.mp4")
+        mix_music_bed(base_path, music_cfg, mixed_path, edit_dir)
+        if mixed_path.exists():
+            base_path = mixed_path
 
     # 3. Subtitles: build if requested, resolve final path
     subs_path: Path | None = None

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -448,11 +448,20 @@ def extract_all_segments(
     # Explicit --fps wins; otherwise preserve the first source's rate.
     if fps is not None:
         out_rate = parse_fps(str(fps))
-    elif ranges:
-        first_src = resolve_path(sources[ranges[0]["source"]], edit_dir)
-        out_rate = probe_source_fps(first_src) or "24"
     else:
-        out_rate = "24"
+        # Resolve the rate from the first MOVING source. Probing a still image
+        # yields a meaningless nominal rate (ffprobe reports 25 for a JPEG),
+        # and a montage that opens on a photo would otherwise force that rate
+        # onto real footage and make the motion judder.
+        out_rate = None
+        for r in ranges:
+            src = resolve_path(sources[r["source"]], edit_dir)
+            if is_still_image(src):
+                continue
+            out_rate = probe_source_fps(src)
+            if out_rate:
+                break
+        out_rate = out_rate or "24"
 
     seg_paths: list[Path] = []
     print(f"extracting {len(ranges)} segment(s) → {clips_dir.name}/  @ {out_rate} fps"
@@ -470,7 +479,18 @@ def extract_all_segments(
         duration = end - start
         out_path = clips_dir / f"seg_{i:02d}_{src_name}.mp4"
 
-        if is_auto:
+        # A per-range "grade" overrides the EDL-wide one. Montages cut between
+        # sources with very different exposure — blown-white ice against a dim
+        # room — and a single global grade cannot reconcile them, while the
+        # auto-grade is deliberately bounded to +/-8% and is too gentle to try.
+        if r.get("grade") is not None:
+            seg_resolved = resolve_grade_filter(r["grade"])
+            if seg_resolved == "__AUTO__":
+                seg_filter, _stats = auto_grade_for_clip(
+                    src_path, start=start, duration=duration, verbose=False)
+            else:
+                seg_filter = seg_resolved
+        elif is_auto:
             seg_filter, _stats = auto_grade_for_clip(src_path, start=start, duration=duration, verbose=False)
         else:
             seg_filter = resolved

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -356,7 +356,12 @@ def extract_segment(
 
     # 30ms audio fades at both edges (Rule 3) — prevent pops
     fade_out_start = max(0.0, duration - 0.03)
-    af = f"afade=t=in:st=0:d=0.03,afade=t=out:st={fade_out_start:.3f}:d=0.03"
+    # `apad` + the `-t` below guarantees the audio runs exactly as long as the
+    # video. A source whose audio stream ends before its video (common in arena
+    # and phone exports) otherwise yields a segment with a short audio track,
+    # which leaves a hole in the concatenated timeline and truncates the mix.
+    af = (f"afade=t=in:st=0:d=0.03,afade=t=out:st={fade_out_start:.3f}:d=0.03"
+          f",apad")
     if mute:
         # Silence rather than drop: every segment must keep an audio stream or
         # the `-c copy` concat produces a file with gaps in its audio timeline.
@@ -535,8 +540,10 @@ def mix_music_bed(
     music_cfg: dict,
     out_path: Path,
     edit_dir: Path,
-) -> None:
+) -> bool:
     """Mix a music bed under the video's existing audio. Video is stream-copied.
+
+    Returns True if an output was written, False if the bed was skipped.
 
     EDL shape:
         "music": {
@@ -554,7 +561,7 @@ def mix_music_bed(
     src = resolve_path(str(music_cfg["source"]), edit_dir)
     if not src.exists():
         print(f"warning: music source does not exist, skipping bed: {src}")
-        return
+        return False
 
     gain = float(music_cfg.get("gain", MUSIC_GAIN))
     natural = float(music_cfg.get("natural_gain", MUSIC_NATURAL_GAIN))
@@ -568,14 +575,16 @@ def mix_music_bed(
 
     # A base with no audio at all (every source silent) has no [0:a] to mix —
     # use the bed alone rather than failing the render. That path needs
-    # `-shortest`, because amix's `duration=first` is what otherwise stops the
-    # infinitely looped bed at the video's length.
+    # `-shortest` on every path: the bed is looped indefinitely, so it is
+    # `-shortest` (not amix) that stops the output at the video's length.
+    # `duration=longest` means a base whose audio ends early still gets scored
+    # all the way to the end of the picture.
     base_has_audio = has_audio_stream(video_path)
     if base_has_audio:
         filt = (
             f"[0:a]volume={natural}[nat];"
             f"[1:a]{music_chain}[bed];"
-            f"[nat][bed]amix=inputs=2:duration=first:dropout_transition=0:normalize=0[aout]"
+            f"[nat][bed]amix=inputs=2:duration=longest:dropout_transition=0:normalize=0[aout]"
         )
         natural_note = f"natural {natural}"
     else:
@@ -594,10 +603,10 @@ def mix_music_bed(
         "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
         "-movflags", "+faststart",
     ]
-    if not base_has_audio:
-        cmd.append("-shortest")
+    cmd.append("-shortest")
     cmd.append(str(out_path))
     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    return True
 
 
 # -------- Master SRT (Rule 5) ------------------------------------------------
@@ -961,8 +970,11 @@ def main() -> None:
     music_cfg = edl.get("music")
     if music_cfg and not args.no_music:
         mixed_path = base_path.with_name(base_path.stem + "_music.mp4")
-        mix_music_bed(base_path, music_cfg, mixed_path, edit_dir)
-        if mixed_path.exists():
+        # Clear any output from a previous render first: if the bed is missing
+        # this time, mix_music_bed writes nothing, and a leftover file would
+        # otherwise be picked up and scored into this render silently.
+        mixed_path.unlink(missing_ok=True)
+        if mix_music_bed(base_path, music_cfg, mixed_path, edit_dir):
             base_path = mixed_path
 
     # 3. Subtitles: build if requested, resolve final path

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -204,6 +204,29 @@ def blurred_fill_chain(width: int, height: int, sigma: int = CANVAS_BLUR_SIGMA) 
     )
 
 
+# Codecs ffprobe reports for single-frame image inputs.
+STILL_IMAGE_CODECS = {"mjpeg", "png", "bmp", "tiff", "webp", "gif", "jpeg2000", "ppm"}
+
+
+def is_still_image(path: Path) -> bool:
+    """True if the source is a single still image rather than a moving clip.
+
+    Stills need `-loop 1` to generate frames for the range's duration. Without
+    it ffmpeg decodes exactly one frame, and the segment ends up with a
+    container duration (borrowed from its audio) but no real video — which then
+    corrupts the concatenated timeline.
+    """
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=codec_name", "-of", "csv=p=0", str(path)],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip().lower()
+        return out in STILL_IMAGE_CODECS
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
 def has_audio_stream(video: Path) -> bool:
     """True if the file carries at least one audio stream.
 
@@ -352,12 +375,18 @@ def extract_segment(
     # own rate; fall back to 24 only if it can't be probed.
     out_rate = rate if rate is not None else (probe_source_fps(source) or "24")
 
-    cmd = ["ffmpeg", "-y", "-ss", f"{seg_start:.3f}", "-i", str(source)]
+    # A still has no timeline to seek into: loop the single frame instead, and
+    # let -t below set how long it holds.
+    still = is_still_image(source)
+    if still:
+        cmd = ["ffmpeg", "-y", "-loop", "1", "-i", str(source)]
+    else:
+        cmd = ["ffmpeg", "-y", "-ss", f"{seg_start:.3f}", "-i", str(source)]
 
     # A silent source still needs an audio stream in its segment — synthesize
     # one, so every segment is uniform for the concat and the music bed has
     # something to mix against.
-    silent_source = not has_audio_stream(source)
+    silent_source = still or not has_audio_stream(source)
     if silent_source:
         cmd += ["-f", "lavfi", "-i",
                 "anullsrc=channel_layout=stereo:sample_rate=48000",
@@ -369,7 +398,11 @@ def extract_segment(
     cmd += [
         "-c:v", "libx264", "-preset", preset, "-crf", crf,
         "-pix_fmt", "yuv420p", "-r", out_rate,
-        "-c:a", "aac", "-b:a", "192k", "-ar", "48000",
+        # Force stereo as well as 48kHz. The concat demuxer takes its parameters
+        # from the FIRST segment, so a single mono source (a LiveBarn export, a
+        # one-mic phone clip) silently collapses the whole timeline to mono —
+        # including a stereo music bed mixed on afterwards.
+        "-c:a", "aac", "-b:a", "192k", "-ar", "48000", "-ac", "2",
         "-movflags", "+faststart",
         str(out_path),
     ]

--- a/tests/test_grade_stills.py
+++ b/tests/test_grade_stills.py
@@ -95,9 +95,14 @@ class AutoGradeDifferentiatesStillsTests(unittest.TestCase):
         """Drive auto_grade_for_clip with a synthetic signalstats reading."""
         def fake_run(cmd, *a, **kw):
             # Locate the metadata target the filtergraph was told to write.
+            # The target may be a bare filename resolved against a cwd, or a
+            # full path — accept either so this test is not coupled to which.
             vf = cmd[cmd.index("-vf") + 1]
             name = vf.rsplit("file=", 1)[1]
-            Path(kw["cwd"], name).write_text(
+            target = Path(name)
+            if not target.is_absolute():
+                target = Path(kw.get("cwd") or ".", name)
+            target.write_text(
                 f"lavfi.signalstats.YBITDEPTH=8\n"
                 f"lavfi.signalstats.YAVG={y_avg}\n"
                 f"lavfi.signalstats.YMIN=16\n"

--- a/tests/test_grade_stills.py
+++ b/tests/test_grade_stills.py
@@ -1,0 +1,128 @@
+"""Auto-grade must actually analyze still images.
+
+Bug: `_sample_frame_stats` built its ffmpeg command as `-ss <start> -i <file>
+-t <duration>`. Seeking into a single-frame input yields ZERO frames, so the
+signalstats metadata file came back empty and the analysis fell through to its
+neutral defaults. Every photograph in a montage therefore received an identical
+canned correction no matter how it actually looked, and `grade: "auto"` produced
+output byte-identical to no grading at all.
+
+Measured on real photos before the fix: two visually different stills both
+reported y_mean 0.5 (the fallback), while a video clip reported 0.8. After the
+fix the same stills report 0.52 and 0.58.
+"""
+
+import importlib.util
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).parents[1] / "helpers" / "grade.py"
+SPEC = importlib.util.spec_from_file_location("video_use_grade_stills", MODULE_PATH)
+assert SPEC and SPEC.loader
+grade = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(grade)
+
+
+class StillDetectionTests(unittest.TestCase):
+    def _detect(self, codec_name):
+        result = unittest.mock.Mock(stdout=codec_name + "\n", returncode=0)
+        with patch.object(grade.subprocess, "run", return_value=result):
+            return grade._is_still_image(Path("x"))
+
+    def test_image_codecs_detected(self):
+        for codec in ("mjpeg", "png", "webp", "bmp", "tiff"):
+            with self.subTest(codec=codec):
+                self.assertTrue(self._detect(codec))
+
+    def test_video_codecs_not_detected(self):
+        for codec in ("h264", "hevc", "vp9", "prores", "av1"):
+            with self.subTest(codec=codec):
+                self.assertFalse(self._detect(codec))
+
+    def test_probe_failure_is_not_fatal(self):
+        err = subprocess.CalledProcessError(1, "ffprobe")
+        with patch.object(grade.subprocess, "run", side_effect=err):
+            self.assertFalse(grade._is_still_image(Path("x")))
+
+
+class SampleFrameStatsCommandTests(unittest.TestCase):
+    """The command shape is the fix — assert it directly."""
+
+    def _cmd_for(self, still: bool):
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            # Leave the metadata file empty; we only care about the command.
+            return unittest.mock.Mock(returncode=0)
+
+        with patch.object(grade, "_is_still_image", return_value=still), \
+             patch.object(grade.subprocess, "run", side_effect=fake_run):
+            grade._sample_frame_stats(Path("src"), start=5.0, duration=3.0)
+        return captured["cmd"]
+
+    def test_still_is_looped_and_not_seeked(self):
+        cmd = self._cmd_for(still=True)
+        self.assertIn("-loop", cmd)
+        self.assertEqual(cmd[cmd.index("-loop") + 1], "1")
+        # There is no timeline to seek into; -ss would consume the only frame.
+        self.assertNotIn("-ss", cmd)
+        self.assertEqual(cmd[cmd.index("-t") + 1], "3.000")
+
+    def test_moving_source_is_seeked_and_not_looped(self):
+        cmd = self._cmd_for(still=False)
+        self.assertNotIn("-loop", cmd)
+        self.assertEqual(cmd[cmd.index("-ss") + 1], "5.000")
+        self.assertEqual(cmd[cmd.index("-t") + 1], "3.000")
+
+    def test_both_paths_still_request_signalstats(self):
+        for still in (True, False):
+            with self.subTest(still=still):
+                cmd = self._cmd_for(still)
+                vf = cmd[cmd.index("-vf") + 1]
+                self.assertIn("signalstats", vf)
+                self.assertIn("metadata=print", vf)
+
+
+class AutoGradeDifferentiatesStillsTests(unittest.TestCase):
+    """The observable symptom: identical output for different photos."""
+
+    def _stats_from(self, y_avg: float):
+        """Drive auto_grade_for_clip with a synthetic signalstats reading."""
+        def fake_run(cmd, *a, **kw):
+            # Locate the metadata target the filtergraph was told to write.
+            vf = cmd[cmd.index("-vf") + 1]
+            name = vf.rsplit("file=", 1)[1]
+            Path(kw["cwd"], name).write_text(
+                f"lavfi.signalstats.YBITDEPTH=8\n"
+                f"lavfi.signalstats.YAVG={y_avg}\n"
+                f"lavfi.signalstats.YMIN=16\n"
+                f"lavfi.signalstats.YMAX=235\n"
+                f"lavfi.signalstats.SATAVG=40\n"
+            )
+            return unittest.mock.Mock(returncode=0)
+
+        with patch.object(grade, "_is_still_image", return_value=True), \
+             patch.object(grade.subprocess, "run", side_effect=fake_run):
+            return grade.auto_grade_for_clip(Path("photo.jpg"), 0.0, 3.0)
+
+    def test_different_stills_produce_different_analysis(self):
+        dark_filter, dark_stats = self._stats_from(70.0)
+        bright_filter, bright_stats = self._stats_from(200.0)
+        # Before the fix both returned the same fallback stats.
+        self.assertNotEqual(dark_stats["y_mean"], bright_stats["y_mean"])
+        self.assertLess(dark_stats["y_mean"], bright_stats["y_mean"])
+
+    def test_a_dark_still_is_lifted_and_a_bright_one_is_not(self):
+        dark_filter, _ = self._stats_from(70.0)
+        bright_filter, _ = self._stats_from(200.0)
+        self.assertIn("gamma=", dark_filter)
+        self.assertNotEqual(dark_filter, bright_filter)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_render_montage.py
+++ b/tests/test_render_montage.py
@@ -475,3 +475,104 @@ class MixCoverageRegressionTests(unittest.TestCase):
                     edit_dir / "out.mp4", edit_dir,
                 )
         self.assertTrue(wrote)
+
+
+class FpsResolutionTests(unittest.TestCase):
+    """Frame rate must come from a moving source, never from a still.
+
+    ffprobe reports a nominal 25 fps for a JPEG. A montage that opens on a
+    photo therefore forced 25 fps onto 30 fps footage and made the motion
+    judder — the whole reel resampled because of the first shot's file type.
+    """
+
+    def _rate_for(self, order):
+        used = []
+
+        def fake_extract(src, start, duration, filt, out, **kw):
+            used.append(kw["rate"])
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"x")
+
+        def fake_probe(path):
+            return {"still.jpg": "25/1", "clip.mp4": "30/1"}.get(Path(path).name)
+
+        with tempfile.TemporaryDirectory() as td:
+            edit_dir = Path(td)
+            edl = {
+                "sources": {"s": "still.jpg", "v": "clip.mp4"},
+                "ranges": [{"source": k, "start": 0, "end": 2} for k in order],
+            }
+            with patch.object(render, "extract_segment", side_effect=fake_extract), \
+                 patch.object(render, "is_still_image",
+                              side_effect=lambda p: Path(p).name == "still.jpg"), \
+                 patch.object(render, "probe_source_fps", side_effect=fake_probe), \
+                 contextlib.redirect_stdout(io.StringIO()):
+                render.extract_all_segments(edl, edit_dir, preview=False)
+        return used
+
+    def test_stills_first_still_picks_the_moving_sources_rate(self):
+        rates = self._rate_for(["s", "s", "v"])
+        self.assertEqual(set(rates), {"30/1"})
+
+    def test_every_segment_shares_one_rate(self):
+        # The -c copy concat requires it.
+        self.assertEqual(len(set(self._rate_for(["s", "v", "s", "v"]))), 1)
+
+    def test_all_stills_falls_back_rather_than_using_a_still_rate(self):
+        self.assertEqual(set(self._rate_for(["s", "s"])), {"24"})
+
+
+class PerRangeGradeTests(unittest.TestCase):
+    """A per-range grade overrides the EDL-wide one.
+
+    A montage cuts between sources with wildly different exposure (blown-white
+    ice against a dim room); one global grade cannot reconcile them, and the
+    auto-grade is bounded to +/-8% and too gentle to try.
+    """
+
+    def _filters(self, edl_extra, ranges):
+        seen = []
+
+        def fake_extract(src, start, duration, filt, out, **kw):
+            seen.append(filt)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"x")
+
+        with tempfile.TemporaryDirectory() as td:
+            edit_dir = Path(td)
+            edl = {"sources": {"a": "a.mp4"}, "ranges": ranges}
+            edl.update(edl_extra)
+            with patch.object(render, "extract_segment", side_effect=fake_extract), \
+                 patch.object(render, "is_still_image", return_value=False), \
+                 patch.object(render, "probe_source_fps", return_value="30/1"), \
+                 contextlib.redirect_stdout(io.StringIO()):
+                render.extract_all_segments(edl, edit_dir, preview=False)
+        return seen
+
+    def test_per_range_grade_wins_over_the_edl_wide_grade(self):
+        out = self._filters(
+            {"grade": "eq=contrast=1.03"},
+            [
+                {"source": "a", "start": 0, "end": 2},
+                {"source": "a", "start": 2, "end": 4, "grade": "eq=gamma=0.60"},
+            ],
+        )
+        self.assertEqual(out[0], "eq=contrast=1.03")
+        self.assertEqual(out[1], "eq=gamma=0.60")
+
+    def test_ranges_without_a_grade_are_unaffected(self):
+        out = self._filters(
+            {"grade": "eq=contrast=1.03"},
+            [{"source": "a", "start": 0, "end": 2}] * 3,
+        )
+        self.assertEqual(set(out), {"eq=contrast=1.03"})
+
+    def test_per_range_auto_resolves_per_segment(self):
+        with patch.object(render, "auto_grade_for_clip",
+                          return_value=("eq=gamma=1.02", {})) as auto:
+            out = self._filters(
+                {},
+                [{"source": "a", "start": 0, "end": 2, "grade": "auto"}],
+            )
+        auto.assert_called_once()
+        self.assertEqual(out, ["eq=gamma=1.02"])

--- a/tests/test_render_montage.py
+++ b/tests/test_render_montage.py
@@ -207,8 +207,12 @@ class MusicBedTests(unittest.TestCase):
         self.assertNotIn("[0:a]", filt)
         self.assertIn("-shortest", cmd)
 
-    def test_normal_path_does_not_pass_shortest(self):
-        self.assertNotIn("-shortest", self._cmd_for({"source": "bed.mp3"}))
+    def test_shortest_bounds_every_path(self):
+        # The bed is looped indefinitely, so -shortest is what stops the output
+        # at the video's length on BOTH the mixed and music-only paths.
+        self.assertIn("-shortest", self._cmd_for({"source": "bed.mp3"}))
+        self.assertIn("-shortest", self._cmd_for({"source": "bed.mp3"},
+                                                 base_has_audio=False))
 
     def test_video_is_stream_copied_not_re_encoded(self):
         cmd = self._cmd_for({"source": "bed.mp3"})
@@ -218,7 +222,9 @@ class MusicBedTests(unittest.TestCase):
         cmd = self._cmd_for({"source": "bed.mp3"})
         filt = cmd[cmd.index("-filter_complex") + 1]
         self.assertIn("normalize=0", filt)
-        self.assertIn("duration=first", filt)
+        # duration=longest, not first: see MixCoverageRegressionTests — first
+        # ended the mix wherever the natural audio happened to stop.
+        self.assertIn("duration=longest", filt)
 
     def test_gains_default_to_music_over_ducked_natural(self):
         cmd = self._cmd_for({"source": "bed.mp3"})
@@ -383,3 +389,89 @@ class StillImageDetectionTests(unittest.TestCase):
         err = subprocess.CalledProcessError(1, "ffprobe")
         with patch.object(render.subprocess, "run", side_effect=err):
             self.assertFalse(render.is_still_image(Path("x")))
+
+
+class MixCoverageRegressionTests(unittest.TestCase):
+    """Two defects found by an automated review of the montage PR.
+
+    Both are silent-wrong failures: the render succeeds and the output looks
+    fine until you listen to the end of it.
+    """
+
+    def test_segment_audio_is_padded_to_the_video_duration(self):
+        # A source whose audio stream ends before its video (arena and phone
+        # exports do this) produced a segment with a short audio track. That
+        # left a hole in the concatenated timeline and ended the music mix
+        # early: a 6s clip with 2s of audio rendered 4s of silent picture.
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return unittest.mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch.object(render, "is_portrait_source", return_value=False), \
+                 patch.object(render, "is_hdr_source", return_value=False), \
+                 patch.object(render, "is_still_image", return_value=False), \
+                 patch.object(render, "has_audio_stream", return_value=True), \
+                 patch.object(render.subprocess, "run", side_effect=fake_run):
+                render.extract_segment(
+                    Path("src.mp4"), 0.0, 6.0, "", Path(td) / "seg.mp4", rate="30/1",
+                )
+        cmd = captured["cmd"]
+        af = cmd[cmd.index("-af") + 1]
+        self.assertTrue(af.endswith("apad"), af)
+        # -t is what bounds the otherwise-infinite pad.
+        self.assertEqual(cmd[cmd.index("-t") + 1], "6.000")
+
+    def test_mix_covers_full_video_even_if_base_audio_is_short(self):
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return unittest.mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+        with tempfile.TemporaryDirectory() as td:
+            edit_dir = Path(td)
+            (edit_dir / "bed.mp3").write_bytes(b"x")
+            with patch.object(render, "probe_duration", return_value=60.0), \
+                 patch.object(render, "has_audio_stream", return_value=True), \
+                 patch.object(render.subprocess, "run", side_effect=fake_run), \
+                 contextlib.redirect_stdout(io.StringIO()):
+                render.mix_music_bed(
+                    edit_dir / "base.mp4", {"source": "bed.mp3"},
+                    edit_dir / "out.mp4", edit_dir,
+                )
+        cmd = captured["cmd"]
+        filt = cmd[cmd.index("-filter_complex") + 1]
+        # duration=first ended the mix at the natural-audio endpoint.
+        self.assertIn("duration=longest", filt)
+        self.assertNotIn("duration=first", filt)
+        # The bed loops forever, so -shortest is what bounds the output now.
+        self.assertIn("-shortest", cmd)
+
+    def test_mix_reports_whether_it_wrote_an_output(self):
+        with tempfile.TemporaryDirectory() as td:
+            edit_dir = Path(td)
+            with patch.object(render.subprocess, "run") as run, \
+                 contextlib.redirect_stdout(io.StringIO()):
+                wrote = render.mix_music_bed(
+                    edit_dir / "base.mp4", {"source": "gone.mp3"},
+                    edit_dir / "out.mp4", edit_dir,
+                )
+            run.assert_not_called()
+        self.assertFalse(wrote)
+
+    def test_successful_mix_reports_true(self):
+        with tempfile.TemporaryDirectory() as td:
+            edit_dir = Path(td)
+            (edit_dir / "bed.mp3").write_bytes(b"x")
+            with patch.object(render, "probe_duration", return_value=10.0), \
+                 patch.object(render, "has_audio_stream", return_value=True), \
+                 patch.object(render.subprocess, "run"), \
+                 contextlib.redirect_stdout(io.StringIO()):
+                wrote = render.mix_music_bed(
+                    edit_dir / "base.mp4", {"source": "bed.mp3"},
+                    edit_dir / "out.mp4", edit_dir,
+                )
+        self.assertTrue(wrote)

--- a/tests/test_render_montage.py
+++ b/tests/test_render_montage.py
@@ -8,6 +8,7 @@ whose spine is a song had no path through this renderer.
 """
 
 import importlib.util
+import subprocess
 import io
 import contextlib
 import json
@@ -297,3 +298,88 @@ class CanvasEdlWiringTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RealFootageRegressionTests(unittest.TestCase):
+    """Three defects found only by feeding real footage through the renderer.
+
+    Synthetic clips cut from one source share codec parameters and are always
+    moving video, so none of these surfaced until a real LiveBarn export (mono
+    audio) and real iPhone stills (single-frame JPEGs) went in.
+    """
+
+    def _cmd(self, *, still=False, has_audio=True):
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return unittest.mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch.object(render, "is_portrait_source", return_value=False), \
+                 patch.object(render, "is_hdr_source", return_value=False), \
+                 patch.object(render, "is_still_image", return_value=still), \
+                 patch.object(render, "has_audio_stream", return_value=has_audio), \
+                 patch.object(render.subprocess, "run", side_effect=fake_run):
+                render.extract_segment(
+                    Path("src"), 5.0, 3.0, "", Path(td) / "seg.mp4", rate="30/1",
+                )
+        return captured["cmd"]
+
+    # --- 1. mono source collapsed the whole reel to mono -------------------
+    def test_channel_count_is_forced_uniform(self):
+        # The concat demuxer takes parameters from the FIRST segment, so one
+        # mono source (a LiveBarn export) silently made the entire montage mono
+        # — including the stereo music bed mixed on afterwards.
+        cmd = self._cmd()
+        self.assertEqual(cmd[cmd.index("-ac") + 1], "2")
+
+    def test_channel_count_forced_for_silent_sources_too(self):
+        cmd = self._cmd(has_audio=False)
+        self.assertEqual(cmd[cmd.index("-ac") + 1], "2")
+
+    # --- 2. stills produced a segment with no video frames ----------------
+    def test_still_image_is_looped(self):
+        # Without -loop 1 ffmpeg decodes exactly one frame; the segment then
+        # reports a duration borrowed from its audio but has no real video, and
+        # the concatenated timeline comes out the wrong length.
+        cmd = self._cmd(still=True)
+        self.assertIn("-loop", cmd)
+        self.assertEqual(cmd[cmd.index("-loop") + 1], "1")
+        self.assertEqual(cmd[cmd.index("-t") + 1], "3.000")
+
+    def test_still_image_is_not_seeked(self):
+        # -ss into a single frame seeks past the end and yields nothing.
+        self.assertNotIn("-ss", self._cmd(still=True))
+
+    def test_moving_source_is_still_seeked(self):
+        cmd = self._cmd(still=False)
+        self.assertEqual(cmd[cmd.index("-ss") + 1], "5.000")
+        self.assertNotIn("-loop", cmd)
+
+    # --- 3. stills carry no audio, so they need synthesized silence -------
+    def test_still_image_gets_synthesized_audio(self):
+        cmd = self._cmd(still=True, has_audio=True)
+        self.assertIn("anullsrc=channel_layout=stereo:sample_rate=48000", cmd)
+
+
+class StillImageDetectionTests(unittest.TestCase):
+    def _detect(self, codec_name):
+        result = unittest.mock.Mock(stdout=codec_name + "\n", returncode=0)
+        with patch.object(render.subprocess, "run", return_value=result):
+            return render.is_still_image(Path("x"))
+
+    def test_image_codecs_detected(self):
+        for codec in ("mjpeg", "png", "webp", "bmp"):
+            with self.subTest(codec=codec):
+                self.assertTrue(self._detect(codec))
+
+    def test_video_codecs_not_detected(self):
+        for codec in ("h264", "hevc", "vp9", "prores"):
+            with self.subTest(codec=codec):
+                self.assertFalse(self._detect(codec))
+
+    def test_probe_failure_is_not_fatal(self):
+        err = subprocess.CalledProcessError(1, "ffprobe")
+        with patch.object(render.subprocess, "run", side_effect=err):
+            self.assertFalse(render.is_still_image(Path("x")))

--- a/tests/test_render_montage.py
+++ b/tests/test_render_montage.py
@@ -1,0 +1,299 @@
+"""Mixed-orientation canvas + music-bed montage support.
+
+Gap this covers: render.py scaled portrait sources by height (-2:1920) and
+landscape by width (1920:-2), so a montage mixing phone verticals with landscape
+footage produced segments of DIFFERENT dimensions — which the `-c copy` concat
+in Rule 2 cannot join. There was also no music-bed support at all, so a montage
+whose spine is a song had no path through this renderer.
+"""
+
+import importlib.util
+import io
+import contextlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).parents[1] / "helpers" / "render.py"
+SPEC = importlib.util.spec_from_file_location("video_use_render_montage", MODULE_PATH)
+assert SPEC and SPEC.loader
+render = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(render)
+
+
+class BlurredFillChainTests(unittest.TestCase):
+    def test_chain_is_single_in_single_out_so_it_drops_into_vf(self):
+        chain = render.blurred_fill_chain(1920, 1080)
+        # No leading or trailing pad labels — otherwise it cannot be used in -vf.
+        self.assertFalse(chain.startswith("["))
+        self.assertTrue(chain.endswith("(H-h)/2"))
+
+    def test_background_covers_and_foreground_fits(self):
+        chain = render.blurred_fill_chain(1920, 1080)
+        self.assertIn("scale=1920:1080:force_original_aspect_ratio=increase", chain)
+        self.assertIn("crop=1920:1080", chain)
+        self.assertIn("scale=1920:1080:force_original_aspect_ratio=decrease", chain)
+        self.assertIn("overlay=(W-w)/2:(H-h)/2", chain)
+
+    def test_honours_canvas_dimensions(self):
+        chain = render.blurred_fill_chain(1280, 720)
+        self.assertIn("crop=1280:720", chain)
+        self.assertNotIn("1920", chain)
+
+
+class CanvasSegmentTests(unittest.TestCase):
+    """The regression: portrait and landscape must render to the SAME size."""
+
+    def _vf_for(self, portrait: bool, canvas: bool, draft: bool = False) -> str:
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return unittest.mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "seg.mp4"
+            with patch.object(render, "is_portrait_source", return_value=portrait), \
+                 patch.object(render, "is_hdr_source", return_value=False), \
+                 patch.object(render.subprocess, "run", side_effect=fake_run):
+                render.extract_segment(
+                    Path("src.mp4"), 0.0, 2.0, "", out,
+                    rate="30/1", canvas=canvas, draft=draft,
+                )
+        cmd = captured["cmd"]
+        return cmd[cmd.index("-vf") + 1]
+
+    def test_without_canvas_orientations_diverge(self):
+        # Documents the pre-existing behaviour the canvas mode exists to escape.
+        self.assertIn("scale=-2:1920", self._vf_for(portrait=True, canvas=False))
+        self.assertIn("scale=1920:-2", self._vf_for(portrait=False, canvas=False))
+
+    def test_with_canvas_orientations_produce_identical_filters(self):
+        portrait_vf = self._vf_for(portrait=True, canvas=True)
+        landscape_vf = self._vf_for(portrait=False, canvas=True)
+        self.assertEqual(portrait_vf, landscape_vf)
+        self.assertIn("crop=1920:1080", portrait_vf)
+
+    def test_draft_canvas_uses_720p(self):
+        vf = self._vf_for(portrait=True, canvas=True, draft=True)
+        self.assertIn("crop=1280:720", vf)
+
+    def test_grade_is_applied_after_the_canvas(self):
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return unittest.mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch.object(render, "is_portrait_source", return_value=True), \
+                 patch.object(render, "is_hdr_source", return_value=False), \
+                 patch.object(render.subprocess, "run", side_effect=fake_run):
+                render.extract_segment(
+                    Path("src.mp4"), 0.0, 2.0, "eq=saturation=1.2",
+                    Path(td) / "seg.mp4", rate="30/1", canvas=True,
+                )
+        cmd = captured["cmd"]
+        vf = cmd[cmd.index("-vf") + 1]
+        self.assertLess(vf.index("overlay="), vf.index("eq=saturation=1.2"))
+
+
+class MuteSegmentTests(unittest.TestCase):
+    def _af_for(self, mute: bool) -> str:
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return unittest.mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch.object(render, "is_portrait_source", return_value=False), \
+                 patch.object(render, "is_hdr_source", return_value=False), \
+                 patch.object(render, "has_audio_stream", return_value=True), \
+                 patch.object(render.subprocess, "run", side_effect=fake_run):
+                render.extract_segment(
+                    Path("src.mp4"), 0.0, 2.0, "", Path(td) / "seg.mp4",
+                    rate="30/1", mute=mute,
+                )
+        cmd = captured["cmd"]
+        return cmd[cmd.index("-af") + 1]
+
+    def test_mute_silences_but_keeps_the_stream_and_the_fades(self):
+        af = self._af_for(mute=True)
+        self.assertTrue(af.startswith("volume=0,"))
+        # Fades must survive — a dropped audio stream breaks the -c copy concat.
+        self.assertIn("afade=t=in", af)
+        self.assertIn("afade=t=out", af)
+
+    def test_unmuted_segments_are_unchanged(self):
+        self.assertNotIn("volume=0", self._af_for(mute=False))
+
+
+class SilentSourceTests(unittest.TestCase):
+    """A silent source must still yield a segment with an audio stream.
+
+    Without this the -c copy concat produces holes in the audio timeline and the
+    music bed has no [0:a] to duck under — a photo montage crashed the render.
+    """
+
+    def _cmd_for(self, source_has_audio: bool):
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return unittest.mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch.object(render, "is_portrait_source", return_value=False), \
+                 patch.object(render, "is_hdr_source", return_value=False), \
+                 patch.object(render, "has_audio_stream", return_value=source_has_audio), \
+                 patch.object(render.subprocess, "run", side_effect=fake_run):
+                render.extract_segment(
+                    Path("src.mp4"), 0.0, 2.0, "", Path(td) / "seg.mp4", rate="30/1",
+                )
+        return captured["cmd"]
+
+    def test_silent_source_gets_synthesized_silence(self):
+        cmd = self._cmd_for(source_has_audio=False)
+        self.assertIn("anullsrc=channel_layout=stereo:sample_rate=48000", cmd)
+        self.assertIn("-map", cmd)
+        self.assertIn("1:a", cmd)
+        # Audio fades are meaningless on synthesized silence and -af would bind
+        # to the wrong input once a second input exists.
+        self.assertNotIn("-af", cmd)
+
+    def test_source_with_audio_is_untouched(self):
+        cmd = self._cmd_for(source_has_audio=True)
+        self.assertNotIn("anullsrc", " ".join(cmd))
+        self.assertIn("-af", cmd)
+
+    def test_both_paths_still_encode_an_audio_stream(self):
+        for has_audio in (True, False):
+            with self.subTest(source_has_audio=has_audio):
+                cmd = self._cmd_for(has_audio)
+                self.assertEqual(cmd[cmd.index("-c:a") + 1], "aac")
+
+
+class MusicBedTests(unittest.TestCase):
+    def _cmd_for(self, cfg, duration=60.0, base_has_audio=True):
+        captured = {}
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return unittest.mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+        with tempfile.TemporaryDirectory() as td:
+            edit_dir = Path(td)
+            (edit_dir / "bed.mp3").write_bytes(b"x")
+            with patch.object(render, "probe_duration", return_value=duration), \
+                 patch.object(render, "has_audio_stream", return_value=base_has_audio), \
+                 patch.object(render.subprocess, "run", side_effect=fake_run), \
+                 contextlib.redirect_stdout(io.StringIO()):
+                render.mix_music_bed(
+                    edit_dir / "base.mp4", cfg, edit_dir / "out.mp4", edit_dir
+                )
+        return captured.get("cmd")
+
+    def test_base_without_audio_falls_back_to_music_only_and_caps_length(self):
+        # amix's duration=first is what stops the infinitely looped bed; without
+        # amix the render needs -shortest or it never terminates.
+        cmd = self._cmd_for({"source": "bed.mp3"}, base_has_audio=False)
+        filt = cmd[cmd.index("-filter_complex") + 1]
+        self.assertNotIn("amix", filt)
+        self.assertNotIn("[0:a]", filt)
+        self.assertIn("-shortest", cmd)
+
+    def test_normal_path_does_not_pass_shortest(self):
+        self.assertNotIn("-shortest", self._cmd_for({"source": "bed.mp3"}))
+
+    def test_video_is_stream_copied_not_re_encoded(self):
+        cmd = self._cmd_for({"source": "bed.mp3"})
+        self.assertIn("copy", cmd[cmd.index("-c:v") + 1])
+
+    def test_amix_disables_normalize_so_explicit_gains_survive(self):
+        cmd = self._cmd_for({"source": "bed.mp3"})
+        filt = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn("normalize=0", filt)
+        self.assertIn("duration=first", filt)
+
+    def test_gains_default_to_music_over_ducked_natural(self):
+        cmd = self._cmd_for({"source": "bed.mp3"})
+        filt = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn(f"volume={render.MUSIC_GAIN}", filt)
+        self.assertIn(f"volume={render.MUSIC_NATURAL_GAIN}", filt)
+
+    def test_explicit_gains_override_defaults(self):
+        cmd = self._cmd_for({"source": "bed.mp3", "gain": 0.6, "natural_gain": 0.2})
+        filt = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn("volume=0.6", filt)
+        self.assertIn("volume=0.2", filt)
+
+    def test_short_bed_is_looped(self):
+        cmd = self._cmd_for({"source": "bed.mp3"})
+        self.assertIn("-stream_loop", cmd)
+        self.assertEqual(cmd[cmd.index("-stream_loop") + 1], "-1")
+
+    def test_tail_fade_is_placed_from_the_video_duration(self):
+        cmd = self._cmd_for({"source": "bed.mp3", "fade_out": 4.0}, duration=100.0)
+        filt = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn("afade=t=out:st=96.000:d=4.000", filt)
+
+    def test_missing_music_file_is_skipped_not_fatal(self):
+        with tempfile.TemporaryDirectory() as td:
+            edit_dir = Path(td)
+            with patch.object(render.subprocess, "run") as run, \
+                 contextlib.redirect_stdout(io.StringIO()) as out:
+                render.mix_music_bed(
+                    edit_dir / "base.mp4", {"source": "nope.mp3"},
+                    edit_dir / "out.mp4", edit_dir,
+                )
+            run.assert_not_called()
+            self.assertIn("warning", out.getvalue().lower())
+
+
+class CanvasEdlWiringTests(unittest.TestCase):
+    def _canvas_flags(self, edl_extra):
+        seen = []
+
+        def fake_extract(src, start, duration, filt, out, **kw):
+            seen.append(kw)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"x")
+
+        with tempfile.TemporaryDirectory() as td:
+            edit_dir = Path(td)
+            (edit_dir / "a.mp4").write_bytes(b"x")
+            edl = {
+                "sources": {"a": "a.mp4"},
+                "ranges": [
+                    {"source": "a", "start": 0, "end": 2},
+                    {"source": "a", "start": 2, "end": 4, "mute": True},
+                ],
+            }
+            edl.update(edl_extra)
+            with patch.object(render, "extract_segment", side_effect=fake_extract), \
+                 patch.object(render, "probe_source_fps", return_value="30/1"), \
+                 contextlib.redirect_stdout(io.StringIO()):
+                render.extract_all_segments(edl, edit_dir, preview=False)
+        return seen
+
+    def test_canvas_fill_enables_canvas_on_every_segment(self):
+        for value in ("fill", "blur", "blurred_fill", "FILL"):
+            with self.subTest(value=value):
+                flags = self._canvas_flags({"canvas": value})
+                self.assertTrue(all(f["canvas"] for f in flags))
+
+    def test_canvas_defaults_off_for_existing_edls(self):
+        flags = self._canvas_flags({})
+        self.assertTrue(all(not f["canvas"] for f in flags))
+
+    def test_per_range_mute_is_passed_through(self):
+        flags = self._canvas_flags({"canvas": "fill"})
+        self.assertEqual([f["mute"] for f in flags], [False, True])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`render.py` currently has no path for a music-bed montage that mixes orientations — the two gaps compound:

1. **Mixed orientation breaks the lossless concat.** Portrait sources are scaled by height (`-2:1920`), landscape by width (`1920:-2`), so segments come out with different dimensions. Rule 2's `-c copy` concat cannot join them, and there is no way to reach a montage that mixes phone verticals with landscape footage.
2. **There is no music-bed support at all.** No `amix`, no ducking. For a montage whose spine is a song rather than speech, the renderer has nothing to offer.

The talking-head model the renderer is built around doesn't hit either of these. A montage hits both immediately.

## What this adds

Two opt-in EDL fields. Both default off, so every existing EDL renders byte-identically.

```json
{
  "canvas": "fill",
  "music": { "source": "bed.mp3", "gain": 0.85, "natural_gain": 0.5, "fade_out": 3.0 },
  "ranges": [ { "source": "phone", "start": 0, "end": 3, "mute": true } ]
}
```

- **`"canvas": "fill"`** renders every segment onto one fixed landscape canvas: a zoomed blurred copy fills it edge-to-edge with the sharp aspect-correct frame centred on top. Landscape fills completely; portrait gets a blurred pillarbox rather than black bars. Every segment shares dimensions, so the lossless concat still works. Draft mode uses a 1280x720 canvas.
- **`"music": {...}`** mixes a bed under the concatenated natural audio — looped if short, cut to length if long. Mixed *after* concat with `-c:v copy`, so it costs no extra video encode.
- **Per-range `"mute": true`** silences a segment's natural audio while keeping the stream, so the bed can cover it.

Two details that are easy to get wrong and are pinned by tests:

- `amix` uses `normalize=0`. Without it amix rescales every input by `1/n` and the explicit gains stop meaning anything.
- The music-only fallback path passes `-shortest`, because `amix`'s `duration=first` is otherwise the only thing stopping an infinitely looped bed.

## Incidental fix: sources with no audio stream

Building this surfaced a pre-existing crash. A source with **no audio stream** — an exported photo, the most common ingredient in a music montage — produced a segment with no audio, so the mix had no `[0:a]` to duck under and the render died.

Silence is now synthesized with `anullsrc` for any source lacking audio. That also closes a quieter hole: a silent clip among audio clips previously left gaps in the concatenated audio timeline.

## Verification

Beyond the unit tests, rendered end-to-end from a 3-segment EDL mixing a 1920x1080 source, a 608x1080 source, and a silent source, with a looped bed:

- all three segments emitted at `1920x1080` with audio streams (the concat precondition)
- muted segment measures **-91.0 dB** without music, **-19.5 dB** with it
- unmuted segment is louder with the bed than without — natural audio ducked under, not replaced
- the unchanged non-canvas path reproduces its prior loudnorm measurement exactly (`I=-22.64 LUFS, TP=-8.74, LRA=3.20`)

Tests: **16 -> 40** on this base.

## Risks and caveats

- **The blurred-fill canvas is a taste call.** A blurred pillarbox is the convention for verticals in a landscape montage, but it is not neutral. It is opt-in for that reason.
- **`gblur` at sigma 20 costs encode time** on the canvas path. Not measured against a long timeline.
- **Verified on Windows only.** The filter chains are platform-agnostic, but a Linux/macOS run would be worth having before merge.
- **This PR is not independently runnable on Windows.** On a Windows console the render crashes at the existing `extracting N segment(s) →` print with `UnicodeEncodeError: 'charmap' codec can't encode '→'`, before reaching any code in this PR. #78 fixes that. I tested here with `PYTHONIOENCODING=utf-8` to work around it. Not a dependency for the merge itself, only for a Windows user exercising the feature.
- Not tested against an iPhone `.MOV` carrying `mebx` timed-metadata streams. The implementation should be safe by construction — `has_audio_stream` uses `-select_streams a`, which ignores data streams, and the silent path maps explicitly rather than with `-map 0:a?` — but that is reasoning, not evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqL3Pwe5Xy2rmrsSzRU9Zg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in EDL fields for mixed-orientation montages and music beds, and fixes how the renderer handles silent, mono, and still-image sources. Both features default off.

**New Features**

- `"canvas": "fill"` renders every segment onto one fixed canvas so portrait and landscape sources stay losslessly concatenable; portrait gets a blurred pillarbox instead of black bars.
- `"music": {...}` mixes a bed under the natural audio after the concat with `-c:v copy`, and `amix` uses `normalize=0` so explicit gains still mean anything.
- Per-range `"mute"` silences a segment's natural audio while keeping the stream, and per-range `"grade"` overrides the EDL-wide grade, including `"auto"`.

**Bug Fixes**

- Silent sources get synthesized silence via `anullsrc`; mono sources are forced to stereo; stills are looped instead of seeked; short audio is padded to video length.
- `amix` uses `duration=longest`, and stale `*_music.mp4` output is cleared before mixing.
- Frame rate is resolved from the first moving source, so an opening photo no longer forces its nominal fps onto footage.
- Auto-grade now analyzes still images instead of silently falling back to neutral defaults.

The blurred-fill look is a taste call, `gblur` at sigma 20 adds encode time, and this path is verified on Windows only.

<sup>Written for commit 2af93c9a6796523b521411d0caab9574c60d31a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

