### PR TITLE
test(render): cover 180-degree rotation preserving orientation

### DIFF
--- a/tests/test_render_orientation.py
+++ b/tests/test_render_orientation.py
@@ -44,6 +44,14 @@ class PortraitDetectionTests(unittest.TestCase):
         stream = {"width": 1920, "height": 1080, "tags": {"rotate": "270"}}
         self.assertFalse(self._is_portrait(stream))
 
+    def test_half_turn_rotation_does_not_change_orientation(self):
+        stream = {
+            "width": 1920,
+            "height": 1080,
+            "side_data_list": [{"rotation": 180}],
+        }
+        self.assertFalse(self._is_portrait(stream))
+
     def test_rotation_can_turn_coded_portrait_into_landscape(self):
         stream = {
             "width": 1080,


### PR DESCRIPTION
is_portrait_source() only swaps width/height for quarter-turn rotations (90/270); a half-turn (180) should leave a landscape source landscape but that path wasn't covered by a test. This adds a regression test for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test for `is_portrait_source()` to verify a 180-degree rotation does not change orientation. The function only swaps width/height for quarter-turn rotations (90/270), but that half-turn path wasn't covered by a test.

<sup>Written for commit 1b337578fb93902c4b5c6336ff054416527c0fd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

