### PR TITLE
render: make subtitle chunking, case and style EDL-driven

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -194,6 +194,25 @@ Alignment=2,MarginV=35
 
 Invent a third style if neither fits. Hard rules: subtitles LAST (Rule 1), output-timeline offsets (Rule 5).
 
+### Driving it from the EDL
+
+`render.py --build-subtitles` reads an optional `subtitle_style` block, so a style is data rather than a code edit:
+
+```json
+"subtitle_style": {
+  "words_per_chunk": 6,
+  "case": "sentence",
+  "force_style": "FontName=Helvetica,FontSize=13,Bold=1,PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,BorderStyle=1,Outline=2,Shadow=1,Alignment=2,MarginV=28"
+}
+```
+
+Defaults reproduce the shipped `bold-overlay` look exactly: `words_per_chunk` 2, `case` `"upper"`, and `SUB_FORCE_STYLE`.
+
+Two things worth knowing when you deviate:
+
+- `"case": "sentence"` keeps the ASR's own capitalization, but a cut can promote a mid-sentence word to the start of a sentence. The builder capitalizes any cue that opens the file or follows sentence-final punctuation, so that case is handled.
+- `force_style`'s `MarginV` is relative to `PlayResY=288`. The default of 90 is tuned for **vertical** video; for 16:9 landscape a value around 28 sits the caption roughly 10% up from the bottom.
+
 ## Animations (when requested)
 
 Animations match the content and the brand. **Get the palette, font, and visual language from the conversation** — never assume a default. If the user hasn't told you, propose a palette in the strategy phase and wait for confirmation before building anything.

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -419,10 +419,20 @@ def _words_in_range(transcript: dict, t_start: float, t_end: float) -> list[dict
 def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
     """Build an output-timeline SRT from per-source transcripts.
 
-    - 2-word chunks (break on any punctuation in between)
-    - UPPERCASE text
-    - Output times computed as word.start - segment_start + segment_offset
+    Chunking and case come from the optional `subtitle_style` block on the EDL:
+
+    - `words_per_chunk` (default 2) - words per caption line, still breaking
+      early on any punctuation in between.
+    - `case` (default "upper") - "upper" shouts every line, which suits a
+      fast-cut social edit. "sentence" leaves the ASR's own capitalization
+      alone, which is what a narrative or documentary read wants.
+    - `force_style` - an ASS override string, read in main().
+
+    Output times are computed as word.start - segment_start + segment_offset.
     """
+    style = edl.get("subtitle_style") or {}
+    words_per_chunk = max(1, int(style.get("words_per_chunk", 2)))
+    case_mode = str(style.get("case", "upper")).lower()
     transcripts_dir = edit_dir / "transcripts"
     sources = edl["sources"]
 
@@ -444,7 +454,7 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
         transcript = json.loads(tr_path.read_text())
         words_in_seg = _words_in_range(transcript, seg_start, seg_end)
 
-        # Group into 2-word chunks, break on punctuation
+        # Group into N-word chunks, break on punctuation
         chunks: list[list[dict]] = []
         current: list[dict] = []
         for w in words_in_seg:
@@ -454,7 +464,7 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
             current.append(w)
             # Break if the current text ends in punctuation or we hit 2 words
             ends_in_punct = bool(text) and text[-1] in PUNCT_BREAK
-            if len(current) >= 2 or ends_in_punct:
+            if len(current) >= words_per_chunk or ends_in_punct:
                 chunks.append(current)
                 current = []
         if current:
@@ -471,13 +481,29 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
             text = re.sub(r"\s+", " ", text).strip()
             # Strip trailing punctuation for cleaner uppercase look
             text = text.rstrip(",;:")
-            text = text.upper()
+            if case_mode == "upper":
+                text = text.upper()
             entries.append((out_start, out_end, text))
 
         seg_offset += seg_duration
 
     # Sort and write as SRT
     entries.sort(key=lambda e: e[0])
+
+    # In sentence case the ASR's capitalization is right for a continuation
+    # line but wrong when a cut promotes a mid-sentence word to the start of a
+    # sentence. Capitalize a cue that opens the file or follows one ending in
+    # sentence-final punctuation.
+    if case_mode == "sentence":
+        recased: list[tuple[float, float, str]] = []
+        prev_text = ""
+        for a, b, t in entries:
+            if t and (not prev_text or prev_text.rstrip()[-1:] in ".!?"):
+                t = t[0].upper() + t[1:]
+            recased.append((a, b, t))
+            prev_text = t
+        entries = recased
+
     lines: list[str] = []
     for i, (a, b, t) in enumerate(entries, start=1):
         lines.append(str(i))
@@ -603,6 +629,7 @@ def build_final_composite(
     subtitles_path: Path | None,
     out_path: Path,
     edit_dir: Path,
+    force_style: str = SUB_FORCE_STYLE,
 ) -> None:
     """Final pass: base → overlays (PTS-shifted) → subtitles LAST → out.
 
@@ -643,7 +670,7 @@ def build_final_composite(
     if has_subs:
         subs_abs = str(subtitles_path.resolve()).replace(":", r"\:").replace("'", r"\'")
         filter_parts.append(
-            f"{current}subtitles='{subs_abs}':force_style='{SUB_FORCE_STYLE}'[outv]"
+            f"{current}subtitles='{subs_abs}':force_style='{force_style}'[outv]"
         )
         out_label = "[outv]"
     else:
@@ -752,13 +779,16 @@ def main() -> None:
 
     # 4. Composite (overlays + subtitles LAST) → intermediate (pre-loudnorm) path
     overlays = edl.get("overlays") or []
+    sub_force_style = (edl.get("subtitle_style") or {}).get("force_style") or SUB_FORCE_STYLE
     if args.no_loudnorm:
         # Composite directly to final output
-        build_final_composite(base_path, overlays, subs_path, out_path, edit_dir)
+        build_final_composite(base_path, overlays, subs_path, out_path, edit_dir,
+                              force_style=sub_force_style)
     else:
         # Composite to a temp file, then run loudnorm → final output
         tmp_composite = out_path.with_suffix(".prenorm.mp4")
-        build_final_composite(base_path, overlays, subs_path, tmp_composite, edit_dir)
+        build_final_composite(base_path, overlays, subs_path, tmp_composite, edit_dir,
+                              force_style=sub_force_style)
         print("loudness normalization → social-ready (-14 LUFS / -1 dBTP / LRA 11)")
         apply_loudnorm_two_pass(tmp_composite, out_path, preview=args.draft)
         tmp_composite.unlink(missing_ok=True)

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -392,6 +392,10 @@ def concat_segments(segment_paths: list[Path], out_path: Path, edit_dir: Path) -
 
 PUNCT_BREAK = set(".,!?;:")
 
+# Recognized values for subtitle_style.case. "upper" is the default and matches
+# the shipped bold-overlay look; "sentence" keeps the ASR's own capitalization.
+SUBTITLE_CASE_MODES = frozenset({"upper", "sentence"})
+
 
 def _srt_timestamp(seconds: float) -> str:
     total_ms = int(round(seconds * 1000))
@@ -431,8 +435,28 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
     Output times are computed as word.start - segment_start + segment_offset.
     """
     style = edl.get("subtitle_style") or {}
-    words_per_chunk = max(1, int(style.get("words_per_chunk", 2)))
+
+    raw_chunk = style.get("words_per_chunk", 2)
+    try:
+        words_per_chunk = int(raw_chunk)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"subtitle_style.words_per_chunk must be an integer, got {raw_chunk!r}"
+        ) from None
+    if words_per_chunk < 1:
+        raise ValueError(
+            f"subtitle_style.words_per_chunk must be >= 1, got {words_per_chunk}"
+        )
+
+    # Validate before generating anything. An unrecognized value used to fall
+    # through applying neither transformation, which silently emitted the raw
+    # ASR capitalization -- not the documented "upper" default, and not an error.
     case_mode = str(style.get("case", "upper")).lower()
+    if case_mode not in SUBTITLE_CASE_MODES:
+        raise ValueError(
+            f"subtitle_style.case must be one of "
+            f"{', '.join(sorted(SUBTITLE_CASE_MODES))}; got {case_mode!r}"
+        )
     transcripts_dir = edit_dir / "transcripts"
     sources = edl["sources"]
 

--- a/helpers/render.py
+++ b/helpers/render.py
@@ -427,6 +427,13 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
 
     - `words_per_chunk` (default 2) - words per caption line, still breaking
       early on any punctuation in between.
+    - `break_on` (default ".,!?;:") - which punctuation forces an early break.
+      Narrow it to ".!?" so a mid-sentence comma stops splitting a phrase.
+    - `balance` (default False) - split each run between breaks into equal-length
+      cues instead of greedily filling to the cap, so a sentence's remainder is
+      not stranded alone on the last line.
+    - `min_words` (default 1) - fold a cue shorter than this into the one before
+      it.
     - `case` (default "upper") - "upper" shouts every line, which suits a
       fast-cut social edit. "sentence" leaves the ASR's own capitalization
       alone, which is what a narrative or documentary read wants.
@@ -446,6 +453,21 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
     if words_per_chunk < 1:
         raise ValueError(
             f"subtitle_style.words_per_chunk must be >= 1, got {words_per_chunk}"
+        )
+
+    break_on = set(str(style.get("break_on", "".join(sorted(PUNCT_BREAK)))))
+    balance = bool(style.get("balance", False))
+
+    raw_min = style.get("min_words", 1)
+    try:
+        min_words = int(raw_min)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"subtitle_style.min_words must be an integer, got {raw_min!r}"
+        ) from None
+    if min_words < 1:
+        raise ValueError(
+            f"subtitle_style.min_words must be >= 1, got {min_words}"
         )
 
     # Validate before generating anything. An unrecognized value used to fall
@@ -478,21 +500,46 @@ def build_master_srt(edl: dict, edit_dir: Path, out_path: Path) -> None:
         transcript = json.loads(tr_path.read_text())
         words_in_seg = _words_in_range(transcript, seg_start, seg_end)
 
-        # Group into N-word chunks, break on punctuation
-        chunks: list[list[dict]] = []
+        # Split into runs at punctuation first, then divide each run into cues.
+        runs: list[list[dict]] = []
         current: list[dict] = []
         for w in words_in_seg:
             text = (w.get("text") or "").strip()
             if not text:
                 continue
             current.append(w)
-            # Break if the current text ends in punctuation or we hit 2 words
-            ends_in_punct = bool(text) and text[-1] in PUNCT_BREAK
-            if len(current) >= words_per_chunk or ends_in_punct:
-                chunks.append(current)
+            if text[-1] in break_on:
+                runs.append(current)
                 current = []
         if current:
-            chunks.append(current)
+            runs.append(current)
+
+        chunks: list[list[dict]] = []
+        for run in runs:
+            if balance:
+                # Greedy filling packs each cue to the cap and strands the run's
+                # remainder on the last line ("...becoming right" / "now."). Use
+                # the same number of cues, sized evenly.
+                k = max(1, -(-len(run) // words_per_chunk))
+                base, extra = divmod(len(run), k)
+                i = 0
+                for j in range(k):
+                    n = base + (1 if j < extra else 0)
+                    chunks.append(run[i:i + n])
+                    i += n
+            else:
+                for i in range(0, len(run), words_per_chunk):
+                    chunks.append(run[i:i + words_per_chunk])
+
+        # A run shorter than min_words still yields a stranded cue.
+        if min_words > 1:
+            merged: list[list[dict]] = []
+            for chunk in chunks:
+                if merged and len(chunk) < min_words:
+                    merged[-1].extend(chunk)
+                else:
+                    merged.append(chunk)
+            chunks = merged
 
         for chunk in chunks:
             local_start = max(seg_start, chunk[0].get("start", seg_start))

--- a/tests/test_render_subtitle_chunking.py
+++ b/tests/test_render_subtitle_chunking.py
@@ -1,0 +1,76 @@
+"""subtitle_style chunking: break_on, balance and min_words.
+
+All three default to the shipped behaviour, so an EDL that does not mention them
+produces exactly the captions it did before.
+"""
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "helpers" / "render.py"
+SPEC = importlib.util.spec_from_file_location("video_use_render", MODULE_PATH)
+assert SPEC and SPEC.loader
+render = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(render)
+
+SENTENCE = "If you are between eighteen and twenty five, can I ask you a question?"
+
+
+class ChunkingTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.edit = Path(self.tmp.name)
+        (self.edit / "transcripts").mkdir()
+        words = [
+            {"type": "word", "text": t, "start": 1.0 + i * 0.5, "end": 1.4 + i * 0.5}
+            for i, t in enumerate(SENTENCE.split())
+        ]
+        (self.edit / "transcripts" / "A.json").write_text(json.dumps({"words": words}))
+        self.addCleanup(self.tmp.cleanup)
+
+    def cues(self, style):
+        edl = {"sources": {"A": "/tmp/A.mov"},
+               "ranges": [{"source": "A", "start": 0.0, "end": 30.0}]}
+        if style is not None:
+            edl["subtitle_style"] = style
+        out = self.edit / "master.srt"
+        render.build_master_srt(edl, self.edit, out)
+        blocks = out.read_text().strip().split("\n\n")
+        return [b.split("\n", 2)[2].strip() for b in blocks]
+
+    def test_default_breaks_on_every_comma(self):
+        # the shipped behaviour: 2-word cues, and the comma after "five" forces a
+        # break that a phrase-aware read would not want
+        c = self.cues({"case": "sentence"})
+        self.assertEqual(c, ["If you", "are between", "eighteen and", "twenty five",
+                             "can I", "ask you", "a question?"])
+
+    def test_break_on_can_ignore_commas(self):
+        c = self.cues({"case": "sentence", "words_per_chunk": 8, "break_on": ".!?"})
+        self.assertEqual(c[0], "If you are between eighteen and twenty five")
+
+    def test_balance_avoids_a_stranded_remainder(self):
+        greedy = self.cues({"case": "sentence", "words_per_chunk": 8, "break_on": ".!?"})
+        even = self.cues({"case": "sentence", "words_per_chunk": 8,
+                          "break_on": ".!?", "balance": True})
+        self.assertEqual(len(greedy), len(even))          # same number of cues
+        self.assertEqual([len(x.split()) for x in greedy], [8, 6])
+        self.assertEqual([len(x.split()) for x in even], [7, 7])
+
+    def test_min_words_folds_a_short_cue_backwards(self):
+        c = self.cues({"case": "sentence", "words_per_chunk": 12,
+                       "break_on": ".!?", "min_words": 4})
+        self.assertEqual(len(c), 1)
+        self.assertTrue(c[0].endswith("a question?"))
+
+    def test_min_words_rejects_nonsense(self):
+        for bad in ("x", 0, -1):
+            with self.assertRaises(ValueError):
+                self.cues({"min_words": bad})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

Caption chunking and case are hardcoded to 2-word UPPERCASE in `build_master_srt`, and `force_style` to a single module constant.

That combination is exactly right for the fast-cut social edit the skill ships as `bold-overlay`. It is wrong for anything with a narrative read — a documentary or a long-form talking head wants 4–7 word lines in sentence case. `SKILL.md` even describes a `natural-sentence` style as something you might invent, but reaching it currently means editing `render.py`.

## Changes

An optional `subtitle_style` block on the EDL, so a caption style is data rather than a code change:

```json
"subtitle_style": {
  "words_per_chunk": 6,
  "case": "sentence",
  "force_style": "FontName=Helvetica,FontSize=13,Bold=1,PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,BorderStyle=1,Outline=2,Shadow=1,Alignment=2,MarginV=28"
}
```

- `words_per_chunk` — words per line, default 2. Still breaks early on punctuation.
- `case` — `"upper"` (default) or `"sentence"`. Sentence case leaves the ASR's own capitalization alone.
- `force_style` — ASS override string, defaulting to `SUB_FORCE_STYLE`.

**One subtlety worth calling out.** In sentence case the ASR's capitalization is correct for a continuation line, but a cut can promote a mid-sentence word to the start of a sentence — which then rendered lowercase. Real example from the edit that prompted this: a segment starting on a restart produced `it is to maintain a digital diary`. The builder now capitalizes any cue that opens the file or follows a cue ending in sentence-final punctuation.

Also documents something that cost me a render to notice: `force_style`'s `MarginV` is relative to `PlayResY=288`, so the shipped default of 90 is tuned for **vertical** video and sits too high in a 16:9 frame. Around 28 puts the caption roughly 10% up from the bottom in landscape.

## Compatibility

Every default reproduces current behaviour. I verified the generated SRT is **byte-identical** to the previous implementation on the same transcript and EDL with no `subtitle_style` present, so existing projects are unaffected.

`tests/` passes (16 tests, 15 subtests).

## Note

Touches `build_final_composite`'s signature and `main()`, so it overlaps slightly with #158 if both land — whichever merges second needs a trivial rebase.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes subtitle chunking, case, and style EDL-driven via an optional `subtitle_style` block on the EDL, so a caption style is data instead of a `render.py` edit. Defaults reproduce the prior 2-word UPPERCASE output byte-identically, and invalid values are now rejected with clear errors.

- `words_per_chunk`, `case`, and `force_style` on the EDL control word grouping, capitalization, and ASS styling; `case` is case-insensitive and `words_per_chunk` must be an integer ≥ 1.
- `break_on`, `balance`, and `min_words` control which punctuation forces a break, whether cues are sized evenly, and folding short cues backward, each defaulting to prior behavior.
- `force_style`'s `MarginV` is relative to `PlayResY=288`, so the default is tuned for vertical video; 16:9 needs a lower value (documented in `SKILL.md`).

**Bug Fixes**
- Capitalizes a sentence-case cue that opens the file or follows sentence-final punctuation, since a cut can promote a mid-sentence word to a sentence start.

<sup>Written for commit 6d03ec05f4d4dbb388afdb885bdb72c898cb6965. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/video-use/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

